### PR TITLE
Cherrypick: Cherrypicks some Nix-Related Commits From Wizard's Den (#3948)

### DIFF
--- a/flake.lock
+++ b/flake.lock
@@ -20,16 +20,16 @@
     },
     "nixpkgs": {
       "locked": {
-        "lastModified": 1737097711,
-        "narHash": "sha256-Zql7TDxEMAOASLSu0wBlfM5SIY+4Pz2R/k17O/asCYc=",
+        "lastModified": 1765890948,
+        "narHash": "sha256-Xe6fZzDS8uy9f17Pv6NEeBS9R6MFyuepbQUy6Xq/wH0=",
         "owner": "NixOS",
         "repo": "nixpkgs",
-        "rev": "3cbc78cfa611511c04f47c4932509f9dbdf4381a",
+        "rev": "f92e917d0cefd3eca9d56ae25d689da841a989fd",
         "type": "github"
       },
       "original": {
         "owner": "NixOS",
-        "ref": "release-24.11",
+        "ref": "release-25.11",
         "repo": "nixpkgs",
         "type": "github"
       }

--- a/flake.nix
+++ b/flake.nix
@@ -1,13 +1,22 @@
 {
   description = "Development environment for Space Station 14";
 
-  inputs.nixpkgs.url = "github:NixOS/nixpkgs/release-24.11";
+  inputs.nixpkgs.url = "github:NixOS/nixpkgs/release-25.11";
   inputs.flake-utils.url = "github:numtide/flake-utils";
 
-  outputs = { self, nixpkgs, flake-utils }:
-    flake-utils.lib.eachDefaultSystem (system: let
-      pkgs = nixpkgs.legacyPackages.${system};
-    in {
-      devShells.default = import ./shell.nix { inherit pkgs; };
-    });
+  outputs =
+    {
+      self,
+      nixpkgs,
+      flake-utils,
+    }:
+    flake-utils.lib.eachDefaultSystem (
+      system:
+      let
+        pkgs = nixpkgs.legacyPackages.${system};
+      in
+      {
+        devShells.default = import ./shell.nix { inherit pkgs; };
+      }
+    );
 }

--- a/shell.nix
+++ b/shell.nix
@@ -1,19 +1,24 @@
-{ pkgs ? (let lock = builtins.fromJSON (builtins.readFile ./flake.lock);
-in import (builtins.fetchTarball {
-  url =
-    "https://github.com/NixOS/nixpkgs/archive/${lock.nodes.nixpkgs.locked.rev}.tar.gz";
-  sha256 = lock.nodes.nixpkgs.locked.narHash;
-}) { }) }:
+{
+  pkgs ? (
+    let
+      lock = builtins.fromJSON (builtins.readFile ./flake.lock);
+    in
+    import (builtins.fetchTarball {
+      url = "https://github.com/NixOS/nixpkgs/archive/${lock.nodes.nixpkgs.locked.rev}.tar.gz";
+      sha256 = lock.nodes.nixpkgs.locked.narHash;
+    }) { }
+  ),
+}:
 
 let
   dependencies = with pkgs; [
-    dotnetCorePackages.sdk_9_0
+    dotnet-sdk_10
     icu
     glfw
-    SDL2
     libGL
     openal
     freetype
+    fontconfig
     fluidsynth
     soundfont-fluid
     gtk3
@@ -39,12 +44,16 @@ let
     xorg.libxshmfence
     mesa
     alsa-lib
+    pipewire
     dbus
     at-spi2-core
     cups
     python3
+    wayland
+    nixfmt
   ];
-in pkgs.mkShell {
+in
+pkgs.mkShell {
   name = "space-station-14-devshell";
   buildInputs = [ pkgs.gtk3 ];
   packages = dependencies;


### PR DESCRIPTION
## About the PR
This PR nicks a quick Nix fix from Monolith. Cherrypicks a cherrypick

## Why / Balance
Bugfix. Version mismatch in `shell.nix`

## Media
<img width="305" height="296" alt="image" src="https://github.com/user-attachments/assets/e70b445a-7aad-4629-80f2-78d241c8906d" />


## Requirements
<!-- Confirm the following by placing an X in the brackets [X]: -->
- [X] I have read relevant guidelines/documentation to this PR found on [our devwiki](https://monolith-station.github.io/mono-docs/).
- [X] I have added media to this PR or it does not require an ingame showcase.
- [X] I can confirm this PR contains either no AI-generated content, or AI-generated content that meets our guidelines.
<!-- You should understand that not following the above may get your PR closed at maintainer’s discretion -->
<!-- When using AI, make sure you are already proficient in creating whatever content you are attempting to generate and that you already have experience contributing to SS14. This means using AI to enhance your preexisting workflow, not vibecoding. -->

## How to test
1. `nix-shell`
2. `dotnet build`. No warning about SDK version
3. Run a server. It starts. You can join and it works