### PR TITLE
Lights on Prebuilt Light Fixtures Aren't Deleted on Save

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -313,3 +313,5 @@ Resources/MapImages
 # Link Files
 *.lnk
 
+# lscache
+*.lscache

--- a/Content.Server/Light/Components/PoweredLightComponent.cs
+++ b/Content.Server/Light/Components/PoweredLightComponent.cs
@@ -6,13 +6,14 @@ using Robust.Shared.Audio;
 using Robust.Shared.Containers;
 using Robust.Shared.Prototypes;
 using Robust.Shared.Serialization.TypeSerializers.Implementations.Custom.Prototype;
+using Content.Server._NF.Shipyard.Systems; // Triad
 
 namespace Content.Server.Light.Components
 {
     /// <summary>
     ///     Component that represents a wall light. It has a light bulb that can be replaced when broken.
     /// </summary>
-    [RegisterComponent, Access(typeof(PoweredLightSystem))]
+    [RegisterComponent, Access(typeof(PoweredLightSystem), typeof(ShipyardGridSaveSystem))] // Triad add ShipyardGridSaveSystem
     public sealed partial class PoweredLightComponent : Component
     {
         [DataField("burnHandSound")]

--- a/Content.Server/_NF/Shipyard/Systems/ShipyardGridSaveSystem.cs
+++ b/Content.Server/_NF/Shipyard/Systems/ShipyardGridSaveSystem.cs
@@ -517,10 +517,11 @@ public sealed class ShipyardGridSaveSystem : EntitySystem
                 if (!TryComp<ContainerFillComponent>(owner, out var containerFill) || containerFill.Containers.Count == 0)
                     return true; // To ensure airlocks that aren't prefilled don't have their door electronics deleted
             }
-            if (HasComp<NodeContainerComponent>(owner))
-                return true; // Preserve node contents, like atmos pipes' air
-            if (TryComp<PoweredLightComponent>(owner, out var light) && light.HasLampOnSpawn == null)
-                return true; // Preserve lights inside tubes if they don't refill on spawn
+            if (TryComp<PoweredLightComponent>(owner, out var light))
+            {
+                light.HasLampOnSpawn = null;
+                return true; // Preserve lights inside tubes and null their on spawn lamp
+            }
             current = owner;
         }
         return false;


### PR DESCRIPTION
## About the PR
Title
Resolves #53 

Meaning lights aren't replaced on shipload from prebuilt fixtures, meaning custom lights will stay



## How to test
<!-- Describe the way it can be tested -->

## Breaking changes
<!-- List any breaking changes, including namespaces, public class/method/field changes, prototype renames; and provide instructions for fixing them. -->

**Changelog**
:cl:
- fix: Fixed lights inside of prebuilt fixtures being replaced on ship load, meaning your custom lights will save correctly.
