### PR TITLE
Atmos Changes

### DIFF
--- a/Content.Server/Atmos/EntitySystems/AirFilterSystem.cs
+++ b/Content.Server/Atmos/EntitySystems/AirFilterSystem.cs
@@ -31,9 +31,12 @@ public sealed class AirFilterSystem : EntitySystem
         if (air.Pressure >= intake.Pressure)
             return;
 
-        var map = _atmosphere.AllowMapGasExtraction ? args.Map : null; // Frontier
+        // Frontier: check running gas extraction
+        if (!_atmosphere.AtmosInputCanRunOnMap(args.Map))
+            return;
+        // End Frontier
 
-        var environment = _atmosphere.GetContainingMixture(uid, args.Grid, map, true, true); // Frontier: args.Map<map
+        var environment = _atmosphere.GetContainingMixture(uid, args.Grid, args.Map, true, true);
         // nothing to intake from
         if (environment == null)
             return;

--- a/Content.Server/Atmos/EntitySystems/AirFilterSystem.cs
+++ b/Content.Server/Atmos/EntitySystems/AirFilterSystem.cs
@@ -31,7 +31,9 @@ public sealed class AirFilterSystem : EntitySystem
         if (air.Pressure >= intake.Pressure)
             return;
 
-        var environment = _atmosphere.GetContainingMixture(uid, args.Grid, args.Map, true, true);
+        var map = _atmosphere.AllowMapGasExtraction ? args.Map : null; // Frontier
+
+        var environment = _atmosphere.GetContainingMixture(uid, args.Grid, map, true, true); // Frontier: args.Map<map
         // nothing to intake from
         if (environment == null)
             return;

--- a/Content.Server/Atmos/EntitySystems/AtmosphereSystem.API.cs
+++ b/Content.Server/Atmos/EntitySystems/AtmosphereSystem.API.cs
@@ -167,12 +167,6 @@ public partial class AtmosphereSystem
             && Resolve(gridEnt, ref gridEnt.Comp1, false)
             && gridEnt.Comp1.Tiles.TryGetValue(gridTile, out var tile))
         {
-            // Frontier: hack to avoid infinite gas extraction from planets
-            if (tile.MapAtmosphere && map == null)
-            {
-                return GasMixture.SpaceGas;
-            }
-            // End Frontier
             if (excite)
             {
                 AddActiveTile(gridEnt.Comp1, tile);

--- a/Content.Server/Atmos/EntitySystems/AtmosphereSystem.API.cs
+++ b/Content.Server/Atmos/EntitySystems/AtmosphereSystem.API.cs
@@ -167,6 +167,12 @@ public partial class AtmosphereSystem
             && Resolve(gridEnt, ref gridEnt.Comp1, false)
             && gridEnt.Comp1.Tiles.TryGetValue(gridTile, out var tile))
         {
+            // Frontier: hack to avoid infinite gas extraction from planets
+            if (tile.MapAtmosphere && map == null)
+            {
+                return GasMixture.SpaceGas;
+            }
+            // End Frontier
             if (excite)
             {
                 AddActiveTile(gridEnt.Comp1, tile);

--- a/Content.Server/Atmos/EntitySystems/AtmosphereSystem.CVars.cs
+++ b/Content.Server/Atmos/EntitySystems/AtmosphereSystem.CVars.cs
@@ -1,3 +1,4 @@
+using Content.Shared._NF.CCVar; // Frontier
 using Content.Shared.CCVar;
 using Robust.Shared.Configuration;
 
@@ -26,6 +27,7 @@ namespace Content.Server.Atmos.EntitySystems
         public float AtmosTickRate { get; private set; }
         public float Speedup { get; private set; }
         public float HeatScale { get; private set; }
+        public bool AllowMapGasExtraction { get; private set; } // Frontier
 
         /// <summary>
         /// Time between each atmos sub-update.  If you are writing an atmos device, use AtmosDeviceUpdateEvent.dt
@@ -55,6 +57,7 @@ namespace Content.Server.Atmos.EntitySystems
             Subs.CVar(_cfg, CCVars.AtmosHeatScale, value => { HeatScale = value; InitializeGases(); }, true);
             Subs.CVar(_cfg, CCVars.ExcitedGroups, value => ExcitedGroups = value, true);
             Subs.CVar(_cfg, CCVars.ExcitedGroupsSpaceIsAllConsuming, value => ExcitedGroupsSpaceIsAllConsuming = value, true);
+            Subs.CVar(_cfg, NFCCVars.AllowMapGasExtraction, value => AllowMapGasExtraction = value, true); // Frontier
         }
     }
 }

