### PR TITLE
Makes Rollerbeds Persistent

### DIFF
--- a/Resources/Prototypes/Entities/Structures/Furniture/rollerbeds.yml
+++ b/Resources/Prototypes/Entities/Structures/Furniture/rollerbeds.yml
@@ -71,6 +71,7 @@
             False: {visible: true}
     - type: StaticPrice
       price: 120
+    - type: HLPersistOnShipSave # Triad
 
 - type: entity
   parent: [RollerBed, RecyclableItemSteelMedium] # Frontier: added RecyclableItemSteelMedium


### PR DESCRIPTION
## About the PR
This PR makes rollerbeds persistent

## Why / Balance
Medical equipment + decoration, plus people can have dedicated rollerbed bays that won't disappear when they save their ship

## Media
<img width="383" height="236" alt="image" src="https://github.com/user-attachments/assets/915925b4-67be-4ef9-8e99-7e53239f7929" />

## Requirements
<!-- Confirm the following by placing an X in the brackets [X]: -->
- [X] I have read relevant guidelines/documentation to this PR found on [our devwiki](https://monolith-station.github.io/mono-docs/).
- [X] I have added media to this PR or it does not require an ingame showcase.
- [X] I can confirm this PR contains either no AI-generated content, or AI-generated content that meets our guidelines.
<!-- You should understand that not following the above may get your PR closed at maintainer’s discretion -->
<!-- When using AI, make sure you are already proficient in creating whatever content you are attempting to generate and that you already have experience contributing to SS14. This means using AI to enhance your preexisting workflow, not vibecoding. -->

## How to test
1. Spawn rollerbeds on a shuttle
2. Reload the save
3. They're still there

**Changelog**
:cl: Minerva
- tweak: Rollerbeds (folded and unfolded) now persist on ship saving.
