### PR TITLE
Disablers Deal No Damage

### DIFF
--- a/Resources/Prototypes/Entities/Objects/Weapons/Guns/Battery/battery_guns.yml
+++ b/Resources/Prototypes/Entities/Objects/Weapons/Guns/Battery/battery_guns.yml
@@ -276,6 +276,7 @@
     fireCost: 30 #Mono: 62.5 >> 30
   - type: StaticPrice
     price: 300
+  - type: PacifismAllowedGun
 
 - type: entity
   name: laser rifle
@@ -629,6 +630,7 @@
     tags:
     - Taser
     - Sidearm
+  - type: PacifismAllowedGun
 
 - type: entity
   name: disabler
@@ -657,6 +659,7 @@
     guides:
     - Security
     # - Antagonists # Frontier: removed guidebook entry
+  - type: PacifismAllowedGun
 
 - type: entity
   name: disabler SMG
@@ -695,6 +698,7 @@
   - type: Appearance
   - type: StaticPrice
     price: 260
+  - type: PacifismAllowedGun
 
 - type: entity
   name: taser
@@ -731,6 +735,7 @@
     steps: 5
     zeroVisible: true
   - type: Appearance
+  - type: PacifismAllowedGun
 
 - type: entity
   name: antique laser pistol

--- a/Resources/Prototypes/Entities/Objects/Weapons/Guns/Projectiles/hitscan.yml
+++ b/Resources/Prototypes/Entities/Objects/Weapons/Guns/Projectiles/hitscan.yml
@@ -93,7 +93,7 @@
   - type: HitscanBasicDamage
     damage:
       types:
-        Heat: 1
+        Heat: 0 # Triad 1->0
 
 - type: entity
   parent: BasicHitscan

--- a/Resources/Prototypes/Entities/Objects/Weapons/Guns/Projectiles/projectiles.yml
+++ b/Resources/Prototypes/Entities/Objects/Weapons/Guns/Projectiles/projectiles.yml
@@ -245,7 +245,7 @@
   - type: Projectile
     damage:
       types:
-        Heat: 5
+        Shock: 0
     soundHit:
       path: "/Audio/Weapons/Guns/Hits/taser_hit.ogg"
     forceSound: true
@@ -331,7 +331,7 @@
     impactEffect: BulletImpactEffectDisabler
     damage:
       types:
-        Heat: 1
+        Heat: 0 # Triad 1->0
     soundHit:
       collection: WeakHit
     forceSound: true

--- a/Resources/Prototypes/Entities/Objects/Weapons/Guns/Projectiles/projectiles.yml
+++ b/Resources/Prototypes/Entities/Objects/Weapons/Guns/Projectiles/projectiles.yml
@@ -291,7 +291,7 @@
     impactEffect: BulletImpactEffectDisabler
     damage:
       types:
-        Heat: 5
+        Heat: 0
     soundHit:
       collection: WeakHit
     forceSound: true
@@ -1034,7 +1034,7 @@
     impactEffect: BulletImpactEffectDisabler
     damage:
       types:
-        Heat: 2
+        Heat: 0
     soundHit:
       collection: WeakHit
     forceSound: true

--- a/Resources/Prototypes/_NF/Entities/Objects/Weapons/Guns/Projectiles/energy.yml
+++ b/Resources/Prototypes/_NF/Entities/Objects/Weapons/Guns/Projectiles/energy.yml
@@ -1,17 +1,18 @@
-- type: entity
-  parent: BulletDisabler
-  id: BulletDisablerStaminaOnly
-  name: disabler bolt
-  categories: [ HideSpawnMenu ]
-  components:
-  - type: Projectile
-    impactEffect: BulletImpactEffectDisabler
-    damage:
-      types:
-        Heat: 0
-    soundHit:
-      collection: WeakHit
-    forceSound: true
+# - type: entity
+#  parent: BulletDisabler
+#  id: BulletDisablerStaminaOnly
+#  name: disabler bolt
+# categories: [ HideSpawnMenu ]
+#  components:
+#  - type: Projectile
+#    impactEffect: BulletImpactEffectDisabler
+#    damage:
+#      types:
+#        Heat: 0
+#    soundHit:
+#      collection: WeakHit
+#    forceSound: true
+# Triad. Use BulletDisabler, wizden changed disablers to do no heat damage.
 
 - type: entity
   id: BulletKineticLowPower

--- a/Resources/Prototypes/_NF/Entities/Objects/Weapons/Guns/turrets.yml
+++ b/Resources/Prototypes/_NF/Entities/Objects/Weapons/Guns/turrets.yml
@@ -23,7 +23,7 @@
       params:
         variation: 0.125
   - type: ProjectileBatteryAmmoProvider
-    proto: BulletDisablerStaminaOnly
+    proto: BulletDisabler # Triad. Changed to BulletDisabler from BulletDisablerStaminaOnly. BulletDisabler deals no damage.
     fireCost: 10
   - type: NpcFactionMember
     factions:


### PR DESCRIPTION
## About the PR
Wizden changed this years ago. Disablers being a non-lethal shouldn't be the MothKiller 3000.

## Technical details
Removes ``BulletDisablerStaminaOnly`` as a prototype. Frontier added this. Replaces all references of it with BulletDisabler.

**Changelog**
:cl:
- tweak: Disablers now deal 0 heat damage. As a result of this, pacifists can now use disablers.
- tweak: Practice weapons can now be used by pacifists.