### PR TITLE
Toggleable Gun System

### DIFF
--- a/Content.Shared/_Triad/Weapons/Ranged/Components/GunToggleableBonusComponent.cs
+++ b/Content.Shared/_Triad/Weapons/Ranged/Components/GunToggleableBonusComponent.cs
@@ -1,0 +1,55 @@
+using Robust.Shared.Audio;
+using Robust.Shared.GameStates;
+
+namespace Content.Shared._Triad.Weapons.Ranged.Components;
+
+/// <summary>
+/// Changes the accuracy of the gun when toggled.
+/// </summary>
+[RegisterComponent, NetworkedComponent, AutoGenerateComponentState]
+public sealed partial class GunToggleableBonusComponent : Component
+{
+    [DataField, AutoNetworkedField]
+    public Angle MinAngle = Angle.FromDegrees(5);
+
+    /// <summary>
+    /// Angle bonus applied upon being toggled. Positive numbers are worse.
+    /// </summary>
+    [DataField, AutoNetworkedField]
+    public Angle MaxAngle = Angle.FromDegrees(5);
+
+    /// <summary>
+    /// Recoil bonuses applied upon being toggled.
+    /// Higher angle decay bonus, quicker recovery.
+    /// </summary>
+    [DataField, AutoNetworkedField]
+    public Angle AngleDecay = Angle.FromDegrees(0);
+
+    /// <summary>
+    /// Recoil bonuses applied upon being toggled.
+    /// Lower angle increase bonus (negative numbers), slower buildup.
+    /// </summary>
+    [DataField, AutoNetworkedField]
+    public Angle AngleIncrease = Angle.FromDegrees(0);
+
+    [DataField, AutoNetworkedField]
+    public float BonusFireRate = 0f;
+
+    /// <summary>
+    /// Whether this gun can be shot if it is toggled.
+    /// </summary>
+    [DataField, AutoNetworkedField]
+    public bool RequiresToggle = true;
+
+    [DataField]
+    public LocId? ExamineMessage = "guntoggleablebonus-component-examine";
+
+    [DataField]
+    public LocId RequiresToggledMessage = "guntoggleablebonus-component-requires-unfolded";
+
+    [DataField, AutoNetworkedField]
+    public TimeSpan LastPopup;
+
+    [DataField, AutoNetworkedField]
+    public TimeSpan PopupCooldown = TimeSpan.FromSeconds(1);
+}

--- a/Content.Shared/_Triad/Weapons/Ranged/Components/GunToggleableBonusComponent.cs
+++ b/Content.Shared/_Triad/Weapons/Ranged/Components/GunToggleableBonusComponent.cs
@@ -1,4 +1,3 @@
-using Robust.Shared.Audio;
 using Robust.Shared.GameStates;
 
 namespace Content.Shared._Triad.Weapons.Ranged.Components;
