### PR TITLE
Cherrypick: Linkable Gyroscopes

### DIFF
--- a/Resources/Prototypes/Entities/Structures/Shuttles/thrusters.yml
+++ b/Resources/Prototypes/Entities/Structures/Shuttles/thrusters.yml
@@ -235,18 +235,15 @@
     price: 300 # Frontier - 2000<300
   - type: PirateBountyItem # Frontier
     id: Gyroscope # Frontier
-<<<<<<< HEAD
   # Mono
   - type: ShipRepairable
     repairTime: 6
     repairCost: 6
-=======
   - type: DeviceLinkSink # Frontier: makes gyroscopes able to recieve signals
     ports:
       - On # Frontier
       - Off # Frontier
       - Toggle # Frontier
->>>>>>> 00b01ae0d3 (make gyroscopes able to recieve signals (#4320))
 
 - type: entity
   id: GyroscopeUnanchored

--- a/Resources/Prototypes/Entities/Structures/Shuttles/thrusters.yml
+++ b/Resources/Prototypes/Entities/Structures/Shuttles/thrusters.yml
@@ -235,10 +235,18 @@
     price: 300 # Frontier - 2000<300
   - type: PirateBountyItem # Frontier
     id: Gyroscope # Frontier
+<<<<<<< HEAD
   # Mono
   - type: ShipRepairable
     repairTime: 6
     repairCost: 6
+=======
+  - type: DeviceLinkSink # Frontier: makes gyroscopes able to recieve signals
+    ports:
+      - On # Frontier
+      - Off # Frontier
+      - Toggle # Frontier
+>>>>>>> 00b01ae0d3 (make gyroscopes able to recieve signals (#4320))
 
 - type: entity
   id: GyroscopeUnanchored


### PR DESCRIPTION
## About the PR
Cherrypicked Bartholemew-Dingleberry's PR from Frontier. Allows gyroscopes to be linked to devices using a multitool.

## Why / Balance
Allows players to turn off their gyroscopes with a push of a button in order to save fuel, like many do with their thrusters.

## Media
<img width="1108" height="418" alt="image" src="https://github.com/user-attachments/assets/831724c4-4e9f-44ed-8009-711a4fa58eb1" />

## Requirements
- [X] I have read relevant guidelines/documentation to this PR found on [our devwiki](https://monolith-station.github.io/mono-docs/).
- [X] I have added media to this PR or it does not require an ingame showcase.
- [X] I can confirm this PR contains either no AI-generated content, or AI-generated content that meets our guidelines.

## How to test
1) Acquire gyroscope
2) Acquire a button or some other device that can send a signal
3) Link the gyroscope to the device as desired
4) Relish in all the gas money you can now save

**Changelog**
:cl:
- add: Adds "DeviceLinkSink" type to gyroscope entity, along with ports for "On", "Off", and "Toggle"
