### PR TITLE
Remove Default Censorship Undergarments for Hydrakin

### DIFF
--- a/Resources/Prototypes/_Obelisk/Entities/Mobs/Player/hydrakin.yml
+++ b/Resources/Prototypes/_Obelisk/Entities/Mobs/Player/hydrakin.yml
@@ -3,3 +3,9 @@
   name: Urist McHydra
   parent: BaseMobHydrakin
   id: MobHydrakin
+  # Triad changes - Remove default undergarments.
+  components:
+  - type: HumanoidAppearance
+    undergarmentTop: null
+    undergarmentBottom: null
+  # End Triad


### PR DESCRIPTION
## About the PR
This PR removes the default censorship undergarments from Hydrakin. I'm not aware of any other ramifications for this

## Why / Balance
Hydrakin are not compatible with undergarments and thus should not have them until properly implemented. Plus they don't exactly need this

## Media
<img width="575" height="526" alt="image" src="https://github.com/user-attachments/assets/71cfa810-4c99-4637-bb61-9736a07d6ba6" />

## Requirements
<!-- Confirm the following by placing an X in the brackets [X]: -->
- [X] I have read relevant guidelines/documentation to this PR found on [our devwiki](https://monolith-station.github.io/mono-docs/).
- [X] I have added media to this PR or it does not require an ingame showcase.
- [X] I can confirm this PR contains either no AI-generated content, or AI-generated content that meets our guidelines.
<!-- You should understand that not following the above may get your PR closed at maintainer’s discretion -->
<!-- When using AI, make sure you are already proficient in creating whatever content you are attempting to generate and that you already have experience contributing to SS14. This means using AI to enhance your preexisting workflow, not vibecoding. -->

## How to test
0. Have "Censor character nudity" on in accessibility options
1. Spawn in a Hydrakin. It should not have underwear
2. Spawn in a Urist. He'll have underwear on
3. Double-check to make sure things still render right on Hydrakin if you'd like

Not really player-facing (currently, people on the server can't even HAVE this accessibility option on because it's not in), so I didn't add a changelog