### PR TITLE
Disable Dwarf

### DIFF
--- a/Resources/Prototypes/Species/dwarf.yml
+++ b/Resources/Prototypes/Species/dwarf.yml
@@ -1,7 +1,7 @@
 - type: species
   id: Dwarf
   name: species-name-dwarf
-  roundStart: true
+  roundStart: false # Triad, we have height sliders and traits
   prototype: MobDwarf
   sprites: MobHumanSprites
   markingLimits: MobHumanMarkingLimits


### PR DESCRIPTION
## About the PR
Disabled Dwarf

## Reasoning
We have:
- alcoholism healing traits
- the scottish accent
- height sliders

Dwarf is literally just a renamed human, there is ZERO difference between them unlike other servers

:cl:
- remove: Disabled the dwarf species
