### PR TITLE
Cherrypick: Add a Countdown to the PDA Showing Time Remaining Until Roundend (#4147)

### DIFF
--- a/Content.Client/PDA/PdaMenu.xaml
+++ b/Content.Client/PDA/PdaMenu.xaml
@@ -44,6 +44,11 @@
             <ContainerButton Name="StationTimeButton">
                 <RichTextLabel Name="StationTimeLabel" Access="Public"/>
             </ContainerButton>
+            <!-- Frontier -->
+            <ContainerButton Name="RemainingTimeButton">
+                <RichTextLabel Name="RemainingTimeLabel" Access="Public"/>
+            </ContainerButton>
+            <!-- End Frontier -->
             <ContainerButton Name="StationAlertLevelInstructionsButton">
                 <RichTextLabel Name="StationAlertLevelInstructions" Access="Public"/>
             </ContainerButton>

--- a/Content.Client/PDA/PdaMenu.xaml.cs
+++ b/Content.Client/PDA/PdaMenu.xaml.cs
@@ -36,7 +36,7 @@ namespace Content.Client.PDA
 
         private string _balance = Loc.GetString("comp-pda-ui-unknown"); // Frontier
         private string _shuttleDeed = Loc.GetString("comp-pda-ui-unknown"); // Frontier
-
+        private TimeSpan? _roundEndTime = null; // Frontier
         private int _currentView;
 
         public event Action<EntityUid>? OnProgramItemPressed;
@@ -204,6 +204,25 @@ namespace Content.Client.PDA
 
             StationTimeLabel.SetMarkup(Loc.GetString("comp-pda-ui-station-time",
                 ("time", stationTime.ToString("hh\\:mm\\:ss"))));
+
+            // Frontier
+            if (state.RoundEndTime is not null)
+            {
+                // Synchronise ticking of the seconds place of the shift time and the roundend time
+                _roundEndTime = TimeSpan.FromSeconds(Math.Floor(state.RoundEndTime.Value.TotalSeconds))
+                                        .Add(TimeSpan.FromMilliseconds(_gameTicker.RoundStartTimeSpan.Milliseconds));
+
+                var remainingTime = _roundEndTime.Value.Subtract(_gameTiming.CurTime);
+                RemainingTimeLabel.SetMarkup(Loc.GetString("comp-pda-ui-remaining-time",
+                    ("time", remainingTime.ToString("hh\\:mm\\:ss"))));
+            }
+            else
+            {
+                _roundEndTime = null;
+            }
+
+            RemainingTimeLabel.Visible = _roundEndTime is not null;
+            // End Frontier
 
             var alertLevel = state.PdaOwnerInfo.StationAlertLevel;
             var alertColor = state.PdaOwnerInfo.StationAlertColor;
@@ -378,6 +397,19 @@ namespace Content.Client.PDA
 
             StationTimeLabel.SetMarkup(Loc.GetString("comp-pda-ui-station-time",
                 ("time", stationTime.ToString("hh\\:mm\\:ss"))));
+
+            // Frontier
+            if (_roundEndTime is not null)
+            {
+                var remainingTime = _roundEndTime.Value.Subtract(_gameTiming.CurTime);
+                RemainingTimeLabel.SetMarkup(Loc.GetString("comp-pda-ui-remaining-time",
+                    ("time", remainingTime.ToString("hh\\:mm\\:ss"))));
+                if (remainingTime < TimeSpan.Zero){
+                    RemainingTimeLabel.Visible = false;
+                    _roundEndTime = null;
+                }
+            }
+            // End Frontier
         }
     }
 }

--- a/Content.Server/PDA/PdaSystem.cs
+++ b/Content.Server/PDA/PdaSystem.cs
@@ -25,6 +25,7 @@ using Content.Server._NF.SectorServices; // Frontier
 using Content.Shared._Mono.Company;
 using Robust.Shared.Prototypes;
 using Content.Shared.DeviceNetwork.Components;
+using Content.Server.RoundEnd; // Frontier
 
 namespace Content.Server.PDA
 {
@@ -42,6 +43,7 @@ namespace Content.Server.PDA
         [Dependency] private readonly IdCardSystem _idCard = default!;
         [Dependency] private readonly SectorServiceSystem _sectorService = default!;
         [Dependency] private readonly IPrototypeManager _prototypeManager = default!;
+        [Dependency] private readonly RoundEndSystem _roundEndSystem = default!; // Frontier
 
         public override void Initialize()
         {
@@ -240,6 +242,7 @@ namespace Content.Server.PDA
                 },
                 balance, // Frontier
                 ownedShipName, // Frontier
+                _roundEndSystem.GetAutoCallTime(), // Frontier
                 pda.StationName,
                 showUplink,
                 hasInstrument,

--- a/Content.Server/RoundEnd/RoundEndSystem.cs
+++ b/Content.Server/RoundEnd/RoundEndSystem.cs
@@ -352,6 +352,30 @@ namespace Content.Server.RoundEnd
             }, _cooldownTokenSource.Token);
         }
 
