### PR TITLE
Removes the Vent Clog 2.0

### DIFF
--- a/Resources/Prototypes/_NF/Events/events.yml
+++ b/Resources/Prototypes/_NF/Events/events.yml
@@ -23,7 +23,7 @@
     # - id: SnakeSpawn
     # - id: SpiderClownSpawn
     # - id: SpiderSpawn
-    - id: VentClog
+    # - id: VentClog # Triad Edit -- Disabled
     - id: BluespaceCargoCrate # Frontier
     - id: BluespaceMcCargoCrate # Frontier
     - id: BluespaceSyndicateCrate # Frontier


### PR DESCRIPTION
## About the PR
Irkalla going for low hanging fruits? More likely than you think.

## Why / Balance
The initial PR was closed due to personal reasons by the author. However judging from the comments it was very much wanted.

The ventclog is currently a very annoying event that adds nothing to the round other than fuck up your floor markings if you clean it with a cleanade.

## Media
Its commenting out an event.

## Requirements
- [X] I have read relevant guidelines/documentation to this PR found on [our devwiki](https://monolith-station.github.io/mono-docs/).
- [X] I have added media to this PR or it does not require an ingame showcase.
- [X] I can confirm this PR contains either no AI-generated content, or AI-generated content that meets our guidelines.


## How to test
You could go boot up a local instance with change applied and force events to run like 30 times and see its not ventclog.

## Breaking changes
None!
## Changelog

**Changelog**
:cl:
- remove: The vent clog event has been disabled.
