### PR TITLE
Modsuit and Toggleable Item Fixes

### DIFF
--- a/Content.Shared/_Goobstation/Clothing/Systems/SharedSealableClothingSystem.cs
+++ b/Content.Shared/_Goobstation/Clothing/Systems/SharedSealableClothingSystem.cs
@@ -1,6 +1,9 @@
 using Content.Shared._Goobstation.Clothing.Components;
 using Content.Shared.ActionBlocker;
 using Content.Shared.Actions;
+using Content.Shared.Atmos.Components;
+using Content.Shared.Body.Components;
+using Content.Shared.Body.Systems;
 using Content.Shared.Clothing;
 using Content.Shared.Clothing.EntitySystems;
 using Content.Shared.DoAfter;
@@ -35,12 +38,13 @@ public abstract class SharedSealableClothingSystem : EntitySystem
     [Dependency] private readonly SharedPopupSystem _popupSystem = default!;
     [Dependency] private readonly SharedPowerCellSystem _powerCellSystem = default!;
     [Dependency] private readonly ToggleableClothingSystem _toggleableSystem = default!;
+    [Dependency] private readonly SharedInternalsSystem _internals = default!; // Triad, fix internals
 
     public override void Initialize()
     {
         base.Initialize();
 
-        SubscribeLocalEvent<SealableClothingComponent, ClothingPartSealCompleteEvent>(OnPartSealingComplete);
+        // SubscribeLocalEvent<SealableClothingComponent, ClothingPartSealCompleteEvent>(OnPartSealingComplete); Triad
 
         SubscribeLocalEvent<SealableClothingControlComponent, ClothingControlSealCompleteEvent>(OnControlSealingComplete);
         SubscribeLocalEvent<SealableClothingControlComponent, ClothingGotEquippedEvent>(OnControlEquip);
@@ -53,19 +57,21 @@ public abstract class SharedSealableClothingSystem : EntitySystem
         SubscribeLocalEvent<SealableClothingControlComponent, SealClothingEvent>(OnControlSealEvent);
         //SubscribeLocalEvent<SealableClothingControlComponent, StartSealingProcessDoAfterEvent>(OnStartSealingDoAfter);
         SubscribeLocalEvent<SealableClothingControlComponent, ToggleClothingAttemptEvent>(OnToggleClothingAttempt);
+
+        SubscribeLocalEvent<BreathToolComponent, ClothingPartSealCompleteEvent>(OnBreathToolSealingComplete); // Triad, breath tool fix
     }
 
     #region Events
 
     /// <summary>
-    /// Toggles components on part when suit complete sealing process
+    /// Toggles components on part when suit complete sealing process, aswell as connecting internals if there is any
     /// </summary>
     /// <param name="part"></param>
-    /// <param name="args"></param>
-    private void OnPartSealingComplete(Entity<SealableClothingComponent> part, ref ClothingPartSealCompleteEvent args)
-    {
-        _componentTogglerSystem.ToggleComponent(part, args.IsSealed);
-    }
+    /// <param name="args"></param> Triad removal
+    //private void OnPartSealingComplete(Entity<SealableClothingComponent> part, ref ClothingPartSealCompleteEvent args)
+    //{
+    //    _componentTogglerSystem.ToggleComponent(part, args.IsSealed);
+    //}
 
     /// <summary>
     ///     Toggles components on control when suit complete sealing process
@@ -237,8 +243,9 @@ public abstract class SharedSealableClothingSystem : EntitySystem
             _audioSystem.PlayPvs(sealableComponet.SealUpSound, uid);
 
         _appearanceSystem.SetData(part.Value, SealableClothingVisuals.Sealed, sealableComponet.IsSealed);
+        _componentTogglerSystem.ToggleComponent(part.Value, sealableComponet.IsSealed);
 
-        var ev = new ClothingPartSealCompleteEvent(sealableComponet.IsSealed);
+        var ev = new ClothingPartSealCompleteEvent(sealableComponet.IsSealed, control.Comp.WearerEntity);
         RaiseLocalEvent(part.Value, ref ev);
 
         NextSealProcess(control);