+        // Frontier: show time remaining in round on PDA
+        public TimeSpan? GetAutoCallTime()
+        {
+            // Handle special cases first
+            if (ExpectedCountdownEnd is not null)
+                return ExpectedCountdownEnd;
+
+            if (_shuttle.EmergencyShuttleArrived || _gameTicker.RunLevel != GameRunLevel.InRound)
+                return null;
+
+            var mins = _autoCalledBefore ? _cfg.GetCVar(CCVars.EmergencyShuttleAutoCallExtensionTime)
+                                        : _cfg.GetCVar(CCVars.EmergencyShuttleAutoCallTime);
+            if (mins == 0)
+            {
+                return null;
+            }
+            else // Normal case where the shuttle hasn't been called yet
+            {
+                return AutoCallStartTime + TimeSpan.FromMinutes(mins) + DefaultCountdownDuration;
+            }
+
+        }
+        // End Frontier
+
         public override void Update(float frameTime)
         {
             // Check if we should auto-call.

--- a/Content.Shared/PDA/PdaUpdateState.cs
+++ b/Content.Shared/PDA/PdaUpdateState.cs
@@ -19,6 +19,7 @@ namespace Content.Shared.PDA
         public string? Address;
         public int Balance; // Frontier
         public string? OwnedShipName; // Frontier
+        public TimeSpan? RoundEndTime; // Frontier
 
         public PdaUpdateState(
             List<NetEntity> programs,
@@ -30,6 +31,7 @@ namespace Content.Shared.PDA
             PdaIdInfoText pdaOwnerInfo,
             int balance, // Frontier
             string? ownedShipName, // Frontier
+            TimeSpan? roundEndTime, // Frontier
             string? stationName,
             bool hasUplink = false,
             bool canPlayMusic = false,
@@ -47,6 +49,7 @@ namespace Content.Shared.PDA
             Address = address;
             Balance = balance; // Frontier
             OwnedShipName = ownedShipName; // Frontier
+            RoundEndTime = roundEndTime; // Frontier
         }
     }
 

--- a/Resources/Locale/en-US/pda/pda-component.ftl
+++ b/Resources/Locale/en-US/pda/pda-component.ftl
@@ -40,6 +40,9 @@ comp-pda-ui-station-alert-level-instructions = Advise: [color=white]{ $instructi
 
 comp-pda-ui-station-time = Shift duration: [color=white]{ $time }[/color]
 
+# Frontier
+comp-pda-ui-remaining-time = Time until shift end: [color=white]{ $time }[/color]
+
 comp-pda-ui-eject-id-button = Eject ID
 
 comp-pda-ui-eject-pen-button = Eject Pen


### PR DESCRIPTION
## About the PR

This PR cherrypicks https://github.com/new-frontiers-14/frontier-station-14/pull/4147, which adds a timer to the PDA that says how long until the round ends

From the original PR:
> Adds a field to the PDA underneath the current shift time showing how long until the round will end.
Mostly accurate (it doesn't take into account the extended shuttle call time if the current alert level is delta or epsilon. But in those cases, it's unlikely that it would be those alert levels for an extended period of time, and the error is only 10 extra minutes of shift time)

I don't know how to test this in an environment more like the server, but given Frontier has this on live it's *probably* fine. It's cvar-based anyway, so I expect it to work fine
The clock reads 10 minutes left at the same time (like off by a couple seconds but whatever) the 10 minute warning announcement is given

## Why / Balance
It's REALLY useful knowing when exactly the round will end, and it's especially useful for people who aren't sure

## Media
<img width="1006" height="528" alt="image" src="https://github.com/user-attachments/assets/caffc621-4113-4f8b-9a03-bd8e17bc4e2a" />

<img width="1017" height="161" alt="image" src="https://github.com/user-attachments/assets/5f65772f-31e6-4fb8-9138-1cd049577568" />


## Requirements
<!-- Confirm the following by placing an X in the brackets [X]: -->
- [X] I have read relevant guidelines/documentation to this PR found on [our devwiki](https://monolith-station.github.io/mono-docs/).
- [X] I have added media to this PR or it does not require an ingame showcase.
- [X] I can confirm this PR contains either no AI-generated content, or AI-generated content that meets our guidelines.
<!-- You should understand that not following the above may get your PR closed at maintainer’s discretion -->
<!-- When using AI, make sure you are already proficient in creating whatever content you are attempting to generate and that you already have experience contributing to SS14. This means using AI to enhance your preexisting workflow, not vibecoding. -->

## How to test
From the original PR:

> Use the command > cvar shuttle.auto_call_time to set the time until round end (if you had your PDA open before this, reopen the menu)
Check that the PDA matches that + 10 minutes
Call the shuttle and check that the PDA matches the shuttle countdown
Let the countdown hit 0 and see that it disappears when the round end summary window appears.

**Changelog**
:cl: Frontier
- add: Added a countdown to when the shift will end to the PDA. Hey! Stop watching the clock and get back to work!