--- a/Content.Server/Atmos/EntitySystems/AtmosphereSystem.Utils.cs
+++ b/Content.Server/Atmos/EntitySystems/AtmosphereSystem.Utils.cs
@@ -4,6 +4,7 @@ using Content.Server.Maps;
 using Content.Shared.Atmos;
 using Content.Shared.Atmos.Components;
 using Content.Shared.Maps;
+using Content.Shared.Shuttles.Components; // Frontier
 using Robust.Shared.Map;
 using Robust.Shared.Map.Components;
 
@@ -128,4 +129,19 @@ public partial class AtmosphereSystem
 
         _tile.PryTile(tileRef);
     }
+
+    // Frontier: disable atmos off maps
+    /// <summary>
+    ///     Checks if atmos input devices are allowed to run on the given map entity.
+    /// </summary>
+    /// <param name="mapGrid">The map in question.</param>
+    public bool AtmosInputCanRunOnMap(EntityUid? mapUid)
+    {
+        // Frontier: check running gas extraction
+        if (!TryComp<MapComponent>(mapUid, out var mapComp))
+            return false;
+
+        return AllowMapGasExtraction || HasComp<FTLMapComponent>(mapUid) || mapComp.MapId == _gameTicker.DefaultMap;
+    }
+    // End Frontier: disable atmos off maps
 }

--- a/Content.Server/Atmos/EntitySystems/AtmosphereSystem.cs
+++ b/Content.Server/Atmos/EntitySystems/AtmosphereSystem.cs
@@ -2,6 +2,7 @@ using Content.Server.Administration.Logs;
 using Content.Server.Atmos.Components;
 using Content.Server.Body.Systems;
 using Content.Server.Fluids.EntitySystems;
+using Content.Server.GameTicking; // Frontier
 using Content.Server.NodeContainer.EntitySystems;
 using Content.Shared.Atmos.EntitySystems;
 using Content.Shared.Decals;
@@ -37,6 +38,7 @@ public sealed partial class AtmosphereSystem : SharedAtmosphereSystem
     [Dependency] private readonly TileSystem _tile = default!;
     [Dependency] private readonly MapSystem _map = default!;
     [Dependency] public readonly PuddleSystem Puddle = default!;
+    [Dependency] private readonly GameTicker _gameTicker = default!; // Frontier
 
     private const float ExposedUpdateDelay = 1f;
     private float _exposedTimer = 0f;

