### PR TITLE
Fix Hydrakin Plasma & Tritium Metabolism

### DIFF
--- a/Resources/Prototypes/Reagents/gases.yml
+++ b/Resources/Prototypes/Reagents/gases.yml
@@ -122,6 +122,9 @@
         conditions:
           - !type:ReagentThreshold
             min: 1.5
+          - !type:OrganType # Triad - Hydrakin metabolises plasma without toxicity, hide the warning.
+            type: Hydrakin
+            shouldHave: false
         clear: True
         time: 5
       - !type:HealthChange # Mono
@@ -171,6 +174,10 @@
         - !type:OrganType
           type: Hydrakin
       - !type:HealthChange
+        conditions:
+        - !type:OrganType # Triad - Hydrakin tolerate inhaled tritium without radiation accumulation.
+          type: Hydrakin
+          shouldHave: false
         scaleByQuantity: true
         ignoreResistances: true
         damage:
@@ -183,6 +190,9 @@
         conditions:
           - !type:ReagentThreshold
             min: 1.5
+          - !type:OrganType # Triad - Hydrakin metabolises tritium without toxicity, hide the warning. Radiation damage still applies.
+            type: Hydrakin
+            shouldHave: false
         clear: True
         time: 5
       - !type:HealthChange # Mono

--- a/Resources/Prototypes/Reagents/gases.yml
+++ b/Resources/Prototypes/Reagents/gases.yml
@@ -174,8 +174,8 @@
         - !type:OrganType
           type: Hydrakin
       - !type:HealthChange
-        conditions:
-        - !type:OrganType # Triad - Hydrakin tolerate inhaled tritium without radiation accumulation.
+        conditions: # Triad - Hydrakin tolerate inhaled tritium without radiation accumulation.
+        - !type:OrganType
           type: Hydrakin
           shouldHave: false
         scaleByQuantity: true


### PR DESCRIPTION
## About the PR
Cleans up two longstanding inconsistencies in the Hydrakin gas-metabolism block in `Resources/Prototypes/Reagents/gases.yml`:

- **Plasma & Tritium TOX icon:** The `Toxins` alert was raised at >=1.5u in the lung even though the poison `HealthChange` already excludes Hydrakin. Added the same `OrganType: Hydrakin, shouldHave: false` guard to both `AdjustAlert` effects so the UI matches the actual damage state.
- **Inhaled Tritium radiation:** Inhaling Tritium dealt 1 Radiation/tick to Hydrakin with no species exclusion, contradicting the Hydrakin guidebook's "unique gases have mostly positive effect" claim. Added the same Hydrakin exclusion to that `HealthChange`. The bloodstream Poison-group radiation (3/tick, fires when Tritium is injected/drunk/touched) is intentionally left intact — shooting up radioactive isotopes should still hurt.

## Why / Balance
Hydrakin already get an `Oxygenate` carve-out for all of Plasma/Tritium/Frezon/N2O/BZ/Healium/Nitrium/Pluoxium and are excluded from the poison damage on Plasma & Tritium. The lore (iceworld with frezon-heavy atmosphere, "capable of breathing all gases") and the in-game guidebook page both already promise this — the missing carve-outs on `AdjustAlert` and the inhaled-radiation `HealthChange` were holes in that contract, not intended balance. No new Hydrakin capabilities are being added; existing ones are just being made internally consistent.

## Media
N/A — fix for an alert icon and an unintended damage tick. No visual content.

## Requirements
- [X] I have read relevant guidelines/documentation to this PR found on [our devwiki](https://monolith-station.github.io/mono-docs/).
- [X] I have added media to this PR or it does not require an ingame showcase.
- [X] I can confirm this PR contains either no AI-generated content, or AI-generated content that meets our guidelines.

## How to test
1. Spawn as a Hydrakin.
2. Fill internals with a Plasma or Tritium tank and breathe from it (or stand in a plasma/trit-flooded room with no oxygen mask).
3. Confirm the **TOX** icon no longer appears in the alert column.
4. Run a health analyzer — confirm 0 Poison damage on both gases and 0 Radiation damage on Tritium inhalation.
5. As a control, inject Tritium directly into the bloodstream (e.g. syringe) and confirm Radiation damage still accrues.

## Breaking changes
None. Pure YAML condition additions on existing effects; no prototype renames, no public API changes.

**Changelog**
:cl:
- fix: Hydrakin no longer get a toxin warning when breathing plasma or tritium.
- fix: Hydrakin no longer take radiation damage from inhaling tritium. Injecting it still hurts.