### PR TITLE
Fix PDAs Not Being Activatable by 'E' 

### DIFF
--- a/Resources/Prototypes/Entities/Objects/Devices/pda.yml
+++ b/Resources/Prototypes/Entities/Objects/Devices/pda.yml
@@ -145,10 +145,13 @@
   - type: CargoSellBlacklist # Frontier: Liltenhead moment
   - type: PirateBountyItem
     id: Pda
-  - type: ToggleableGhostRole # Frontier: Literally only for the wipe verb and nothing else.
-    wipeVerbText: pda-wipe-device-verb-text # Frontier
-    wipeVerbPopup: pda-wiped-device # Frontier
-    mindRoles: [] # Frontier: no default value here
+  # Triad Start
+  # We don't need this. This also breaks PDA UIs.
+  # - type: ToggleableGhostRole # Frontier: Literally only for the wipe verb and nothing else.
+  #  wipeVerbText: pda-wipe-device-verb-text # Frontier
+  #  wipeVerbPopup: pda-wiped-device # Frontier
+  #  mindRoles: [] # Frontier: no default value here
+  # Triad End
   - type: ShipyardSellCondition # Frontier: Teleport to shipyard console on sale
     preserveOnSale: true
 


### PR DESCRIPTION
## About the PR
Title. Fixes this bug.
Toggleableghostrole component was bulldozing the UI

:cl:
- fix: Fixed PDAs UI not being activatable by 'E' (activate in world keybind)
