### PR TITLE
Fixes Rule Links

### DIFF
--- a/Resources/ServerInfo/_Triad/Guidebook/Rules/CoreRules/RuleC0.xml
+++ b/Resources/ServerInfo/_Triad/Guidebook/Rules/CoreRules/RuleC0.xml
@@ -14,19 +14,19 @@
 
   Each section contains its own list of rules. Click on the section name to view the full version.
 
-  - [textlink="Section 1. Behavioral Rules" link="RuleC1"]
-  - [textlink="Section 2. Gameplay Rules" link="RuleC2"]
-  - [textlink="Section 3. Metagaming Rules" link="RuleC3"]
-  - [textlink="Section 4. New-life Rules" link="RuleC4"]
-  - [textlink="Section 5. Character Naming Rules" link="RuleC5"]
-  - [textlink="Section 6. Roleplay Rules" link="RuleC6"]
-  - [textlink="Section 7. Powergaming Rules" link="RuleC7"]
-  - [textlink="Section 8. End-Of-Round (EOR) Rules" link="RuleC8"]
-  - [textlink="Section 9. Erotic-Role-Play (ERP) Rules" link="RuleC9"]
-  - [textlink="Section 10. Command and Security Rules" link="RuleC10"]
-  - [textlink="Section 11. Antagonist Rules" link="RuleC11"]
-  - [textlink="Section 12. Escalation Guidelines" link="RuleC12"]
-  - [textlink="Section 13: Ship saving" link="RuleC13"]
+  - [textlink="Section 1. Behavioral Rules" link="TriadRuleC1"]
+  - [textlink="Section 2. Gameplay Rules" link="TriadRuleC2"]
+  - [textlink="Section 3. Metagaming Rules" link="TriadRuleC3"]
+  - [textlink="Section 4. New-life Rules" link="TriadRuleC4"]
+  - [textlink="Section 5. Character Naming Rules" link="TriadRuleC5"]
+  - [textlink="Section 6. Roleplay Rules" link="TriadRuleC6"]
+  - [textlink="Section 7. Powergaming Rules" link="TriadRuleC7"]
+  - [textlink="Section 8. End-Of-Round (EOR) Rules" link="TriadRuleC8"]
+  - [textlink="Section 9. Erotic-Role-Play (ERP) Rules" link="TriadRuleC9"]
+  - [textlink="Section 10. Command and Security Rules" link="TriadRuleC10"]
+  - [textlink="Section 11. Antagonist Rules" link="TriadRuleC11"]
+  - [textlink="Section 12. Escalation Guidelines" link="TriadRuleC12"]
+  - [textlink="Section 13: Ship saving" link="TriadRuleC13"]
 
 
   [color=#ffff00][head=3]Severity guidelines:[/head][/color]


### PR DESCRIPTION
## About the PR
This PR fixes the links in RuleC0 to actually point to Triad rules

## Why / Balance
We are not Monolith, and the links seemed to point there

## Media
It's very hard to take a screenshot of this due to its nature. This is after I clicked a link in Server Rules

<img width="571" height="200" alt="image" src="https://github.com/user-attachments/assets/e5d8d622-e711-47a0-8d7a-be861acd07ec" />

## Requirements
<!-- Confirm the following by placing an X in the brackets [X]: -->
- [X] I have read relevant guidelines/documentation to this PR found on [our devwiki](https://monolith-station.github.io/mono-docs/).
- [X] I have added media to this PR or it does not require an ingame showcase.
- [X] I can confirm this PR contains either no AI-generated content, or AI-generated content that meets our guidelines.
<!-- You should understand that not following the above may get your PR closed at maintainer’s discretion -->
<!-- When using AI, make sure you are already proficient in creating whatever content you are attempting to generate and that you already have experience contributing to SS14. This means using AI to enhance your preexisting workflow, not vibecoding. -->

## How to test
1. Open the guidebook on the overview page
2. Click a link
3. You are brought to one of the Triad rule guidebook pages
4. Maybe try the dedicated Rules viewer too. Click on a link. Seems to work

Changelog optional. I decided this was... maybe player-facing enough to mention

**Changelog**
:cl: Minerva
- fix: The guidebook now properly links to Triad rules.