### PR TITLE
LPB Pointers Saving Is Kill 

### DIFF
--- a/Resources/Prototypes/_NF/Entities/Objects/Devices/pinpointer.yml
+++ b/Resources/Prototypes/_NF/Entities/Objects/Devices/pinpointer.yml
@@ -19,7 +19,7 @@
     component: SyndicateFOB
     targetName: unknown
   - type: SavingContraband # Triad
-    examineText: ship-saving-contraband-2-text
+    examineText: ship-saving-contraband-1-text
 
 # Dead Drop
 - type: entity

--- a/Resources/Prototypes/_NF/Entities/Objects/Devices/pinpointer.yml
+++ b/Resources/Prototypes/_NF/Entities/Objects/Devices/pinpointer.yml
@@ -18,6 +18,8 @@
   - type: Pinpointer
     component: SyndicateFOB
     targetName: unknown
+  - type: SavingContraband # Triad
+    examineText: ship-saving-contraband-2-text
 
 # Dead Drop
 - type: entity


### PR DESCRIPTION
## About the PR
<!-- What did you change? -->
<!-- If this is a code change, summarize at high level how your new code works. This makes it easier to review. -->
LPB pin pointer no longer saveable

## Why / Balance
<!-- Discuss how this would affect game balance or explain why it was changed. Link any relevant discussions or issues. -->
roundstart info on LPB, also following up on seperation as requested from
https://github.com/Triad-Sector/Triad_Sector/pull/128

## Media
<!-- Attach media if the PR makes ingame changes (clothing, items, features, etc). 
Small fixes/refactors are exempt. Media may be used in SS14 progress reports with credit. -->

## Requirements
<!-- Confirm the following by placing an X in the brackets [X]: -->
- [x] I have read relevant guidelines/documentation to this PR found on [our devwiki](https://monolith-station.github.io/mono-docs/).
- [x] I have added media to this PR or it does not require an ingame showcase.
- [x] I can confirm this PR contains either no AI-generated content, or AI-generated content that meets our guidelines.
<!-- You should understand that not following the above may get your PR closed at maintainer’s discretion -->
<!-- When using AI, make sure you are already proficient in creating whatever content you are attempting to generate and that you already have experience contributing to SS14. This means using AI to enhance your preexisting workflow, not vibecoding. -->

## How to test
<!-- Describe the way it can be tested -->
spawn in, put in stash, save, should be gone
## Breaking changes
<!-- List any breaking changes, including namespaces, public class/method/field changes, prototype renames; and provide instructions for fixing them. -->
should be none, only 2 line

**Changelog**
<!-- Add a Changelog entry to make players aware of new features or changes that could affect gameplay.
Make sure to read the guidelines and take this Changelog template out of the comment block in order for it to show up.
Changelog must have a :cl: symbol, so the bot recognizes the changes and adds them to the game's changelog.
Remove this symbol for non-player facing PRs.-->
:cl:
- tweak: LPB pinpointers can no longer be saved in stash

