### PR TITLE
Makes Lights Persistent

### DIFF
--- a/Resources/Prototypes/Entities/Structures/Lighting/base_lighting.yml
+++ b/Resources/Prototypes/Entities/Structures/Lighting/base_lighting.yml
@@ -83,6 +83,7 @@
       - !type:PlaySoundBehavior
         sound:
           collection: GlassBreak
+  - type: HLPersistOnShipSave # Triad
   # Mono
   - type: ShipRepairable
     repairTime: 1


### PR DESCRIPTION
## About the PR
This PR makes lights persistent, allowing people to keep their light changes through ship saving/loading

I mistakenly made an issue at https://github.com/Triad-Sector/Triad_Sector/issues/53 with these changes active. I am silly

I do not fully understand what I've done or the consequences of it

## Why / Balance
Your bulb swaps getting completely overriden does not seem to be intentional. It's a massive obstacle to customizing

## Requirements
<!-- Confirm the following by placing an X in the brackets [X]: -->
- [X] I have read relevant guidelines/documentation to this PR found on [our devwiki](https://monolith-station.github.io/mono-docs/).
- [X] I have added media to this PR or it does not require an ingame showcase.
- [X] I can confirm this PR contains either no AI-generated content, or AI-generated content that meets our guidelines.
<!-- You should understand that not following the above may get your PR closed at maintainer’s discretion -->
<!-- When using AI, make sure you are already proficient in creating whatever content you are attempting to generate and that you already have experience contributing to SS14. This means using AI to enhance your preexisting workflow, not vibecoding. -->

## How to test
1. Get a ship
2. Swap some light tubes
3. Build two lights. Put a light in one and leave the other empty
4. Save and load the shuttle. Your changed lights will stay changed. The new light you put a bulb into will still have the bulb
5. Your removed lights will be replaced because that's broken. See https://github.com/Triad-Sector/Triad_Sector/issues/53

**Changelog** 
:cl: Minerva
- fix: Lights are now persistent, meaning swapped light tubes will not be replaced with the original ones upon reloading ships. Removing existing tubes is still broken as they will be replaced with what they were.