### PR TITLE
Uncomments Water Vapor Canisters From the Catalog for Feroxi

### DIFF
--- a/Resources/Prototypes/Catalog/Cargo/cargo_atmospherics.yml
+++ b/Resources/Prototypes/Catalog/Cargo/cargo_atmospherics.yml
@@ -78,17 +78,17 @@
   category: cargoproduct-category-name-atmospherics
   group: market
 
-#- type: cargoProduct
-#  name: "water vapor canister"
-#  id: AtmosphericsWaterVapor
-#  description: "Water vapor canister"
-#  icon:
-#    sprite: Structures/Storage/canister.rsi
-#    state: water_vapor
-#  product: WaterVaporCanister
-#  cost: 2600
-#  category: cargoproduct-category-name-atmospherics
-#  group: market
+# Triad changes - Feroxi use water vapor. Block uncommented.
+- type: cargoProduct
+  id: AtmosphericsWaterVapor
+  icon:
+    sprite: _NF/Structures/Storage/canister.rsi
+    state: water_vapor
+  product: WaterVaporCanister
+  cost: 3000 # 2600<3000
+  category: cargoproduct-category-name-atmospherics
+  group: market
+# End Triad
 
 - type: cargoProduct
   id: AtmosphericsPlasma # Mono - Make plasma canisters buyable again


### PR DESCRIPTION
## About the PR
This PR uncomments water vapor canisters from the catalog, allowing them to be bought
Additionally, I've
- Changed their price to 3000 to prevent Infinite Money
- Changed the icon to use _NF canisters like the rest of the file
- *Generally* just cleaned this up for parity with the rest of the file

Should I have just moved this into Triad namespace...

## Why / Balance
Requested in ideas. Feroxi use water vapor and I think they'd want the option of buying refills

## Media
**Price on image outdated. I didn't bother restarting my devenv for a price change**
<img width="926" height="189" alt="image" src="https://github.com/user-attachments/assets/035024c8-c607-494b-894c-0e5d63b4e2ca" />

## Requirements
<!-- Confirm the following by placing an X in the brackets [X]: -->
- [x] I have read relevant guidelines/documentation to this PR found on [our devwiki](https://monolith-station.github.io/mono-docs/).
- [x] I have added media to this PR or it does not require an ingame showcase.
- [x] I can confirm this PR contains either no AI-generated content, or AI-generated content that meets our guidelines.

## How to test
1. Go to the mall
2. Search the console for "water vapor"

**Changelog**
:cl: Minerva
- tweak: Water vapor canisters are now on sale at the Trade Mall for 3000 credits.
