### PR TITLE
Makes Portable Gaslocks Persistent

### DIFF
--- a/Resources/Prototypes/_NF/Entities/Structures/Piping/Atmospherics/binary.yml
+++ b/Resources/Prototypes/_NF/Entities/Structures/Piping/Atmospherics/binary.yml
@@ -261,3 +261,4 @@
           radius: 0.2
           position: "0,-0.5"
         hard: false
+  - type: HLPersistOnShipSave # Triad


### PR DESCRIPTION
## About the PR
This PR makes portable gaslocks persistent

## Why / Balance
Gas mining drills are persistent, so why not their gaslocks?

## Media
<img width="547" height="493" alt="image" src="https://github.com/user-attachments/assets/bb4a5a6e-b68a-4b81-8128-4b9d66fa4c01" />

## Requirements
<!-- Confirm the following by placing an X in the brackets [X]: -->
- [X] I have read relevant guidelines/documentation to this PR found on [our devwiki](https://monolith-station.github.io/mono-docs/).
- [X] I have added media to this PR or it does not require an ingame showcase.
- [X] I can confirm this PR contains either no AI-generated content, or AI-generated content that meets our guidelines.
<!-- You should understand that not following the above may get your PR closed at maintainer’s discretion -->
<!-- When using AI, make sure you are already proficient in creating whatever content you are attempting to generate and that you already have experience contributing to SS14. This means using AI to enhance your preexisting workflow, not vibecoding. -->

## How to test
1. Spawn in portable gaslocks. Anchor one if you really want to
2. Reload ship save. They're still there

**Changelog**
:cl: Minerva
- tweak: Portable gaslocks now persist on ship save.
