### PR TITLE
Sanitize Lathes Queues and Loops on Ship Save

### DIFF
--- a/Content.Server/_NF/Shipyard/Systems/ShipyardGridSaveSystem.cs
+++ b/Content.Server/_NF/Shipyard/Systems/ShipyardGridSaveSystem.cs
@@ -29,8 +29,10 @@ using Robust.Shared.Serialization.Markdown.Mapping;
 using Robust.Shared.Utility;
 using YamlDotNet.Core;
 using YamlDotNet.RepresentationModel;
+using Content.Server.Lathe.Components; // Triad
 using Content.Server.Light.Components;
 using Content.Shared._Triad.Shipyard.Save; // Triad
+using Content.Shared.Lathe; // Triad
 using Content.Shared._Triad.Shipyard.Load; // Triad
 using Content.Shared._Triad.Shipyard.Save.Contraband; // Triad
 using System.Linq;
@@ -284,6 +286,10 @@ public sealed class ShipyardGridSaveSystem : EntitySystem
             // Triad: remove any edge spreaders, we cannot save these
             RemoveEdgeSpreaderComponentComponentsOnGrid(gridUid);
 
+            // Triad
+            // Reset fabricators: disable loop/skip and cancel active jobs to prevent mid-save exceptions
+            ResetFabricatorsOnGrid(gridUid);
+
             // Remove repair data, it is re-added on load
             RemComp<ShipRepairDataComponent>(gridUid);
 
@@ -356,6 +362,28 @@ public sealed class ShipyardGridSaveSystem : EntitySystem
         foreach (var uid in toRemove)
         {
             Del(uid);
+        }
+    }
+
+    // Triad
+    /// <summary>
+    /// Resets all fabricators on the grid before saving: disables loop mode, disables skip mode,
+    /// clears the queue, and cancels any active production job.
+    /// This prevents the serializer from hitting an in-progress fab state and breaking mid-save.
+    /// </summary>
+    private void ResetFabricatorsOnGrid(EntityUid gridUid)
+    {
+        var latheQuery = _entityManager.EntityQueryEnumerator<LatheComponent, TransformComponent>();
+        while (latheQuery.MoveNext(out var uid, out var lathe, out var xform))
+        {
+            if (xform.GridUid != gridUid)
+                continue;
+
+            lathe.Loop = false;
+            lathe.SkipBad = false;
+            lathe.Queue.Clear();
+            lathe.CurrentRecipe = null;
+            RemComp<LatheProducingComponent>(uid);
         }
     }
 


### PR DESCRIPTION
## About the PR
in lathes, cancel loops, clear queues, on ship save
<!-- If this is a code change, summarize at high level how your new code works. This makes it easier to review. -->

## Why / Balance
Bugfix -- having queued jobs and loops fails serialization.
<!-- Discuss how this would affect game balance or explain why it was changed. Link any relevant discussions or issues. -->

## Media
<!-- Attach media if the PR makes ingame changes (clothing, items, features, etc). 
Small fixes/refactors are exempt. Media may be used in SS14 progress reports with credit. -->

## Requirements
<!-- Confirm the following by placing an X in the brackets [X]: -->
- [x] I have read relevant guidelines/documentation to this PR found on [our devwiki](https://monolith-station.github.io/mono-docs/).
- [x] I have added media to this PR or it does not require an ingame showcase.
- [x] I can confirm this PR contains either no AI-generated content, or AI-generated content that meets our guidelines.
<!-- You should understand that not following the above may get your PR closed at maintainer’s discretion -->
<!-- When using AI, make sure you are already proficient in creating whatever content you are attempting to generate and that you already have experience contributing to SS14. This means using AI to enhance your preexisting workflow, not vibecoding. -->

## How to test
load ship, make looped job, get it stuck because no materials or just running, save -- enjoy no broken saving
<!-- Describe the way it can be tested -->

## Breaking changes
<!-- List any breaking changes, including namespaces, public class/method/field changes, prototype renames; and provide instructions for fixing them. -->

**Changelog**
<!-- Add a Changelog entry to make players aware of new features or changes that could affect gameplay.
Make sure to read the guidelines and take this Changelog template out of the comment block in order for it to show up.
Changelog must have a :cl: symbol, so the bot recognizes the changes and adds them to the game's changelog.
Remove this symbol for non-player facing PRs.-->
:cl:
- fix: ongoing tasks in lathes don't break ship saving any more
