### PR TITLE
Makes Canisters Persistent

### DIFF
--- a/Resources/Prototypes/Entities/Structures/Storage/Canisters/gas_canisters.yml
+++ b/Resources/Prototypes/Entities/Structures/Storage/Canisters/gas_canisters.yml
@@ -131,6 +131,7 @@
         collection: FootstepHull
     - type: Paintable # Upstream#37341
       group: Canisters # Upstream#37341
+    - type: HLPersistOnShipSave # Triad
 
 - type: entity
   parent: GasCanister


### PR DESCRIPTION
## About the PR
This PR makes canisters persistent

## Why / Balance
I'm not fully aware of the ramifications of this, but this is some good convenience for a bunch of roles. Salvagers/whatever can keep canisters by airlocks for a quick refill on air. Some ships are intended to be refilled via leaving a loose canister inside a chamber

Canisters could already be stored via anchoring them to a connector port. All this PR does is make them persistent without it. Gases on tiles are already persistent, so persistent gases is nothing new

## Media
<img width="433" height="334" alt="image" src="https://github.com/user-attachments/assets/3171f978-3f8e-4d94-8ad3-568f6b65d3b3" />

## Requirements
<!-- Confirm the following by placing an X in the brackets [X]: -->
- [X] I have read relevant guidelines/documentation to this PR found on [our devwiki](https://monolith-station.github.io/mono-docs/).
- [X] I have added media to this PR or it does not require an ingame showcase.
- [X] I can confirm this PR contains either no AI-generated content, or AI-generated content that meets our guidelines.
<!-- You should understand that not following the above may get your PR closed at maintainer’s discretion -->
<!-- When using AI, make sure you are already proficient in creating whatever content you are attempting to generate and that you already have experience contributing to SS14. This means using AI to enhance your preexisting workflow, not vibecoding. -->

## How to test
1. Put a canister on your shuttle. Anchoring it is not required
2. Save and load the shuttle
3. The canister is still there

**Changelog**
:cl: Minerva
- tweak: Canisters now save with ships without needing to anchor them.