### PR TITLE
Ship Save Contraband Additions

### DIFF
--- a/Content.Shared/_Triad/Shipyard/SavingContrabandComponent.cs
+++ b/Content.Shared/_Triad/Shipyard/SavingContrabandComponent.cs
@@ -2,6 +2,7 @@ namespace Content.Shared._Triad.Shipyard;
 
 /// <summary>
 /// Entities with this component will not be saved when a ship is saved.
+/// Optional field for examine text.
 /// </summary>
 [RegisterComponent]
 public sealed partial class SavingContrabandComponent : Component

--- a/Content.Shared/_Triad/Shipyard/SavingContrabandSystem.cs
+++ b/Content.Shared/_Triad/Shipyard/SavingContrabandSystem.cs
@@ -1,18 +1,36 @@
 using Content.Shared.Examine;
+using Content.Shared.Verbs;
+using Robust.Shared.Utility;
 
 namespace Content.Shared._Triad.Shipyard;
 
 public sealed class SavingContrabandSystem : EntitySystem
 {
+    [Dependency] private readonly ExamineSystemShared _examine = default!;
+
     public override void Initialize()
     {
-        SubscribeLocalEvent<SavingContrabandComponent, ExaminedEvent>(OnExamined);
+        SubscribeLocalEvent<SavingContrabandComponent, GetVerbsEvent<ExamineVerb>>(OnDetailedExamine);
     }
 
-    private void OnExamined(Entity<SavingContrabandComponent> ent, ref ExaminedEvent args)
+    private void OnDetailedExamine(Entity<SavingContrabandComponent> ent, ref GetVerbsEvent<ExamineVerb> args)
     {
         if (ent.Comp.ExamineText == null)
             return;
-        args.PushMarkup(Loc.GetString(ent.Comp.ExamineText));
+
+        if (!args.CanInteract)
+            return;
+
+        var examineText = Loc.GetString(ent.Comp.ExamineText);
+
+        var msg = new FormattedMessage();
+        msg.AddMarkupOrThrow(examineText);
+
+        _examine.AddDetailedExamineVerb(args,
+            ent.Comp,
+            msg,
+            Loc.GetString("ship-saving-contraband-examine-verb-text"),
+            "/Textures/Interface/VerbIcons/anchor.svg.192dpi.png",
+            Loc.GetString("ship-saving-contraband-examine-verb-message"));
     }
 }

--- a/Resources/Locale/en-US/_Triad/contraband/ship-saving-contraband.ftl
+++ b/Resources/Locale/en-US/_Triad/contraband/ship-saving-contraband.ftl
@@ -1,6 +1,6 @@
 ship-saving-contraband-verb-text = Ship Storing Eligibility
 ship-saving-contraband-verb-message = Check if this item is eligible to be stored on a ship.
 
-ship-saving-contraband-1-text = [color=blue]This is listed as Class 1 Ship Contraband. Legal to own, but will be seized upon ship storing.[/color]
-ship-saving-contraband-2-text = [color=yellow]This is listed as Class 2 Ship Contraband. Civilian possession is illegal and will be seized upon ship storing.[/color]
-ship-saving-contraband-3-text = [color=red]This is listed as Class 3 Ship Contraband. Posession of this item is illegal and will be seized upon ship storing.[/color]
+ship-saving-contraband-1-text = [color=blue]This is listed as Class 1 Ship Contraband. Legal to own, but will be seized upon storing to the shipyard.[/color]
+ship-saving-contraband-2-text = [color=yellow]This is listed as Class 2 Ship Contraband. Civilian possession is illegal and will be seized upon storing to the shipyard.[/color]
+ship-saving-contraband-3-text = [color=red]This is listed as Class 3 Ship Contraband. Posession of this item is illegal and will be seized upon storing to the shipyard.[/color]

--- a/Resources/Locale/en-US/_Triad/contraband/ship-saving-contraband.ftl
+++ b/Resources/Locale/en-US/_Triad/contraband/ship-saving-contraband.ftl
@@ -1,3 +1,6 @@
-ship-saving-contraband-1-text = [color=blue]This is listed as Class 1 Ship Contraband. Legal to own but will be removed upon saving the ship.[/color]
-ship-saving-contraband-2-text = [color=blue]This is listed as Class 2 Ship Contraband. Civilian possession is illegal and will be removed upon saving the ship.[/color]
-ship-saving-contraband-3-text = [color=blue]This is listed as Class 3 Ship Contraband. Posession of this item is illegal and will be removed upon saving the ship.[/color]
+ship-saving-contraband-verb-text = Ship Storing Eligibility
+ship-saving-contraband-verb-message = Check if this item is eligible to be stored on a ship.
+
+ship-saving-contraband-1-text = [color=blue]This is listed as Class 1 Ship Contraband. Legal to own, but will be seized upon ship storing.[/color]
+ship-saving-contraband-2-text = [color=yellow]This is listed as Class 2 Ship Contraband. Civilian possession is illegal and will be seized upon ship storing.[/color]
+ship-saving-contraband-3-text = [color=red]This is listed as Class 3 Ship Contraband. Posession of this item is illegal and will be seized upon ship storing.[/color]

--- a/Resources/Locale/en-US/_Triad/contraband/ship-saving-contraband.ftl
+++ b/Resources/Locale/en-US/_Triad/contraband/ship-saving-contraband.ftl
@@ -1,6 +1,6 @@
 ship-saving-contraband-verb-text = Ship Storing Eligibility
 ship-saving-contraband-verb-message = Check if this item is eligible to be stored on a ship.
 
-ship-saving-contraband-1-text = [color=blue]This is listed as Class 1 Ship Contraband. Legal to own, but will be seized upon storing to the shipyard.[/color]
+ship-saving-contraband-1-text = [color=green]This is listed as Class 1 Ship Contraband. Legal to own, but will be seized upon storing to the shipyard.[/color]
 ship-saving-contraband-2-text = [color=yellow]This is listed as Class 2 Ship Contraband. Civilian possession is illegal and will be seized upon storing to the shipyard.[/color]
 ship-saving-contraband-3-text = [color=red]This is listed as Class 3 Ship Contraband. Posession of this item is illegal and will be seized upon storing to the shipyard.[/color]


### PR DESCRIPTION
## About the PR
Rewords the contraband examine text to be more larpy and also adds a button to see the ship save contraband status instead of it just being pasted onto the examine text

## Media

<img width="505" height="172" alt="Screenshot_20260502_162310" src="https://github.com/user-attachments/assets/692dd4d8-8532-4f4b-94d7-1999e5ae3dfd" />
<img width="407" height="168" alt="Screenshot_20260502_162321" src="https://github.com/user-attachments/assets/583b8961-f53e-4f75-83bf-fa9e7a2862d6" />
<img width="392" height="165" alt="Screenshot_20260502_162555" src="https://github.com/user-attachments/assets/1f9b0368-27cd-4ec5-a6e5-8704319bb538" />




**Changelog**
:cl:
- add: New examine button for ship saving contraband.