### PR TITLE
Makes Bedrolls Persistent

### DIFF
--- a/Resources/Prototypes/_NF/Entities/Structures/Furniture/bedroll.yml
+++ b/Resources/Prototypes/_NF/Entities/Structures/Furniture/bedroll.yml
@@ -72,6 +72,7 @@
   - type: Construction
     graph: GraphNFBedrollFolded
     node: NFBedrollFolded
+  - type: HLPersistOnShipSave # Triad
 
 - type: entity
   parent: NFBedroll


### PR DESCRIPTION
## About the PR
This PR makes bedrolls persistent

## Why / Balance
Bedrolls are mapped on a lot of ships and some people leave them down as, like... decor or a convenient bed or something. They shouldn't vanish into the aether because they're furniture I think

## Media
<img width="574" height="523" alt="image" src="https://github.com/user-attachments/assets/1fce1496-595d-488b-bdef-873321e08fc1" />


## Requirements
<!-- Confirm the following by placing an X in the brackets [X]: -->
- [X] I have read relevant guidelines/documentation to this PR found on [our devwiki](https://monolith-station.github.io/mono-docs/).
- [X] I have added media to this PR or it does not require an ingame showcase.
- [X] I can confirm this PR contains either no AI-generated content, or AI-generated content that meets our guidelines.
<!-- You should understand that not following the above may get your PR closed at maintainer’s discretion -->
<!-- When using AI, make sure you are already proficient in creating whatever content you are attempting to generate and that you already have experience contributing to SS14. This means using AI to enhance your preexisting workflow, not vibecoding. -->

## How to test
1. Buy a Gondola (for example, because it has bedrolls)
2. Fold one up if you'd like
3. Save and load the ship. The bedrolls should stay

**Changelog**
:cl: Minerva
- tweak: Bedrolls are now saved with ships.