### PR TITLE
Restore Default Volume on Hydrakin Emote Sounds

### DIFF
--- a/Resources/Prototypes/_Mono/Voice/speech_emote_sounds.yml
+++ b/Resources/Prototypes/_Mono/Voice/speech_emote_sounds.yml
@@ -2,7 +2,7 @@
   id: UnisexHydrakin
   params:
     variation: 0.125
-    volume: -8
+    # Triad: dropped `volume: -8` so Hydrakin emotes play at default loudness, matching peer species
   sounds:
     Scream:
       collection: HydrakinScream


### PR DESCRIPTION
## About the PR
Drops the `volume: -8` override on the `UnisexHydrakin` emoteSounds prototype in [Resources/Prototypes/_Mono/Voice/speech_emote_sounds.yml](Resources/Prototypes/_Mono/Voice/speech_emote_sounds.yml#L5) so Hydrakin emotes (scream, laugh, sigh, gasp, trill, wurble, etc.) play at the default 0 dB loudness instead of being attenuated 8 dB below every other species.

`variation: 0.125` is preserved, so pitch jitter is unchanged. A `# Triad:` comment is left in place documenting the removal.

## Why / Balance
Hydrakin were noticeably quieter than peer species in ambient play:

| Species | Emote volume |
|---|---|
| Human / Reptilian / Slime / etc. | 0 dB (default, no override) |
| Harpy | -5 dB |
| Diona | -5 to -10 dB per-emote |
| **Hydrakin (before)** | **-8 dB** |
| **Hydrakin (after)** | **0 dB** |

At -8 dB they were the quietest species on the roster, often inaudible in even mild ambient noise. Bringing them to the default puts them on equal footing with humans and reptilians and a hair louder than Harpy, which feels more proportionate to a large reptilian-shaped mob.

## Media
N/A (audio gain change).

## Requirements
- [x] I have read relevant guidelines/documentation to this PR found on [our devwiki](https://monolith-station.github.io/mono-docs/).
- [x] I have added media to this PR or it does not require an ingame showcase.
- [x] I can confirm this PR contains either no AI-generated content, or AI-generated content that meets our guidelines.

## How to test
1. Spawn or join as a Hydrakin.
2. Trigger several emotes via the emote menu (`*scream`, `*laugh`, `*sigh`, `*trill`, `*wurble`).
3. Compare loudness to a Human / Reptilian playing the same emote nearby. Hydrakin emotes should now sit at the same baseline level rather than being audibly quieter.

## Breaking changes
None. Behavior change is gameplay-side audio gain only; no prototype IDs, namespaces, or fields touched.

**Changelog**
:cl:
- tweak: Hydrakin emotes now play at the default species volume instead of being attenuated 8 dB.