@@ -9,6 +8,9 @@ namespace Content.Shared._Triad.Weapons.Ranged.Components;
 [RegisterComponent, NetworkedComponent, AutoGenerateComponentState]
 public sealed partial class GunToggleableBonusComponent : Component
 {
+    [DataField, AutoNetworkedField]
+    public TimeSpan DoAfterTime = TimeSpan.FromSeconds(0.5);
+
     [DataField, AutoNetworkedField]
     public Angle MinAngle = Angle.FromDegrees(5);
 

--- a/Content.Shared/_Triad/Weapons/Ranged/Components/GunToggleableBonusComponent.cs
+++ b/Content.Shared/_Triad/Weapons/Ranged/Components/GunToggleableBonusComponent.cs
@@ -38,7 +38,7 @@ public sealed partial class GunToggleableBonusComponent : Component
     public float BonusFireRate = 0f;
 
     /// <summary>
-    /// Whether this gun can be shot if it is toggled.
+    /// If true, the gun can only be shot if toggled.
     /// </summary>
     [DataField, AutoNetworkedField]
     public bool RequiresToggle = true;

--- a/Content.Shared/_Triad/Weapons/Ranged/Events/GunToggleableToggleDoAfterEvent.cs
+++ b/Content.Shared/_Triad/Weapons/Ranged/Events/GunToggleableToggleDoAfterEvent.cs
@@ -1,0 +1,7 @@
+﻿using Content.Shared.DoAfter;
+using Robust.Shared.Serialization;
+
+namespace Content.Shared._Triad.Weapons.Ranged.Events;
+
+[Serializable, NetSerializable]
+public sealed partial class GunToggleableToggleDoAfterEvent : SimpleDoAfterEvent;

--- a/Content.Shared/_Triad/Weapons/Ranged/Systems/GunToggleableBonusSystem.cs
+++ b/Content.Shared/_Triad/Weapons/Ranged/Systems/GunToggleableBonusSystem.cs
@@ -6,6 +6,9 @@ using Content.Shared.Weapons.Ranged.Systems;
 using Robust.Shared.Timing;
 using Content.Shared._Triad.Weapons.Ranged.Components;
 using Content.Shared.Item.ItemToggle.Components;
+using Content.Shared.Verbs;
+using Content.Shared.DoAfter;
+using Content.Shared._Triad.Weapons.Ranged.Events;
 
 namespace Content.Shared._Triad.Weapons.Ranged.Systems;
 
@@ -15,6 +18,7 @@ public sealed class GunToggleableBonusSystem : EntitySystem
     [Dependency] private readonly SharedGunSystem _gun = default!;
     [Dependency] private readonly SharedPopupSystem _popup = default!;
     [Dependency] private readonly ItemToggleSystem _itemToggle = default!;
+    [Dependency] private readonly SharedDoAfterSystem _doAfter = default!;
 
     public override void Initialize()
     {
@@ -24,6 +28,8 @@ public sealed class GunToggleableBonusSystem : EntitySystem
         SubscribeLocalEvent<GunToggleableBonusComponent, ShotAttemptedEvent>(OnShootAttempt);
         SubscribeLocalEvent<GunToggleableBonusComponent, ExaminedEvent>(OnExamine);
         SubscribeLocalEvent<GunToggleableBonusComponent, ItemToggledEvent>(OnToggled);
+        SubscribeLocalEvent<GunToggleableBonusComponent, GetVerbsEvent<AlternativeVerb>>(OnAlternateVerb);
+        SubscribeLocalEvent<GunToggleableBonusComponent, GunToggleableToggleDoAfterEvent>(OnToggleDoAfterEvent);
     }
 
     private void OnGunRefreshModifiers(Entity<GunToggleableBonusComponent> bonus, ref GunRefreshModifiersEvent args)
@@ -63,5 +69,47 @@ public sealed class GunToggleableBonusSystem : EntitySystem
     private void OnToggled(Entity<GunToggleableBonusComponent> ent, ref ItemToggledEvent args)
     {
         _gun.RefreshModifiers(ent.Owner);
+    }
+
+    // Temporary shitcode for doafter toggle since item toggle doesn't support doafters yet
+    private void OnAlternateVerb(Entity<GunToggleableBonusComponent> ent, ref GetVerbsEvent<AlternativeVerb> args)
+    {
+        if (!TryComp<ItemToggleComponent>(ent.Owner, out var toggle))
+            return;
+
+        if (!args.CanAccess || !args.CanInteract || !toggle.OnAltUse)
+            return;
+
+        var user = args.User;
+
+        args.Verbs.Add(new AlternativeVerb()
+        {
+            Text = !toggle.Activated ? Loc.GetString(toggle.VerbToggleOn) : Loc.GetString(toggle.VerbToggleOff),
+            Priority = toggle.AltPriority,
+            Act = () =>
+            {
+                var ev = new GunToggleableToggleDoAfterEvent();
+                var doAfterEventArgs = new DoAfterArgs(EntityManager, user, ent.Comp.DoAfterTime, ev, ent.Owner, target: ent.Owner, used: ent.Owner)
+                {
+                    BreakOnMove = false,
+                    BreakOnDamage = false,
+                    NeedHand = true,
+                };
+
+                _doAfter.TryStartDoAfter(doAfterEventArgs);
+            }
+        });
+    }
+
+    private void OnToggleDoAfterEvent(Entity<GunToggleableBonusComponent> ent, ref GunToggleableToggleDoAfterEvent args)
+    {
+        if (args.Handled || args.Cancelled)
+            return;
+
+        if (!TryComp<ItemToggleComponent>(ent.Owner, out var toggle))
+            return;
+
+        args.Handled = true;
+        _itemToggle.Toggle((ent.Owner, toggle), args.User, predicted: toggle.Predictable);
     }
 }

--- a/Content.Shared/_Triad/Weapons/Ranged/Systems/GunToggleableBonusSystem.cs
+++ b/Content.Shared/_Triad/Weapons/Ranged/Systems/GunToggleableBonusSystem.cs
@@ -77,7 +77,7 @@ public sealed class GunToggleableBonusSystem : EntitySystem
         if (!TryComp<ItemToggleComponent>(ent.Owner, out var toggle))
             return;
 
-        if (!args.CanAccess || !args.CanInteract || !toggle.OnAltUse)
+        if (!args.CanAccess || !args.CanInteract)
             return;
 
         var user = args.User;

