### PR TITLE
Stash Change and Other Item Size Changes

### DIFF
--- a/Resources/Prototypes/Entities/Clothing/Back/backpacks.yml
+++ b/Resources/Prototypes/Entities/Clothing/Back/backpacks.yml
@@ -229,7 +229,7 @@
   # Triad, change item shape
   - type: Item
     shape:
-    - 0,0,7,5 
+    - 0,0,4,4
   # Triad end
   - type: ExplosionResistance # Goobstation
     damageCoefficient: 0.1

--- a/Resources/Prototypes/Entities/Clothing/Back/backpacks.yml
+++ b/Resources/Prototypes/Entities/Clothing/Back/backpacks.yml
@@ -226,6 +226,9 @@
   - type: Storage
     grid:
     - 0,0,10,3
+  - type: Item # Triad, change item shape
+    shape:
+    - 0,0,7,5 # Triad end
   - type: ExplosionResistance # Goobstation
     damageCoefficient: 0.1
 

--- a/Resources/Prototypes/Entities/Clothing/Back/backpacks.yml
+++ b/Resources/Prototypes/Entities/Clothing/Back/backpacks.yml
@@ -226,9 +226,11 @@
   - type: Storage
     grid:
     - 0,0,10,3
-  - type: Item # Triad, change item shape
+  # Triad, change item shape
+  - type: Item
     shape:
-    - 0,0,7,5 # Triad end
+    - 0,0,7,5 
+  # Triad end
   - type: ExplosionResistance # Goobstation
     damageCoefficient: 0.1
 

--- a/Resources/Prototypes/Entities/Objects/Specific/Medical/medkits.yml
+++ b/Resources/Prototypes/Entities/Objects/Specific/Medical/medkits.yml
@@ -17,6 +17,8 @@
         - Pill
         - Hypospray
         - HandLabeler
+        - GasTank
+        - BreathMask
         tags:
         - FitsInMedicalStash
         - PillCanister

--- a/Resources/Prototypes/Entities/Objects/Specific/Medical/medkits.yml
+++ b/Resources/Prototypes/Entities/Objects/Specific/Medical/medkits.yml
@@ -11,6 +11,27 @@
     maxItemSize: Small
     grid:
     - 0,0,3,1
+    # Triad Start, medkit whitelist
+    whitelist:
+        components:
+        - Pill
+        - Hypospray
+        - MedicalBag
+        - HandLabeler
+        tags:
+        - FitsInMedicalStash
+        - PillCanister
+        - CentrifugeCompatible
+        - Syringe
+        - Ointment
+        - Brutepack
+        - Bloodpack
+        - Gauze
+        - Bottle
+        - GlassBeaker
+        - ChemDispensable
+        - CigPack
+    # Triad End
   - type: Item
     size: Normal # Frontier: Large<Normal
     shape: # Frontier

--- a/Resources/Prototypes/Entities/Objects/Specific/Medical/medkits.yml
+++ b/Resources/Prototypes/Entities/Objects/Specific/Medical/medkits.yml
@@ -16,7 +16,6 @@
         components:
         - Pill
         - Hypospray
-        - MedicalBag
         - HandLabeler
         tags:
         - FitsInMedicalStash

--- a/Resources/Prototypes/Entities/Objects/Specific/Medical/medkits.yml
+++ b/Resources/Prototypes/Entities/Objects/Specific/Medical/medkits.yml
@@ -114,7 +114,7 @@
 - type: entity
   name: combat medical kit
   description: "For the big weapons among us."
-  parent: BaseStorageItem
+  parent: Medkit # Triad, parent change
   id: MedkitCombat
   components:
   - type: Sprite

--- a/Resources/Prototypes/_Triad/Entities/Structures/Storage/ShipPersistent/ship_stash.yml
+++ b/Resources/Prototypes/_Triad/Entities/Structures/Storage/ShipPersistent/ship_stash.yml
@@ -17,6 +17,7 @@
       - Store
       - Cash
       - Headset
+      - SavingContraband
 
 - type: entity
   parent: BasePersistentShipStorageStash

--- a/Resources/Prototypes/_Triad/Entities/Structures/Storage/ShipPersistent/ship_stash.yml
+++ b/Resources/Prototypes/_Triad/Entities/Structures/Storage/ShipPersistent/ship_stash.yml
@@ -79,7 +79,6 @@
         components:
           - Pill
           - Hypospray
-          - MedicalBag
           - HandLabeler
         tags:
           - FitsInMedicalStash


### PR DESCRIPTION
## About the PR
- Prevents nested storage abuse with medkits, they now have a whitelist
- Stashes can no longer physically fit items marked with SaveContraband
- Changed the size of the tactical backpack. The size of the backpack was only huge, meaning you could store roughly 4 bloodred hardsuits per backpack with 4 backpacks total in a stash. We do not need this kind of hoarding of armor and large items.

## Media
Before
<img width="429" height="271" alt="image" src="https://github.com/user-attachments/assets/a24ac2bb-af9a-4007-9494-18a13fe8863a" />


After
<img width="387" height="246" alt="image" src="https://github.com/user-attachments/assets/e7b76462-7c1b-4940-9efc-661bafc03938" />


## Requirements
<!-- Confirm the following by placing an X in the brackets [X]: -->
- [x] I have read relevant guidelines/documentation to this PR found on [our devwiki](https://monolith-station.github.io/mono-docs/).
- [x] I have added media to this PR or it does not require an ingame showcase.
- [x] I can confirm this PR contains either no AI-generated content, or AI-generated content that meets our guidelines.
<!-- You should understand that not following the above may get your PR closed at maintainer’s discretion -->
<!-- When using AI, make sure you are already proficient in creating whatever content you are attempting to generate and that you already have experience contributing to SS14. This means using AI to enhance your preexisting workflow, not vibecoding. -->

**Changelog**
:cl:
- tweak: Medkits can only fit medical items and things like beakers now
- fix: Fixed stashes being able to physically fit items marked as save contraband
- tweak: Changed the size of the advanced tactical backpack to be bigger. Now a 5x5, from a 4x4