### PR TITLE
Magazine Firerate System

### DIFF
--- a/Content.Shared/Weapons/Ranged/Components/MagazineAffectsFireRateComponent.cs
+++ b/Content.Shared/Weapons/Ranged/Components/MagazineAffectsFireRateComponent.cs
@@ -1,0 +1,11 @@
+using Robust.Shared.GameStates;
+
+namespace Content.Shared.Weapons.Ranged.Components;
+
+[RegisterComponent]
+[NetworkedComponent]
+public sealed partial class MagazineAffectsFireRateComponent : Component
+{
+    [DataField]
+    public float? DefaultFireRate;
+}

--- a/Content.Shared/Weapons/Ranged/Components/MagazineFireRateModifierComponent.cs
+++ b/Content.Shared/Weapons/Ranged/Components/MagazineFireRateModifierComponent.cs
@@ -1,0 +1,14 @@
+using Robust.Shared.GameStates;
+
+namespace Content.Shared.Weapons.Ranged.Components;
+
+[RegisterComponent]
+[NetworkedComponent]
+public sealed partial class MagazineFireRateModifierComponent : Component
+{
+    [DataField]
+    public float FireRateMultiplier = 1f;
+
+    [DataField]
+    public float FireRateOverride = 0f;
+}

--- a/Content.Shared/Weapons/Ranged/Systems/SharedGunSystem.cs
+++ b/Content.Shared/Weapons/Ranged/Systems/SharedGunSystem.cs
@@ -351,7 +351,27 @@ public abstract partial class SharedGunSystem : EntitySystem
     {
         if (TryComp<AutoShootGunComponent>(gunUid, out var auto) && !auto.CanFire && auto.RemainingTime <= TimeSpan.FromSeconds(0)) // Frontier // Mono
             return; // Frontier
-
+			
+		// Triad start
+		if (TryComp<MagazineAffectsFireRateComponent>(gunUid, out var fireRateComp))
+		{
+			fireRateComp.DefaultFireRate ??= gun.FireRate;
+			gun.FireRate = fireRateComp.DefaultFireRate.Value;
+			if (Containers.TryGetContainer(gunUid, "gun_magazine", out var magContainer) &&
+				magContainer.ContainedEntities.Count > 0)
+			{
+				var mag = magContainer.ContainedEntities[0];
+				if (TryComp<MagazineFireRateModifierComponent>(mag, out var modifier))
+				{
+					gun.FireRate = modifier.FireRateOverride > 0f
+						? modifier.FireRateOverride
+						: gun.FireRate * modifier.FireRateMultiplier;
+				}
+			}
+			RefreshModifiers((gunUid, gun));
+		}
+		// Triad end
+		
         if (gun.FireRateModified <= 0f ||
             !_actionBlockerSystem.CanAttack(user))
         {


### PR DESCRIPTION
## About the PR
Adds new components for setting different fire rates depending on the magazine in specified guns

## Why / Balance
Originally intended for my other PR (StA-52) but I was asked to make a separate PR. The system can be applied to any gun/mag

## Media
https://imgur.com/a/PQRJ6AP

## Requirements
- [X] I have read relevant guidelines/documentation to this PR found on [our devwiki](https://monolith-station.github.io/mono-docs/).
- [X] I have added media to this PR or it does not require an ingame showcase.
- [X] I can confirm this PR contains either no AI-generated content, or AI-generated content that meets our guidelines.

## How to test
- Add the corresponding components to a gun and mag, then use it ingame

**Changelog**
:cl:
- add: Adds new components for setting different fire rates depending on the magazine in specified guns