### PR TITLE
Fixes Layering for Undergarments

### DIFF
--- a/Resources/Prototypes/_DV/Entities/Mobs/Species/chitinid.yml
+++ b/Resources/Prototypes/_DV/Entities/Mobs/Species/chitinid.yml
@@ -118,6 +118,8 @@
       - map: [ "enum.HumanoidVisualLayers.LArm" ]
       - map: [ "enum.HumanoidVisualLayers.RLeg" ]
       - map: [ "enum.HumanoidVisualLayers.LLeg" ]
+      - map: [ "enum.HumanoidVisualLayers.UndergarmentBottom" ] # Triad - Underwear.
+      - map: [ "enum.HumanoidVisualLayers.UndergarmentTop" ] # Triad - Underwear.
       - map: [ "jumpsuit" ]
       - map: [ "balaclava" ]
       - map: [ "enum.HumanoidVisualLayers.LHand" ]

--- a/Resources/Prototypes/_DV/Entities/Mobs/Species/feroxi.yml
+++ b/Resources/Prototypes/_DV/Entities/Mobs/Species/feroxi.yml
@@ -46,8 +46,8 @@
         # its fine, but its still very stupid that it has to be done like this instead of allowing sprites to just directly insert a stencil clear.
         # sprite refactor when
         state: l_leg
-      #- map: [ "enum.HumanoidVisualLayers.Underwear" ] TODO, TRIAD
-      #- map: [ "enum.HumanoidVisualLayers.Undershirt" ] TODO, TRIAD
+      - map: [ "enum.HumanoidVisualLayers.UndergarmentBottom" ] # Triad - Underwear.
+      - map: [ "enum.HumanoidVisualLayers.UndergarmentTop" ] # Triad - Underwear.
       - map: [ "jumpsuit" ]
       - map: [ "enum.HumanoidVisualLayers.LHand" ]
       - map: [ "enum.HumanoidVisualLayers.RHand" ]

--- a/Resources/Prototypes/_DV/Entities/Mobs/Species/harpy.yml
+++ b/Resources/Prototypes/_DV/Entities/Mobs/Species/harpy.yml
@@ -43,8 +43,10 @@
     - map: [ "enum.HumanoidVisualLayers.LArm" ]
     - map: [ "enum.HumanoidVisualLayers.RLeg" ]
     - map: [ "enum.HumanoidVisualLayers.LLeg" ]
-    - map: [ "underpants" ]
-    - map: [ "undershirt" ]
+    #- map: [ "underpants" ] # Triad removal - Underwear.
+    #- map: [ "undershirt" ] # Triad removal - Underwear.
+    - map: [ "enum.HumanoidVisualLayers.UndergarmentBottom" ] # Triad - Underwear.
+    - map: [ "enum.HumanoidVisualLayers.UndergarmentTop" ] # Triad - Underwear.
     - map: [ "socks" ]
     - map: [ "jumpsuit" ]
     - map: [ "balaclava" ]
@@ -185,8 +187,10 @@
     - map: [ "enum.HumanoidVisualLayers.LArm" ]
     - map: [ "enum.HumanoidVisualLayers.RLeg" ]
     - map: [ "enum.HumanoidVisualLayers.LLeg" ]
-    - map: [ "underpants" ]
-    - map: [ "undershirt" ]
+    #- map: [ "underpants" ] # Triad removal - Underwear.
+    #- map: [ "undershirt" ] # Triad removal - Underwear.
+    - map: [ "enum.HumanoidVisualLayers.UndergarmentBottom" ] # Triad - Underwear.
+    - map: [ "enum.HumanoidVisualLayers.UndergarmentTop" ] # Triad - Underwear.
     - map: [ "socks" ]
     - map: [ "jumpsuit" ]
     - map: [ "balaclava" ]

