### PR TITLE
Alternate Backpack Solution

### DIFF
--- a/Content.Shared/Storage/EntitySystems/SharedStorageSystem.cs
+++ b/Content.Shared/Storage/EntitySystems/SharedStorageSystem.cs
@@ -1,6 +1,7 @@
 using System.Collections.Frozen;
 using System.Diagnostics.CodeAnalysis;
 using System.Linq;
+using Content.Shared._RMC14.Storage;
 using Content.Shared.ActionBlocker;
 using Content.Shared.Administration.Logs;
 using Content.Shared.CCVar;
@@ -68,6 +69,9 @@ public abstract class SharedStorageSystem : EntitySystem
     [Dependency] protected readonly SharedTransformSystem TransformSystem = default!;
     [Dependency] protected readonly SharedUserInterfaceSystem UI = default!;
     [Dependency] protected readonly UseDelaySystem UseDelay = default!;
+
+    // RMC14
+    [Dependency] protected readonly RMCStorageSystem RMCStorage = default!;
 
     private EntityQuery<ItemComponent> _itemQuery;
     private EntityQuery<StackComponent> _stackQuery;
@@ -1077,6 +1081,12 @@ public abstract class SharedStorageSystem : EntitySystem
                 reason = "comp-storage-insufficient-capacity";
                 return false;
             }
+        }
+
+        if (!RMCStorage.CanInsert((uid, storageComp), insertEnt, out var popup))
+        {
+            reason = popup;
+            return false;
         }
 
         CheckingCanInsert = true;

--- a/Content.Shared/_RMC14/Storage/LimitedStorageComponent.cs
+++ b/Content.Shared/_RMC14/Storage/LimitedStorageComponent.cs
@@ -1,0 +1,30 @@
+﻿using Content.Shared.Whitelist;
+using Robust.Shared.GameStates;
+using Robust.Shared.Serialization;
+
+namespace Content.Shared._RMC14.Storage;
+
+[RegisterComponent, NetworkedComponent, AutoGenerateComponentState]
+[Access(typeof(RMCStorageSystem))]
+public sealed partial class LimitedStorageComponent : Component
+{
+    [DataField, AutoNetworkedField]
+    public List<Limit> Limits = new();
+
+    [DataDefinition]
+    [Serializable, NetSerializable]
+    public partial struct Limit()
+    {
+        [DataField]
+        public int Count = 1;
+
+        [DataField]
+        public EntityWhitelist? Blacklist = new();
+
+        [DataField(required: true)]
+        public EntityWhitelist? Whitelist = new();
+
+        [DataField(required: true)]
+        public LocId Popup;
+    }
+}

--- a/Content.Shared/_RMC14/Storage/RMCStorageSystem.cs
+++ b/Content.Shared/_RMC14/Storage/RMCStorageSystem.cs
@@ -1,0 +1,127 @@
+using Content.Shared.Storage;
+using Content.Shared.Whitelist;
+
+namespace Content.Shared._RMC14.Storage;
+
+public sealed class RMCStorageSystem : EntitySystem
+{
+    [Dependency] private readonly EntityWhitelistSystem _entityWhitelist = default!;
+
+    private EntityQuery<StorageComponent> _storageQuery;
+
+    public override void Initialize()
+    {
+        _storageQuery = GetEntityQuery<StorageComponent>();
+    }
+
+    private bool CanInsertStorageLimit(Entity<StorageComponent?, LimitedStorageComponent?> limited, EntityUid toInsert, out LocId popup)
+    {
+        popup = default;
+        if (!Resolve(limited, ref limited.Comp2, false) ||
+            !_storageQuery.Resolve(limited, ref limited.Comp1, false))
+        {
+            return true;
+        }
+
+        foreach (var limit in limited.Comp2.Limits)
+        {
+            if (!_entityWhitelist.IsWhitelistPassOrNull(limit.Whitelist, toInsert))
+                continue;
+
+            if (_entityWhitelist.IsBlacklistPass(limit.Blacklist, toInsert))
+                continue;
+
+            var storedCount = 0;
+            foreach (var stored in limited.Comp1.StoredItems.Keys)
+            {
+                if (stored == toInsert)
+                    continue;
+
+                if (!_entityWhitelist.IsWhitelistPassOrNull(limit.Whitelist, stored))
+                    continue;
+
+                if (_entityWhitelist.IsBlacklistPass(limit.Blacklist, stored))
+                    continue;
+
+                storedCount++;
+                if (storedCount >= limit.Count)
+                    break;
+            }
+
+            if (storedCount < limit.Count)
+                continue;
+
+            popup = limit.Popup == default ? "triad-storage-limit-cant-fit" : limit.Popup;
+            return false;
+        }
+
+        return true;
+    }
+
+    public bool TryGetLastItem(Entity<StorageComponent?> storage, out EntityUid item)
+    {
+        item = default;
+        if (!Resolve(storage, ref storage.Comp, false))
+            return false;
+
+        ItemStorageLocation? lastLocation = null;
+        foreach (var (stored, location) in storage.Comp.StoredItems)
+        {
+            if (lastLocation is not { } last ||
+                last.Position.Y < location.Position.Y)
+            {
+                item = stored;
+                lastLocation = location;
+                continue;
+            }
+
+            if (last.Position.Y == location.Position.Y &&
+                last.Position.X > location.Position.X)
+            {
+                item = stored;
+                lastLocation = location;
+            }
+        }
+
+        return item != default;
+    }
+
+    public bool TryGetFirstItem(Entity<StorageComponent?> storage, out EntityUid item)
+    {
+        item = default;
+        if (!Resolve(storage, ref storage.Comp, false))
+            return false;
+
+        ItemStorageLocation? firstLocation = null;
+        foreach (var (stored, location) in storage.Comp.StoredItems)
+        {
+            if (firstLocation is not { } first ||
+                first.Position.Y > location.Position.Y)
+            {
+                item = stored;
+                firstLocation = location;
+                continue;
+            }
+
+            if (first.Position.Y == location.Position.Y &&
+                first.Position.X < location.Position.X)
+            {
+                item = stored;
+                firstLocation = location;
+            }
+        }
+
+        return item != default;
+    }
+
+    public bool CanInsert(Entity<StorageComponent?> storage, EntityUid toInsert, out LocId popup)
+    {
+        if (!CanInsertStorageLimit((storage, storage, null), toInsert, out popup))
+            return false;
+
+        //if (!CanInsertStoreSkill((storage, storage, null), toInsert, user, out popup))
+        //return false; TODO TRIAD
+
+        return true;
+    }
+}

