### PR TITLE
Ship Save Fixes

### DIFF
--- a/Content.Server/Power/Components/BatterySelfRechargerComponent.cs
+++ b/Content.Server/Power/Components/BatterySelfRechargerComponent.cs
@@ -1,4 +1,5 @@
 using System;
+using Robust.Shared.Serialization.TypeSerializers.Implementations.Custom; // Triad - for TimeOffsetSerializer
 
 namespace Content.Server.Power.Components
 {
@@ -31,6 +32,6 @@ namespace Content.Server.Power.Components
         /// <summary>
         /// Do not auto recharge if this timestamp has yet to happen, set for the auto recharge pause system.
         /// </summary>
-        [DataField] public TimeSpan NextAutoRecharge = TimeSpan.FromSeconds(0f);
+        [DataField(customTypeSerializer: typeof(TimeOffsetSerializer))] public TimeSpan NextAutoRecharge = TimeSpan.FromSeconds(0f); // Triad - give it TimeOffsetSerializer so that saved maps don't have to worry about the timestamp being in the past when loaded
     }
 }

--- a/Content.Server/_HL/Shipyard/ShipSaveYamlSanitizer.cs
+++ b/Content.Server/_HL/Shipyard/ShipSaveYamlSanitizer.cs
@@ -116,7 +116,7 @@ public static class ShipSaveYamlSanitizer
         "DnaSequenceInjector",
         "DoorRemote",
         "EmergencyShuttleConsole",
-        "GeneralStationRecordConsole",
+        // "GeneralStationRecordConsole",
         "GeneticAnalyzer",
         "Ghost",
         "GhostRole",

--- a/Content.Server/_NF/Shipyard/Systems/ShipyardGridSaveSystem.cs
+++ b/Content.Server/_NF/Shipyard/Systems/ShipyardGridSaveSystem.cs
@@ -37,6 +37,8 @@ using Content.Shared.Doors.Components;
 using Content.Shared._Mono.ShipRepair.Components;
 using Robust.Shared.Collections;
 using Content.Shared.NodeContainer;
+using Content.Server.Station.Systems;
+using Content.Server._NF.ShuttleRecords;
 
 namespace Content.Server._NF.Shipyard.Systems;
 
@@ -56,6 +58,8 @@ public sealed class ShipyardGridSaveSystem : EntitySystem
     [Dependency] private readonly SharedDeviceLinkSystem _deviceLink = default!;
     [Dependency] private readonly IPrototypeManager _prototypeManager = default!; // HardLight
     [Dependency] private readonly SharedTransformSystem _transform = default!; // Triad
+    [Dependency] private readonly StationSystem _station = default!; // Triad
+    [Dependency] private readonly ShuttleRecordsSystem _shuttleRecords = default!; // Triad
 
     public List<ShipSaveLimitsPrototype> ShipSaveEntityLimits { get; private set; } = new();
 
@@ -117,6 +121,10 @@ public sealed class ShipyardGridSaveSystem : EntitySystem
             // Also remove any other shuttle deeds that reference this shuttle
             RemoveAllShuttleDeeds(grid);
 
+            // Destroy the station on the shuttle
+            if (_station.GetOwningStation(grid) is { Valid: true } shuttleStationUid)
+                _station.DeleteStation(shuttleStationUid);
+
             // Delete the shuttle
             QueueDel(grid);
         }
@@ -124,6 +132,9 @@ public sealed class ShipyardGridSaveSystem : EntitySystem
         {
             return false;
         }
+
+        // Update all record UI (skip records, no new records)
+        _shuttleRecords.RefreshStateForAll(true);
 
         return true;
     }
@@ -138,7 +149,7 @@ public sealed class ShipyardGridSaveSystem : EntitySystem
 
         while (query.MoveNext(out var entityUid, out var deed))
         {
-            if (deed.ShuttleUid != null && _entityManager.EntityExists(deed.ShuttleUid.Value) && deed.ShuttleUid.Value == shuttleUid)
+            if (deed.ShuttleUid != null && Exists(deed.ShuttleUid.Value) && deed.ShuttleUid.Value == shuttleUid)
             {
                 deedsToRemove.Add(entityUid);
             }

--- a/Resources/Prototypes/_Mono/Entities/SpaceArtillery/SpaceArtillery/Energy/launcher.yml
+++ b/Resources/Prototypes/_Mono/Entities/SpaceArtillery/SpaceArtillery/Energy/launcher.yml
@@ -764,8 +764,6 @@
   - type: ShipRepairable
     repairTime: 25
     repairCost: 100
-  - type: SpawnOnShipLoad # Triad fix apollo
-    spawn: WeaponLaserTurretApollo
 
 # PRE- FRACTURE
 


### PR DESCRIPTION
## About the PR
- Fixed joining a shuttle's crew from the latejoin screen sometimes killing your game, saving a ship properly removes the station now so this should no longer happen

- Fixed recharging weapons not working on loaded ships by givng it ``TimeOffsetSerializer``

**Changelog**
<!-- Add a Changelog entry to make players aware of new features or changes that could affect gameplay.
Make sure to read the guidelines and take this Changelog template out of the comment block in order for it to show up.
Changelog must have a :cl: symbol, so the bot recognizes the changes and adds them to the game's changelog.
Remove this symbol for non-player facing PRs.-->
:cl:
- fix: Fixed joining a saved shuttle's crew from the join menu bringing you to a black screen
- fix: Fixed recharging weapons not working on loaded shuttles.