--- a/Resources/Prototypes/_DV/Entities/Mobs/Species/rodentia.yml
+++ b/Resources/Prototypes/_DV/Entities/Mobs/Species/rodentia.yml
@@ -47,6 +47,8 @@
       - map: [ "enum.HumanoidVisualLayers.LArm" ]
       - map: [ "enum.HumanoidVisualLayers.RLeg" ]
       - map: [ "enum.HumanoidVisualLayers.LLeg" ]
+      - map: [ "enum.HumanoidVisualLayers.UndergarmentBottom" ] # Triad - Underwear.
+      - map: [ "enum.HumanoidVisualLayers.UndergarmentTop" ] # Triad - Underwear.
       - map: [ "jumpsuit" ]
       - map: [ "balaclava" ]
       - map: [ "enum.HumanoidVisualLayers.LHand" ]

--- a/Resources/Prototypes/_DV/Entities/Mobs/Species/vulpkanin.yml
+++ b/Resources/Prototypes/_DV/Entities/Mobs/Species/vulpkanin.yml
@@ -42,6 +42,8 @@
       - map: [ "enum.HumanoidVisualLayers.LArm" ]
       - map: [ "enum.HumanoidVisualLayers.RLeg" ]
       - map: [ "enum.HumanoidVisualLayers.LLeg" ]
+      - map: [ "enum.HumanoidVisualLayers.UndergarmentBottom" ] # Triad - Underwear.
+      - map: [ "enum.HumanoidVisualLayers.UndergarmentTop" ] # Triad - Underwear.
       - shader: StencilClear
         sprite: Mobs/Species/Human/parts.rsi #PJB on stencil clear being on the left leg: "...this is 'fine'" -https://github.com/space-wizards/space-station-14/pull/12217#issuecomment-1291677115
         # its fine, but its still very stupid that it has to be done like this instead of allowing sprites to just directly insert a stencil clear.

--- a/Resources/Prototypes/_EinsteinEngines/Entities/Mobs/Player/silicon_base.yml
+++ b/Resources/Prototypes/_EinsteinEngines/Entities/Mobs/Player/silicon_base.yml
@@ -120,8 +120,10 @@
     - map: ["enum.HumanoidVisualLayers.LFoot"]
     - map: ["enum.HumanoidVisualLayers.RFoot"]
     - map: ["socks"]
-    - map: ["underpants"]
-    - map: ["undershirt"]
+    #- map: [ "underpants" ] # Triad removal - Underwear.
+    #- map: [ "undershirt" ] # Triad removal - Underwear.
+    - map: [ "enum.HumanoidVisualLayers.UndergarmentBottom" ] # Triad - Underwear.
+    - map: [ "enum.HumanoidVisualLayers.UndergarmentTop" ] # Triad - Underwear.
     - map: ["jumpsuit"]
     - map: ["enum.HumanoidVisualLayers.LHand"]
     - map: ["enum.HumanoidVisualLayers.RHand"]


### PR DESCRIPTION
## About the PR
This PR fixes layering for undergarments for a few species (listed in the changelog). Previously, the undergarments would layer over everything **including** cuffs or, in the case of Harpy, apparently only do that in loadout

## Why / Balance
It's called underwear, not outerwear

## Media
<img width="629" height="347" alt="image" src="https://github.com/user-attachments/assets/42133e11-f32c-4b70-a25f-efc26bd555ed" />


## Requirements
<!-- Confirm the following by placing an X in the brackets [X]: -->
- [X] I have read relevant guidelines/documentation to this PR found on [our devwiki](https://monolith-station.github.io/mono-docs/).
- [X] I have added media to this PR or it does not require an ingame showcase.
- [X] I can confirm this PR contains either no AI-generated content, or AI-generated content that meets our guidelines.

## How to test
1. Add underwear to the species listed in the changelog
2. The underwears will not layer over clothes in the loadout
3. Spawn in. The underwears will not layer over clothes ingame

**Changelog**
:cl: Minerva
- fix: Undergarment layering has been fixed for the following species: IPC, Harpy, Rodentia, Feroxi, Vulpkanin, Chitinid.