@@ -273,6 +280,16 @@ public abstract class SharedSealableClothingSystem : EntitySystem
 
         return;
     }
+
+    // Triad
+    private void OnBreathToolSealingComplete(Entity<BreathToolComponent> tool, ref ClothingPartSealCompleteEvent args)
+    {
+        if (args.User == null || !TryComp<InternalsComponent>(args.User.Value, out var internals))
+            return;
+
+        _internals.ConnectBreathTool((args.User.Value, internals), tool.Owner);
+    }
+    // Triad end
     #endregion
 
     /// <summary>
@@ -369,7 +386,7 @@ public abstract class SharedSealableClothingSystem : EntitySystem
             else
                 _audioSystem.PlayEntity(comp.UnsealCompleteSound, comp.WearerEntity!.Value, uid);
 
-            var ev = new ClothingControlSealCompleteEvent(comp.IsCurrentlySealed);
+            var ev = new ClothingControlSealCompleteEvent(comp.IsCurrentlySealed, comp.WearerEntity);
             RaiseLocalEvent(control, ref ev);
 
             _appearanceSystem.SetData(uid, SealableClothingVisuals.Sealed, comp.IsCurrentlySealed);
@@ -451,18 +468,20 @@ public sealed partial class SealClothingEvent : InstantActionEvent
 ///     Raises on control when clothing finishes it's sealing or unsealing process
 /// </summary>
 [ByRefEvent]
-public readonly record struct ClothingControlSealCompleteEvent(bool IsSealed)
+public readonly record struct ClothingControlSealCompleteEvent(bool IsSealed, EntityUid? User)
 {
     public readonly bool IsSealed = IsSealed;
+    public readonly EntityUid? User = User; // Triad
 }
 
 /// <summary>
 ///     Raises on part when clothing finishes it's sealing or unsealing process
 /// </summary>
 [ByRefEvent]
-public readonly record struct ClothingPartSealCompleteEvent(bool IsSealed)
+public readonly record struct ClothingPartSealCompleteEvent(bool IsSealed, EntityUid? User)
 {
     public readonly bool IsSealed = IsSealed;
+    public readonly EntityUid? User = User; // Triad
 }
 
 public sealed partial class ClothingSealAttemptEvent : CancellableEntityEventArgs

--- a/Resources/Prototypes/Entities/Objects/Devices/base_handheld.yml
+++ b/Resources/Prototypes/Entities/Objects/Devices/base_handheld.yml
@@ -6,6 +6,7 @@
   - type: ActivatableUIRequiresPowerCell
   - type: ItemToggle
     onUse: false # above component does the toggling
+    onActivate: false # Triad, fixing handheld computers' interfaces not opening with E
   - type: PowerCellDraw
     drawRate: 0
     useRate: 20

--- a/Resources/Prototypes/Entities/Structures/Machines/Medical/cryo_pod.yml
+++ b/Resources/Prototypes/Entities/Structures/Machines/Medical/cryo_pod.yml
@@ -88,6 +88,8 @@
           components:
             - FitsInDispenser
   - type: ItemToggle
+    onUse: false # Triad
+    onActivate: false # Triad, fixes cryopod health analyzer not opening
   - type: HealthAnalyzer
     scanDelay: 0
   - type: UserInterface

--- a/Resources/Prototypes/_Mono/Entities/Clothing/Head/Hardsuits/mercenaries.yml
+++ b/Resources/Prototypes/_Mono/Entities/Clothing/Head/Hardsuits/mercenaries.yml
@@ -38,6 +38,8 @@
     interfaces:
       enum.RadarConsoleUiKey.Key:
         type: RadarConsoleBoundUserInterface
+  - type: HandheldLight
+    toggleOnInteract: false # Triad, fixes radar not being activatable with E
   - type: HideLayerClothing
     slots:
     - Hair

--- a/Resources/Prototypes/_Mono/Entities/Clothing/Head/Hardsuits/ui.yml
+++ b/Resources/Prototypes/_Mono/Entities/Clothing/Head/Hardsuits/ui.yml
@@ -68,6 +68,8 @@
         Slash: 0.9
         Piercing: 0.9
         Heat: 0.9