--- a/Content.Server/Atmos/Piping/Unary/EntitySystems/GasPassiveVentSystem.cs
+++ b/Content.Server/Atmos/Piping/Unary/EntitySystems/GasPassiveVentSystem.cs
@@ -24,9 +24,12 @@ namespace Content.Server.Atmos.Piping.Unary.EntitySystems
 
         private void OnPassiveVentUpdated(EntityUid uid, GasPassiveVentComponent vent, ref AtmosDeviceUpdateEvent args)
         {
-            var map = _atmosphereSystem.AllowMapGasExtraction ? args.Map : null; // Frontier
+            // Frontier: check running gas extraction
+            if (!_atmosphereSystem.AtmosInputCanRunOnMap(args.Map))
+                return;
+            // End Frontier
 
-            var environment = _atmosphereSystem.GetContainingMixture(uid, args.Grid, map, true, true); // Frontier: args.Map<map
+            var environment = _atmosphereSystem.GetContainingMixture(uid, args.Grid, args.Map, true, true);
 
             if (environment == null)
                 return;

--- a/Content.Server/Atmos/Piping/Unary/EntitySystems/GasPassiveVentSystem.cs
+++ b/Content.Server/Atmos/Piping/Unary/EntitySystems/GasPassiveVentSystem.cs
@@ -24,7 +24,9 @@ namespace Content.Server.Atmos.Piping.Unary.EntitySystems
 
         private void OnPassiveVentUpdated(EntityUid uid, GasPassiveVentComponent vent, ref AtmosDeviceUpdateEvent args)
         {
-            var environment = _atmosphereSystem.GetContainingMixture(uid, args.Grid, args.Map, true, true);
+            var map = _atmosphereSystem.AllowMapGasExtraction ? args.Map : null; // Frontier
+
+            var environment = _atmosphereSystem.GetContainingMixture(uid, args.Grid, map, true, true); // Frontier: args.Map<map
 
             if (environment == null)
                 return;

--- a/Content.Server/Atmos/Piping/Unary/EntitySystems/GasVentPumpSystem.cs
+++ b/Content.Server/Atmos/Piping/Unary/EntitySystems/GasVentPumpSystem.cs
@@ -85,7 +85,9 @@ namespace Content.Server.Atmos.Piping.Unary.EntitySystems
                 return;
             }
 
-            var environment = _atmosphereSystem.GetContainingMixture(uid, args.Grid, args.Map, true, true);
+            var map = _atmosphereSystem.AllowMapGasExtraction ? args.Map : null; // Frontier
+
+            var environment = _atmosphereSystem.GetContainingMixture(uid, args.Grid, map, true, true); // Frontier: args.Map<map
 
             // We're in an air-blocked tile... Do nothing.
             if (environment == null)

--- a/Content.Server/Atmos/Piping/Unary/EntitySystems/GasVentPumpSystem.cs
+++ b/Content.Server/Atmos/Piping/Unary/EntitySystems/GasVentPumpSystem.cs
@@ -85,9 +85,12 @@ namespace Content.Server.Atmos.Piping.Unary.EntitySystems
                 return;
             }
 
-            var map = _atmosphereSystem.AllowMapGasExtraction ? args.Map : null; // Frontier
+            // Frontier: check running gas extraction
+            if (!_atmosphereSystem.AtmosInputCanRunOnMap(args.Map))
+                return;
+            // End Frontier
 
-            var environment = _atmosphereSystem.GetContainingMixture(uid, args.Grid, map, true, true); // Frontier: args.Map<map
+            var environment = _atmosphereSystem.GetContainingMixture(uid, args.Grid, args.Map, true, true);
 
             // We're in an air-blocked tile... Do nothing.
             if (environment == null)

--- a/Content.Server/Atmos/Piping/Unary/EntitySystems/GasVentScrubberSystem.cs
+++ b/Content.Server/Atmos/Piping/Unary/EntitySystems/GasVentScrubberSystem.cs
@@ -66,8 +66,10 @@ namespace Content.Server.Atmos.Piping.Unary.EntitySystems
             if (args.Grid is not {} grid)
                 return;
 
+            var map = _atmosphereSystem.AllowMapGasExtraction ? args.Map : null; // Frontier
+
             var position = _transformSystem.GetGridTilePositionOrDefault(uid);
-            var environment = _atmosphereSystem.GetTileMixture(grid, args.Map, position, true);
+            var environment = _atmosphereSystem.GetTileMixture(grid, map, position, true); // Frontier: args.Map<map
 
             Scrub(timeDelta, scrubber, environment, outlet);
 

--- a/Content.Server/Atmos/Piping/Unary/EntitySystems/GasVentScrubberSystem.cs
+++ b/Content.Server/Atmos/Piping/Unary/EntitySystems/GasVentScrubberSystem.cs
@@ -66,10 +66,13 @@ namespace Content.Server.Atmos.Piping.Unary.EntitySystems
             if (args.Grid is not {} grid)
                 return;
 
-            var map = _atmosphereSystem.AllowMapGasExtraction ? args.Map : null; // Frontier
+            // Frontier: check running gas extraction
+            if (!_atmosphereSystem.AtmosInputCanRunOnMap(args.Map))
+                return;
+            // End Frontier
 
             var position = _transformSystem.GetGridTilePositionOrDefault(uid);
-            var environment = _atmosphereSystem.GetTileMixture(grid, map, position, true); // Frontier: args.Map<map
+            var environment = _atmosphereSystem.GetTileMixture(grid, args.Map, position, true);
 
             Scrub(timeDelta, scrubber, environment, outlet);
 

