### PR TITLE
UI Bugfixes

### DIFF
--- a/Content.Client/VendingMachines/VendingMachineBoundUserInterface.cs
+++ b/Content.Client/VendingMachines/VendingMachineBoundUserInterface.cs
@@ -63,6 +63,11 @@ namespace Content.Client.VendingMachines
         public void Refresh()
         {
             var system = EntMan.System<VendingMachineSystem>();
+
+            // Triad - Attempt to fix another client-side grid-reload bug.
+            if (!EntMan.HasComponent<VendingMachineComponent>(Owner))
+                return;
+
             _cachedInventory = system.GetAllInventory(Owner);
 
             // Frontier: state, market modifier, balance status

--- a/Content.Client/_Triad/Chemistry/UI/ModernChemMasterBui.cs
+++ b/Content.Client/_Triad/Chemistry/UI/ModernChemMasterBui.cs
@@ -43,6 +43,8 @@ public sealed class ModernChemMasterBui(EntityUid owner, Enum uiKey) : BoundUser
                 (uint) _window.BottleDosage.Value, _window.LabelLine));
         _window.BufferSortButton.OnPressed += _ => SendMessage(
             new ChemMasterSortingTypeCycleMessage());
+        _window.BufferSortButtonClassic.OnPressed += _ => SendMessage(
+            new ChemMasterSortingTypeCycleMessage());
         _window.OutputBufferDraw.OnPressed += _ => SendMessage(
             new ChemMasterOutputDrawSourceMessage(ChemMasterDrawSource.Internal));
         _window.OutputBeakerDraw.OnPressed += _ => SendMessage(

--- a/Content.Client/_Triad/Chemistry/UI/ModernChemMasterWindow.xaml.cs
+++ b/Content.Client/_Triad/Chemistry/UI/ModernChemMasterWindow.xaml.cs
@@ -387,6 +387,9 @@ public sealed partial class ModernChemMasterWindow : FancyWindow
             BufferInfoClassic.Children.Add(BuildReagentRow(reagent.color, rowCount, reagent.name, reagent.reagentId, reagent.quantity, true, true, modernMode: false));
             rowCount++;
         }
+
+        if (!string.IsNullOrEmpty(SearchBar.Text))
+            UpdateReagentPrototypes(SearchBar.Text);
     }
 
     private void BuildContainerUI(Control control, ContainerInfo? info, bool addReagentButtons, bool modernMode)


### PR DESCRIPTION
## About the PR
<!-- What did you change? -->
<!-- If this is a code change, summarize at high level how your new code works. This makes it easier to review. -->
Just a few bugfixes with the Vending Machine and ChemMaster UIs.

## Why / Balance
<!-- Discuss how this would affect game balance or explain why it was changed. Link any relevant discussions or issues. -->
Buge.

## Media
<!-- Attach media if the PR makes ingame changes (clothing, items, features, etc). 
Small fixes/refactors are exempt. Media may be used in SS14 progress reports with credit. -->

## Requirements
<!-- Confirm the following by placing an X in the brackets [X]: -->
- [X] I have read relevant guidelines/documentation to this PR found on [our devwiki](https://monolith-station.github.io/mono-docs/).
- [X] I have added media to this PR or it does not require an ingame showcase.
- [X] I can confirm this PR contains either no AI-generated content, or AI-generated content that meets our guidelines.
<!-- You should understand that not following the above may get your PR closed at maintainer’s discretion -->
<!-- When using AI, make sure you are already proficient in creating whatever content you are attempting to generate and that you already have experience contributing to SS14. This means using AI to enhance your preexisting workflow, not vibecoding. -->

## How to test
<!-- Describe the way it can be tested -->
Unsure about the Vending Machine fix, as it was spontaneous as well, but try clicking a Chem in the ChemMaster with a search bar search, and try using the Classic Mode sort buttons.

## Breaking changes
<!-- List any breaking changes, including namespaces, public class/method/field changes, prototype renames; and provide instructions for fixing them. -->
Not a bug with my changes, but the ChemMaster does NOT update while open and a jug is dragged onto it to be emptied. Couldn't fix it myself, so someone else will have to investigate. I tried for an hour straight.

**Changelog**
<!-- Add a Changelog entry to make players aware of new features or changes that could affect gameplay.
Make sure to read the guidelines and take this Changelog template out of the comment block in order for it to show up.
Changelog must have a :cl: symbol, so the bot recognizes the changes and adds them to the game's changelog.
Remove this symbol for non-player facing PRs.-->
:cl:
- fix: (Potentially) fixed a Vending Machine client-side grid reload bug, similar to what the Chem Master had.
- fix: Fixed the ChemMaster Classic-mode sorting.
- fix: Fixed the ChemMaster search bar resetting on a UI update.
