### PR TITLE
Tourniquets in Medical Stashes

### DIFF
--- a/Resources/Prototypes/Entities/Objects/Specific/Medical/healing.yml
+++ b/Resources/Prototypes/Entities/Objects/Specific/Medical/healing.yml
@@ -272,7 +272,7 @@
     - type: Tag
       tags:
         - SecBeltEquip
-        - FitsInMedicalStash #triad
+        - FitsInMedicalStash # Triad
     - type: Sprite
       state: tourniquet
     - type: Item

--- a/Resources/Prototypes/Entities/Objects/Specific/Medical/healing.yml
+++ b/Resources/Prototypes/Entities/Objects/Specific/Medical/healing.yml
@@ -272,7 +272,6 @@
     - type: Tag
       tags:
         - SecBeltEquip
-        - FitsInMedicalStash #triad
     - type: Sprite
       state: tourniquet
     - type: Item

--- a/Resources/Prototypes/Entities/Objects/Specific/Medical/healing.yml
+++ b/Resources/Prototypes/Entities/Objects/Specific/Medical/healing.yml
@@ -272,6 +272,7 @@
     - type: Tag
       tags:
         - SecBeltEquip
+        - FitsInMedicalStash #triad
     - type: Sprite
       state: tourniquet
     - type: Item

--- a/Resources/Prototypes/Entities/Objects/Specific/Medical/healing.yml
+++ b/Resources/Prototypes/Entities/Objects/Specific/Medical/healing.yml
@@ -272,6 +272,7 @@
     - type: Tag
       tags:
         - SecBeltEquip
+        - FitsInMedicalStash
     - type: Sprite
       state: tourniquet
     - type: Item

--- a/Resources/Prototypes/Entities/Objects/Specific/Medical/healing.yml
+++ b/Resources/Prototypes/Entities/Objects/Specific/Medical/healing.yml
@@ -272,7 +272,7 @@
     - type: Tag
       tags:
         - SecBeltEquip
-        - FitsInMedicalStash
+        - FitsInMedicalStash #triad
     - type: Sprite
       state: tourniquet
     - type: Item

--- a/Resources/Prototypes/_Triad/Entities/Structures/Storage/ShipPersistent/ship_stash.yml
+++ b/Resources/Prototypes/_Triad/Entities/Structures/Storage/ShipPersistent/ship_stash.yml
@@ -101,7 +101,6 @@
           - ChemDispensable
           - CigPack
           - Medkit
-          - Tourniquet
     - type: Construction
       graph: MedicalSecureStorageGraph
       node: MedicalSecureStorageNode

--- a/Resources/Prototypes/_Triad/Entities/Structures/Storage/ShipPersistent/ship_stash.yml
+++ b/Resources/Prototypes/_Triad/Entities/Structures/Storage/ShipPersistent/ship_stash.yml
@@ -101,6 +101,7 @@
           - ChemDispensable
           - CigPack
           - Medkit
+          - Tourniquet
     - type: Construction
       graph: MedicalSecureStorageGraph
       node: MedicalSecureStorageNode


### PR DESCRIPTION
## About the PR
Added the "FitsInMedicalStash" tag to tourniquets.

## Why / Balance
Tourniquets are medical items, so they should fit in medical stashes

## Media
behold
<img width="403" height="315" alt="image" src="https://github.com/user-attachments/assets/55b13e2a-3698-42e0-a747-c64314b78e9c" />

## Requirements
- [X] I have read relevant guidelines/documentation to this PR found on [our devwiki](https://monolith-station.github.io/mono-docs/).
- [X] I have added media to this PR or it does not require an ingame showcase.
- [X] I can confirm this PR contains either no AI-generated content, or AI-generated content that meets our guidelines.

## How to test
1) Acquire medical stash
2) Acquire tourniquet
3) Place tourniquet inside medical stash
4) Profit

**Changelog**
:cl:
- add: Added "FitsInMedicalStash" tag to tourniquets