### PR TITLE
Water Vapor in Tank Dispensers for Feroxi

### DIFF
--- a/Resources/Prototypes/Catalog/VendingMachines/Inventories/tankdispenser.yml
+++ b/Resources/Prototypes/Catalog/VendingMachines/Inventories/tankdispenser.yml
@@ -11,6 +11,10 @@
 #    ExtendedEmergencyNitrogenTankFilled: 5 # Frontier
     NitrogenTankFilled: 10
     DoubleEmergencyNitrogenTankFilled: 10
+    # Triad changes - Feroxi use water vapor.
+    WaterVaporTankFilled: 10
+    DoubleEmergencyWaterVaporTankFilled: 10
+    # End Triad
 
 - type: vendingMachineInventory
   id: TankDispenserEngineeringInventory
@@ -18,7 +22,9 @@
     PlasmaTankFilled: 10
     NitrogenTankFilled: 10
     OxygenTankFilled: 10
+    WaterVaporTankFilled: 10 # Triad - Feroxi use water vapor.
   emaggedInventory:
     DoubleEmergencyAirTankFilled: 1
     DoubleEmergencyOxygenTankFilled: 1
     DoubleEmergencyNitrogenTankFilled: 1
+    DoubleEmergencyWaterVaporTankFilled: 1 # Triad - Feroxi use water vapor.


### PR DESCRIPTION
## About the PR
This PR adds water vapor tanks to tank dispensers

I've matched how this is done in the rest of the file for parity

## Why / Balance
Requested in an ideas thread. Feroxi use the stuff to help with Not Dying, so it may as well be included like the nitrogen for slimepeople/vox

## Media
<img width="545" height="375" alt="image" src="https://github.com/user-attachments/assets/6517e8dc-6d48-446c-b89b-4db5da7f93eb" />

## Requirements
<!-- Confirm the following by placing an X in the brackets [X]: -->
- [X] I have read relevant guidelines/documentation to this PR found on [our devwiki](https://monolith-station.github.io/mono-docs/).
- [X] I have added media to this PR or it does not require an ingame showcase.
- [X] I can confirm this PR contains either no AI-generated content, or AI-generated content that meets our guidelines.
<!-- You should understand that not following the above may get your PR closed at maintainer’s discretion -->
<!-- When using AI, make sure you are already proficient in creating whatever content you are attempting to generate and that you already have experience contributing to SS14. This means using AI to enhance your preexisting workflow, not vibecoding. -->

## How to test
1. Get a gas tank dispenser. There's two variants, I believe. If nothing else, there's one on the Caracara
2. Look inside
3. Water vapor tanks with equivalent stock and types to the rest

**Changelog**
:cl: Minerva
- tweak: Gas tank dispensers now stock water vapor tanks.