--- a/Resources/Locale/en-US/_Triad/storage/storage.ftl
+++ b/Resources/Locale/en-US/_Triad/storage/storage.ftl
@@ -1,0 +1,3 @@
+triad-storage-limit-cant-fit = That doesn't fit in there!
+
+triad-storage-limit-too-many-advanced-backpacks = You can only fit one advanced backpack in here!

--- a/Resources/Prototypes/Entities/Clothing/Back/backpacks.yml
+++ b/Resources/Prototypes/Entities/Clothing/Back/backpacks.yml
@@ -226,13 +226,13 @@
   - type: Storage
     grid:
     - 0,0,10,3
-  # Triad, change item shape
-  - type: Item
-    shape:
-    - 0,0,4,4
-  # Triad end
   - type: ExplosionResistance # Goobstation
     damageCoefficient: 0.1
+  # Triad Start
+  - type: Tag
+    tags:
+    - AdvancedTacticalBackpack
+  # Triad End
 
 - type: entity
   parent: ClothingBackpackERTLeader

--- a/Resources/Prototypes/_Triad/Entities/Structures/Storage/ShipPersistent/ship_stash.yml
+++ b/Resources/Prototypes/_Triad/Entities/Structures/Storage/ShipPersistent/ship_stash.yml
@@ -59,6 +59,13 @@
       node: MilitaryStorageStashNode
     - type: ShipSaveLimit
       limitId: MilitaryStash
+    - type: LimitedStorage
+      limits:
+      - popup: triad-storage-limit-too-many-advanced-backpacks
+        count: 1
+        whitelist:
+          tags:
+          - AdvancedTacticalBackpack
 
 - type: entity
   parent: BasePersistentShipStorageStash

--- a/Resources/Prototypes/_Triad/tags.yml
+++ b/Resources/Prototypes/_Triad/tags.yml
@@ -4,7 +4,7 @@
 
 - type: Tag
   id: FitsInMedicalStash
-  
+
 # Melee Weapons
 - type: Tag
   id: Cutlass
@@ -14,3 +14,7 @@
 
 - type: Tag
   id: Sword
+
+# Clothing
+- type: Tag
+  id: AdvancedTacticalBackpack


### PR DESCRIPTION
## About the PR
Backpack is now smaller again, reverted back to 4x4
As a result you can only put 1 backpack per stash
Allows people to carry important items alongside a backpack without allowing the hoarding of tactical backpacks


## Technical details
Ports RMC limited storage system

## Media
<img width="571" height="465" alt="image" src="https://github.com/user-attachments/assets/94d9ad3e-f59b-4205-ae64-db2f1021712b" />

**Changelog**
:cl:
- tweak: Tactical backpacks are now 4x4 again.
- tweak: You can only fit 1 tactical backpack into a military stash,