### PR TITLE
Lowercases the Stash Recipe Names

### DIFF
--- a/Resources/Prototypes/_Triad/Recipes/Construction/machine.yml
+++ b/Resources/Prototypes/_Triad/Recipes/Construction/machine.yml
@@ -1,6 +1,6 @@
 - type: construction
   id: CivilianStorageStash
-  name: Civilian Storage Stash
+  name: civilian storage stash
   description: Miscellaneous everyday supplies and personal items. Preserves stored items across ship deployments.
   graph: CivilianStorageStashGraph
   startNode: start
@@ -17,7 +17,7 @@
 
 - type: construction
   id: MilitaryStorageStash
-  name: Military Storage Stash
+  name: military storage stash
   description: A reinforced flatpack storage unit for secure operations. Preserves stored items across ship deployments.
   graph: MilitaryStorageStashGraph
   startNode: start
@@ -34,7 +34,7 @@
 
 - type: construction
   id: MedicalSecureStorage
-  name: Medical Sanitized Stash
+  name: medical sanitized stash
   description: Sterile stash of clean medical supplies. Preserves stored items across ship deployments.
   graph: MedicalSecureStorageGraph
   startNode: start
@@ -51,7 +51,7 @@
 
 - type: construction
   id: BotanicalStorageUnit
-  name: Botanical Greenhouse Stash
+  name: botanical greenhouse stash
   description: Assorted seeds, plants, and gardening gear stash. Contents are securely preserved across ship operations.
   graph: BotanicalStorageUnitGraph
   startNode: start


### PR DESCRIPTION
## About the PR
This PR lowercases all of the stash recipe names

## Why / Balance
Parity with every other recipe name. It's weird having Ones Cased Like This next to entirely lowercase ones.

## Media
<img width="936" height="683" alt="image" src="https://github.com/user-attachments/assets/4993bc5d-1f99-46ec-861c-2d50f779a6aa" />

## Requirements
<!-- Confirm the following by placing an X in the brackets [X]: -->
- [X] I have read relevant guidelines/documentation to this PR found on [our devwiki](https://monolith-station.github.io/mono-docs/).
- [X] I have added media to this PR or it does not require an ingame showcase.
- [X] I can confirm this PR contains either no AI-generated content, or AI-generated content that meets our guidelines.
<!-- You should understand that not following the above may get your PR closed at maintainer’s discretion -->
<!-- When using AI, make sure you are already proficient in creating whatever content you are attempting to generate and that you already have experience contributing to SS14. This means using AI to enhance your preexisting workflow, not vibecoding. -->

## How to test
1. Open the crafting menu
2. Look around if you'd like. About everything else is entirely lowercase
3. Search "stash". All the stash names are lowercase

This is barely player-facing at all because it's a minor typo fix and doesn't even concern the actual entities. If a changelog is added for whatever reason, `Minerva` is my preferred name