+  - type: HandheldLight
+    toggleOnInteract: false # Triad, fixes radar not being activatable with E
   - type: HideLayerClothing
     slots:
     - Hair

--- a/Resources/Prototypes/_Mono/Entities/Clothing/Head/Hardsuits/ussp.yml
+++ b/Resources/Prototypes/_Mono/Entities/Clothing/Head/Hardsuits/ussp.yml
@@ -114,6 +114,8 @@
     interfaces:
       enum.RadarConsoleUiKey.Key:
         type: RadarConsoleBoundUserInterface
+  - type: HandheldLight
+    toggleOnInteract: false # Triad, fixes radar not being activatable with E
   - type: Armor
     modifiers:
       coefficients:

--- a/Resources/Prototypes/_Mono/Entities/Clothing/Head/modsuit.yml
+++ b/Resources/Prototypes/_Mono/Entities/Clothing/Head/modsuit.yml
@@ -279,6 +279,7 @@
     addPrefix: true
     blinkingBehaviourId: blinking
     radiatingBehaviourId: radiating
+    toggleOnInteract: false # Triad, fixes radar not being activatable with E
   - type: ItemTogglePointLight
   - type: LightBehaviour
     behaviours:

--- a/Resources/Prototypes/_Mono/Entities/Clothing/OuterClothing/Hardsuits/trauma.yml
+++ b/Resources/Prototypes/_Mono/Entities/Clothing/OuterClothing/Hardsuits/trauma.yml
@@ -37,6 +37,8 @@
       head: ClothingHeadHelmetHardsuitTrauma
       helmetcover: ClothingHeadHelmetCoverBlock
       helmetattachment: ClothingHeadHelmetAttachmentBlock
+  - type: HandheldLight
+    toggleOnInteract: false # Triad, fixes radar not being activatable with E
   - type: StaticPrice
     price: 1400
     vendPrice: 10000
@@ -81,6 +83,8 @@
       head: ClothingHeadHelmetHardsuitTraumaLeader
       helmetcover: ClothingHeadHelmetCoverBlock
       helmetattachment: ClothingHeadHelmetAttachmentBlock
+  - type: HandheldLight
+    toggleOnInteract: false # Triad, fixes radar not being activatable with E
   - type: StaticPrice
     price: 4200
     vendPrice: 25000


### PR DESCRIPTION
## About the PR
- fixed handheld mass scanners not being toggleable by E and hardsuit mass scanners
- fixed modsuit helmets not acting as breath masks

## Media
<img width="457" height="465" alt="Screenshot_20260430_164143" src="https://github.com/user-attachments/assets/9757cbeb-66c2-4ca8-bdb8-323eb670b83f" />
<img width="779" height="638" alt="Screenshot_20260430_164357" src="https://github.com/user-attachments/assets/d8f07370-6cb4-4cbb-80b7-c36113922c11" />
<img width="760" height="416" alt="Screenshot_20260430_175757" src="https://github.com/user-attachments/assets/fc12c7d4-9359-4f79-b5fe-d622fa36d0a9" />


## Requirements
<!-- Confirm the following by placing an X in the brackets [X]: -->
- [x] I have read relevant guidelines/documentation to this PR found on [our devwiki](https://monolith-station.github.io/mono-docs/).
- [x] I have added media to this PR or it does not require an ingame showcase.
- [x] I can confirm this PR contains either no AI-generated content, or AI-generated content that meets our guidelines.
<!-- You should understand that not following the above may get your PR closed at maintainer’s discretion -->
<!-- When using AI, make sure you are already proficient in creating whatever content you are attempting to generate and that you already have experience contributing to SS14. This means using AI to enhance your preexisting workflow, not vibecoding. -->

## Technical details
Changes to ``SharedSealableClothingSystem`` to allow for a user field on the seal events
Connects to the breath tool when seals complete

**Changelog**
:cl:
- fix: Fixed cryopods, handheld mass scanners, and hardsuit mass scanners not being activatable by 'E' (activate in world keybind)
- fix: Fixed modsuit helmets not acting as breath masks. You can now connect internals to them.
