### PR TITLE
Fix Resomi and Vox Having Error on Certain Modsuits

### DIFF
--- a/Resources/Prototypes/_Goobstation/Entities/Clothing/Head/modsuit.yml
+++ b/Resources/Prototypes/_Goobstation/Entities/Clothing/Head/modsuit.yml
@@ -153,8 +153,6 @@
     clothingVisuals:
       head:
       - state: equipped-HEAD
-      head-resomi:
-      - state: equipped-HEAD-resomi
       head-vox:
       - state: equipped-HEAD-vox
   - type: Sprite
@@ -389,8 +387,6 @@
     clothingVisuals:
       head:
       - state: equipped-HEAD
-      head-resomi:
-      - state: equipped-HEAD-resomi
       head-vox:
       - state: equipped-HEAD-vox
   - type: SealableClothingVisuals
@@ -398,8 +394,6 @@
     clothingVisuals:
       head:
       - state: equipped-HEAD-sealed
-      head-resomi:
-      - state: equipped-HEAD-sealed-resomi
       head-vox:
       - state: equipped-HEAD-sealed-vox
   - type: Armor
@@ -504,8 +498,6 @@
     clothingVisuals:
       head:
       - state: equipped-HEAD
-      head-resomi:
-      - state: equipped-HEAD-resomi
       head-vox:
       - state: equipped-HEAD-vox
   - type: Sprite
@@ -515,8 +507,6 @@
     clothingVisuals:
       head:
       - state: equipped-HEAD-sealed
-      head-resomi:
-      - state: equipped-HEAD-sealed-resomi
       head-vox:
       - state: equipped-HEAD-sealed-vox
   - type: Armor

--- a/Resources/Prototypes/_Goobstation/Entities/Clothing/OuterClothing/modsuit.yml
+++ b/Resources/Prototypes/_Goobstation/Entities/Clothing/OuterClothing/modsuit.yml
@@ -58,8 +58,6 @@
       - state: equipped-OUTERCLOTHING-sealed
       outerClothing-vox:
       - state: equipped-OUTERCLOTHING-sealed-vox
-      outerClothing-resomi:
-      - state: equipped-OUTERCLOTHING-sealed-resomi
   - type: ClothingSpeedModifier
     walkModifier: 1
     sprintModifier: 1
@@ -95,8 +93,6 @@
       - state: equipped-OUTERCLOTHING-sealed
       outerClothing-vox:
       - state: equipped-OUTERCLOTHING-sealed-vox
-      outerClothing-resomi:
-      - state: equipped-OUTERCLOTHING-sealed-resomi
   - type: ClothingSpeedModifier
     walkModifier: 0.87
     sprintModifier: 0.87
@@ -146,8 +142,6 @@
       - state: equipped-OUTERCLOTHING-sealed
       outerClothing-vox:
       - state: equipped-OUTERCLOTHING-sealed-vox
-      outerClothing-resomi:
-      - state: equipped-OUTERCLOTHING-sealed-resomi
   - type: ClothingSpeedModifier
     walkModifier: 0.90
     sprintModifier: 0.90
@@ -196,9 +190,6 @@
       - state: equipped-OUTERCLOTHING-sealed
       outerClothing-vox:
       - state: equipped-OUTERCLOTHING-sealed-vox
-
-      outerClothing-resomi:
-      - state: equipped-OUTERCLOTHING-sealed-resomi
   - type: ClothingSpeedModifier
     walkModifier: 1.05
     sprintModifier: 1.05
@@ -238,8 +229,6 @@
       - state: equipped-OUTERCLOTHING-sealed
       outerClothing-vox:
       - state: equipped-OUTERCLOTHING-sealed-vox
-      outerClothing-resomi:
-      - state: equipped-OUTERCLOTHING-sealed-resomi
   - type: ClothingSpeedModifier
     walkModifier: 0.95 # Mono
     sprintModifier: 0.95 # Mono
@@ -279,8 +268,6 @@
       - state: equipped-OUTERCLOTHING-sealed
       outerClothing-vox:
       - state: equipped-OUTERCLOTHING-sealed-vox
-      outerClothing-resomi:
-      - state: equipped-OUTERCLOTHING-sealed-resomi
   - type: ClothingSpeedModifier
     walkModifier: 0.95
     sprintModifier: 0.95
@@ -320,8 +307,6 @@
       - state: equipped-OUTERCLOTHING-sealed
       outerClothing-vox:
       - state: equipped-OUTERCLOTHING-sealed-vox
-      outerClothing-resomi:
-      - state: equipped-OUTERCLOTHING-sealed-resomi
   - type: ClothingSpeedModifier
     walkModifier: 0.85
     sprintModifier: 0.85
@@ -361,9 +346,6 @@
       - state: equipped-OUTERCLOTHING-sealed
       outerClothing-vox:
       - state: equipped-OUTERCLOTHING-sealed-vox
-
-      outerClothing-resomi:
-      - state: equipped-OUTERCLOTHING-sealed-resomi
   - type: ClothingSpeedModifier
     walkModifier: 0.90
     sprintModifier: 0.90

--- a/Resources/Prototypes/_Mono/Entities/Clothing/OuterClothing/modsuit.yml
+++ b/Resources/Prototypes/_Mono/Entities/Clothing/OuterClothing/modsuit.yml
@@ -104,8 +104,6 @@
       - state: equipped-OUTERCLOTHING-sealed
       outerClothing-vox:
       - state: equipped-OUTERCLOTHING-sealed-vox
-      outerClothing-resomi:
-      - state: equipped-OUTERCLOTHING-sealed-resomi
   - type: ExplosionResistance
     damageCoefficient: 0.2
   - type: Armor
@@ -145,8 +143,6 @@
       - state: equipped-OUTERCLOTHING-sealed
       outerClothing-vox:
       - state: equipped-OUTERCLOTHING-sealed-vox
-      outerClothing-resomi:
-      - state: equipped-OUTERCLOTHING-sealed-resomi
   - type: ExplosionResistance
     damageCoefficient: 0.7 # Mono
   - type: Armor


### PR DESCRIPTION
## About the PR

Removes the reference to the non existent sprites

## Media
<img width="482" height="295" alt="image" src="https://github.com/user-attachments/assets/68f192e1-43ea-4d13-ae05-bf9e3df062ca" />
<img width="482" height="295" alt="image" src="https://github.com/user-attachments/assets/68f192e1-43ea-4d13-ae05-bf9e3df062ca" />
<img width="482" height="295" alt="image" src="https://github.com/user-attachments/assets/68f192e1-43ea-4d13-ae05-bf9e3df062ca" />

**Changelog**
:cl:
- fix: Fixed resomi and vox having error on certain modsuits.
