### PR TITLE
Removes the Vent Clog

### DIFF
--- a/Resources/Prototypes/_NF/Events/events.yml
+++ b/Resources/Prototypes/_NF/Events/events.yml
@@ -9,7 +9,7 @@
     # - id: BureaucraticError
     # - id: ClericalError
     # - id: CockroachMigration #Triad edit - Disable
-    - id: GasLeak #Triad
+    - id: GasLeak
     #- id: GreytideVirus
     - id: IonStorm # its calm like 90% of the time smh
     # - id: KudzuGrowth
@@ -23,7 +23,7 @@
     # - id: SnakeSpawn
     # - id: SpiderClownSpawn
     # - id: SpiderSpawn
-    # - id: VentClog #Triad
+    # - id: VentClog # Triad removal
     - id: BluespaceCargoCrate # Frontier
     - id: BluespaceMcCargoCrate # Frontier
     - id: BluespaceSyndicateCrate # Frontier

--- a/Resources/Prototypes/_NF/Events/events.yml
+++ b/Resources/Prototypes/_NF/Events/events.yml
@@ -9,7 +9,7 @@
     # - id: BureaucraticError
     # - id: ClericalError
     # - id: CockroachMigration #Triad edit - Disable
-    - id: GasLeak
+    - id: GasLeak #Triad
     #- id: GreytideVirus
     - id: IonStorm # its calm like 90% of the time smh
     # - id: KudzuGrowth
@@ -23,11 +23,11 @@
     # - id: SnakeSpawn
     # - id: SpiderClownSpawn
     # - id: SpiderSpawn
-    - id: VentClog
+    # - id: VentClog #Triad
     - id: BluespaceCargoCrate # Frontier
     - id: BluespaceMcCargoCrate # Frontier
     - id: BluespaceSyndicateCrate # Frontier
-#   - id: BluespaceBrokenMcDelivery # Frontier. Mono edit - Disabled
+    - id: BluespaceBrokenMcDelivery # Frontier. Mono edit - Disabled # Triad enable
     - id: SmugglingFax # Frontier
     # - id: SnailMigration # Mono. Triad edit - Disable
 

--- a/Resources/Prototypes/_NF/Events/events.yml
+++ b/Resources/Prototypes/_NF/Events/events.yml
@@ -27,7 +27,7 @@
     - id: BluespaceCargoCrate # Frontier
     - id: BluespaceMcCargoCrate # Frontier
     - id: BluespaceSyndicateCrate # Frontier
-    - id: BluespaceBrokenMcDelivery # Frontier. Mono edit - Disabled # Triad enable
+    #- id: BluespaceBrokenMcDelivery # Frontier. Mono edit - Disabled
     - id: SmugglingFax # Frontier
     # - id: SnailMigration # Mono. Triad edit - Disable
 


### PR DESCRIPTION
## About the PR
It just doesnt make sense
why is it that a computer alarm a system that all ships may have a backup when they are separate atmospheric systems 

also its nothing but annoying it works for a station because there is a post to be a janitor, but it is just annoying as fuck on a ship 


**Changelog**

:cl:
- remove: Removed VentClog event
