### PR TITLE
Moves and Renames the Stash Whitelist Tags

### DIFF
--- a/Resources/Prototypes/Entities/Objects/Specific/Hydroponics/tools.yml
+++ b/Resources/Prototypes/Entities/Objects/Specific/Hydroponics/tools.yml
@@ -188,5 +188,5 @@
   # Triad
   - type: Tag
     tags:
-    - BotanicalTableCompatible
+    - FitsInBotanicalStash
   # End Triad

--- a/Resources/Prototypes/_NF/Entities/Objects/Specific/Medical/medical_bag.yml
+++ b/Resources/Prototypes/_NF/Entities/Objects/Specific/Medical/medical_bag.yml
@@ -65,5 +65,5 @@
   # Triad
   - type: Tag
     tags:
-    - MedicialBluespaceDeskCompatible  
+    - FitsInMedicalStash
   # End Triad

--- a/Resources/Prototypes/_Triad/Entities/Structures/Storage/ShipPersistent/ship_stash.yml
+++ b/Resources/Prototypes/_Triad/Entities/Structures/Storage/ShipPersistent/ship_stash.yml
@@ -75,6 +75,7 @@
           - Hypospray
           - MedicalBag
         tags:
+          - FitsInMedicalStash
           - PillCanister
           - CentrifugeCompatible
           - Syringe
@@ -85,7 +86,6 @@
           - Bottle
           - GlassBeaker
           - ChemDispensable
-          - MedicialBluespaceDeskCompatible
           - CigPack
           - Medkit
     - type: Construction
@@ -119,7 +119,7 @@
         - Produce
         - Seed
         tags:
-        - BotanicalTableCompatible
+        - FitsInBotanicalStash
         - BotanyShovel
         - BotanyHatchet
         - PlantSampleTaker

--- a/Resources/Prototypes/_Triad/tags.yml
+++ b/Resources/Prototypes/_Triad/tags.yml
@@ -1,0 +1,5 @@
+- type: Tag
+  id: FitsInBotanicalStash
+
+- type: Tag
+  id: FitsInMedicalStash

--- a/Resources/Prototypes/tags.yml
+++ b/Resources/Prototypes/tags.yml
@@ -136,9 +136,6 @@
   id: Bot
 
 - type: Tag
-  id: BotanicalTableCompatible
-
-- type: Tag
   id: BotanyHatchet
 
 - type: Tag
@@ -809,9 +806,6 @@
 
 - type: Tag
   id: Medal
-
-- type: Tag
-  id: MedicialBluespaceDeskCompatible
 
 - type: Tag
   id: Medkit


### PR DESCRIPTION
## About the PR
This PR moves the Triad stash tags out of upstream files and into a Triad namespace

I also renamed them from
- `BotanicalTableCompatible` to `FitsInBotanicalStash`
- `MedicialBluespaceDeskCompatible` to `FitsInMedicalStash`

https://github.com/Triad-Sector/Triad_Sector/commit/945360026e358689a9bd13df3b1ff317c7d8e1d7 is the commit that added these tags

## Why / Balance
They were using outdated names (this PR replaces them with more generic ones so they don't need to be renamed again), and one had a typo in it

Triad files outside of _Triad

## Media
(~~bad crop? we're gonna starve~~ I accidentally cropped it too high to include the whole medical bag)

<img width="431" height="301" alt="image" src="https://github.com/user-attachments/assets/3f488fba-f208-44ab-bf53-74ab5163e70e" />


## Requirements
<!-- Confirm the following by placing an X in the brackets [X]: -->
- [X] I have read relevant guidelines/documentation to this PR found on [our devwiki](https://monolith-station.github.io/mono-docs/).
- [X] I have added media to this PR or it does not require an ingame showcase.
- [X] I can confirm this PR contains either no AI-generated content, or AI-generated content that meets our guidelines.
<!-- You should understand that not following the above may get your PR closed at maintainer’s discretion -->
<!-- When using AI, make sure you are already proficient in creating whatever content you are attempting to generate and that you already have experience contributing to SS14. This means using AI to enhance your preexisting workflow, not vibecoding. -->

## How to test
1. Spawn in Medical and Botanical stashes
2. Try putting a plant bag or medical bag into either of them. They still fit their respective stash

## Breaking changes
The `BotanicalTableCompatible` tag has been renamed to `FitsInBotanicalStash`.
The `MedicialBluespaceDeskCompatible` tag has been renamed to `FitsInMedicalStash`.

Not player-facing. No changelog required
