### PR TITLE
Adds Labelers to Stash Whitelists

### DIFF
--- a/Resources/Prototypes/_Triad/Entities/Structures/Storage/ShipPersistent/ship_stash.yml
+++ b/Resources/Prototypes/_Triad/Entities/Structures/Storage/ShipPersistent/ship_stash.yml
@@ -74,6 +74,7 @@
           - Pill
           - Hypospray
           - MedicalBag
+          - HandLabeler
         tags:
           - FitsInMedicalStash
           - PillCanister
@@ -118,6 +119,7 @@
         components:
         - Produce
         - Seed
+        - HandLabeler
         tags:
         - FitsInBotanicalStash
         - BotanyShovel


### PR DESCRIPTION
## About the PR
This PR adds everything with the `HandLabeler` component to Botanical/Medical stash whitelists. I chose to add this to both because botanists and chemists use labelers

This PR closes `Medical Stash doesn't take a labeler` in the ideas thread on the Discord

## Why / Balance
Requested in the Discord. If someone wants to use one of their persistence slots on storing a cheap tool for labeling things, why not? Good bit of convenience for people doing botany or chemistry or whatever

## Media
<img width="644" height="457" alt="image" src="https://github.com/user-attachments/assets/65f044cf-87fa-441c-8d66-37b9bb2e6bb4" />

## Requirements
<!-- Confirm the following by placing an X in the brackets [X]: -->
- [X] I have read relevant guidelines/documentation to this PR found on [our devwiki](https://monolith-station.github.io/mono-docs/).
- [X] I have added media to this PR or it does not require an ingame showcase.
- [X] I can confirm this PR contains either no AI-generated content, or AI-generated content that meets our guidelines.
<!-- You should understand that not following the above may get your PR closed at maintainer’s discretion -->
<!-- When using AI, make sure you are already proficient in creating whatever content you are attempting to generate and that you already have experience contributing to SS14. This means using AI to enhance your preexisting workflow, not vibecoding. -->

## How to test
1. Spawn in botanical and medical stashes
2. Spawn two labelers
3. Put them into the stashes. They both go in

**Changelog**
:cl: Minerva
- tweak: Labelers may now be stored in Botanical and Medical stashes.