--- a/Content.Shared/_Triad/Weapons/Ranged/Systems/GunToggleableBonusSystem.cs
+++ b/Content.Shared/_Triad/Weapons/Ranged/Systems/GunToggleableBonusSystem.cs
@@ -1,0 +1,67 @@
+using Content.Shared.Examine;
+using Content.Shared.Popups;
+using Content.Shared.Item.ItemToggle;
+using Content.Shared.Weapons.Ranged.Events;
+using Content.Shared.Weapons.Ranged.Systems;
+using Robust.Shared.Timing;
+using Content.Shared._Triad.Weapons.Ranged.Components;
+using Content.Shared.Item.ItemToggle.Components;
+
+namespace Content.Shared._Triad.Weapons.Ranged.Systems;
+
+public sealed class GunToggleableBonusSystem : EntitySystem
+{
+    [Dependency] private readonly IGameTiming _timing = default!;
+    [Dependency] private readonly SharedGunSystem _gun = default!;
+    [Dependency] private readonly SharedPopupSystem _popup = default!;
+    [Dependency] private readonly ItemToggleSystem _itemToggle = default!;
+
+    public override void Initialize()
+    {
+        base.Initialize();
+
+        SubscribeLocalEvent<GunToggleableBonusComponent, GunRefreshModifiersEvent>(OnGunRefreshModifiers);
+        SubscribeLocalEvent<GunToggleableBonusComponent, ShotAttemptedEvent>(OnShootAttempt);
+        SubscribeLocalEvent<GunToggleableBonusComponent, ExaminedEvent>(OnExamine);
+        SubscribeLocalEvent<GunToggleableBonusComponent, ItemToggledEvent>(OnToggled);
+    }
+
+    private void OnGunRefreshModifiers(Entity<GunToggleableBonusComponent> bonus, ref GunRefreshModifiersEvent args)
+    {
+        if (!_itemToggle.IsActivated(bonus.Owner))
+            return;
+
+        args.MinAngle += bonus.Comp.MinAngle;
+        args.MaxAngle += bonus.Comp.MaxAngle;
+        args.AngleDecay += bonus.Comp.AngleDecay;
+        args.AngleIncrease += bonus.Comp.AngleIncrease;
+        args.FireRate += bonus.Comp.BonusFireRate;
+    }
+
+    private void OnShootAttempt(Entity<GunToggleableBonusComponent> ent, ref ShotAttemptedEvent args)
+    {
+        if (ent.Comp.RequiresToggle && _itemToggle.IsActivated(ent.Owner))
+        {
+            args.Cancel();
+
+            var time = _timing.CurTime;
+            if (time > ent.Comp.LastPopup + ent.Comp.PopupCooldown)
+            {
+                ent.Comp.LastPopup = time;
+                var message = Loc.GetString(ent.Comp.RequiresToggledMessage, ("item", ent.Owner));
+                _popup.PopupClient(message, args.Used, args.User);
+            }
+        }
+    }
+
+    private void OnExamine(Entity<GunToggleableBonusComponent> ent, ref ExaminedEvent args)
+    {
+        if (ent.Comp.ExamineMessage != null)
+            args.PushText(Loc.GetString(ent.Comp.ExamineMessage));
+    }
+
+    private void OnToggled(Entity<GunToggleableBonusComponent> ent, ref ItemToggledEvent args)
+    {
+        _gun.RefreshModifiers(ent.Owner);
+    }
+}

--- a/Resources/Locale/en-US/_Triad/weapons/ranged/guntoggleablebonus-component.ftl
+++ b/Resources/Locale/en-US/_Triad/weapons/ranged/guntoggleablebonus-component.ftl
@@ -1,0 +1,2 @@
+guntoggleablebonus-component-examine = This weapon has improved accuracy when unfolded.
+guntoggleablebonus-component-requires-unfolded = { CAPITALIZE(THE($item))} must be unfolded!


### PR DESCRIPTION
## About the PR
Added a toggleable gun system, where with the ``ItemToggleComponent`` the gun will have changed stats depending on the toggle state

I've attached some media with a test gun, this gun is NOT ingame
It's all code, nothing new is added to the playable game

## Why / Balance
For future additions, it's a nice system that works nicely with the modular item toggle system
You can use this to make a gun with a stock

## Media
<img width="191" height="106" alt="image" src="https://github.com/user-attachments/assets/9a9d2169-e0ce-4560-a28e-8fec91df2eda" />

https://github.com/user-attachments/assets/6d618ee8-731d-466d-a6ad-92cfe9e79d48




## Requirements
<!-- Confirm the following by placing an X in the brackets [X]: -->
- [x] I have read relevant guidelines/documentation to this PR found on [our devwiki](https://monolith-station.github.io/mono-docs/).
- [x] I have added media to this PR or it does not require an ingame showcase.
- [x] I can confirm this PR contains either no AI-generated content, or AI-generated content that meets our guidelines.
<!-- You should understand that not following the above may get your PR closed at maintainer’s discretion -->
<!-- When using AI, make sure you are already proficient in creating whatever content you are attempting to generate and that you already have experience contributing to SS14. This means using AI to enhance your preexisting workflow, not vibecoding.-->
**Changelog**
Not player facing