--- a/Content.Server/Atmos/Portable/PortableScrubberSystem.cs
+++ b/Content.Server/Atmos/Portable/PortableScrubberSystem.cs
@@ -57,6 +57,11 @@ namespace Content.Server.Atmos.Portable
             if (!component.Enabled)
                 return;
 
+            // Frontier: check running gas extraction
+            if (!_atmosphereSystem.AtmosInputCanRunOnMap(args.Map))
+                return;
+            // End Frontier
+
             // If we are on top of a connector port, empty into it.
             if (_nodeContainer.TryGetNode(uid, component.PortName, out PortablePipeNode? portableNode)
                 && portableNode.ConnectionsEnabled)
@@ -75,10 +80,8 @@ namespace Content.Server.Atmos.Portable
             if (args.Grid is not {} grid)
                 return;
 
-            var map = _atmosphereSystem.AllowMapGasExtraction ? args.Map : null; // Frontier
-
             var position = _transformSystem.GetGridTilePositionOrDefault(uid);
-            var environment = _atmosphereSystem.GetTileMixture(grid, map, position, true); // Frontier: args.Map<map
+            var environment = _atmosphereSystem.GetTileMixture(grid, args.Map, position, true);
 
             var running = Scrub(timeDelta, component, environment);
 

--- a/Content.Server/Atmos/Portable/PortableScrubberSystem.cs
+++ b/Content.Server/Atmos/Portable/PortableScrubberSystem.cs
@@ -75,8 +75,10 @@ namespace Content.Server.Atmos.Portable
             if (args.Grid is not {} grid)
                 return;
 
+            var map = _atmosphereSystem.AllowMapGasExtraction ? args.Map : null; // Frontier
+
             var position = _transformSystem.GetGridTilePositionOrDefault(uid);
-            var environment = _atmosphereSystem.GetTileMixture(grid, args.Map, position, true);
+            var environment = _atmosphereSystem.GetTileMixture(grid, map, position, true); // Frontier: args.Map<map
 
             var running = Scrub(timeDelta, component, environment);
 

--- a/Content.Shared/_NF/CCVar/NFCCVars.cs
+++ b/Content.Shared/_NF/CCVar/NFCCVars.cs
@@ -242,4 +242,13 @@ public sealed class NFCCVars
     /// </summary>
     public static readonly CVarDef<float> CrateGenerationGridBoundsScale =
         CVarDef.Create("nf14.events.crate_generation_grid_bounds_scale", 0.6f, CVar.SERVERONLY);
+
+    /*
+     * Atmos
+     */
+    /// <summary>
+    ///     If true, allows map extraction (scrubbing a planet's atmosphere).
+    /// </summary>
+    public static readonly CVarDef<bool> AllowMapGasExtraction =
+        CVarDef.Create("nf14.atmos.allow_map_gas_extraction", false, CVar.SERVER | CVar.REPLICATED);
 }

--- a/Resources/Prototypes/_NF/Entities/Objects/Specific/Atmospherics/deposits.yml
+++ b/Resources/Prototypes/_NF/Entities/Objects/Specific/Atmospherics/deposits.yml
@@ -488,7 +488,7 @@
   - type: ItemToggle
   - type: ProximityBeeper
   - type: ProximityDetector
-    range: 20
+    range: 64
     criteria:
       components:
       - GasDeposit


### PR DESCRIPTION
## About the PR
Ports a few PRs from Frontier:
- https://github.com/new-frontiers-14/frontier-station-14/pull/3061
- https://github.com/new-frontiers-14/frontier-station-14/pull/3116

The gas deposit scanner change is simply for QoL.
For disabling atmos siphoning on exped planets, it is currently way too overpowered to keep in the game. There isn't any challenge or gameplay behind it, all you need to is set up a small/medium sized chamber with some scrubbers and you will make passive money (25k up to almost 125k on nitrous oxide/co2/water vapor planets)

Gas siphoning planets can be added back if we get extra gameplay mechanics behind it so it isn't just boring free money

**Changelog**
:cl: Frontier-Station
- remove: You can no longer siphon gas onto your ship from expedition planets.
