### PR TITLE
Syndicate Bomb Linkable Trigger & Screen Timers for Mapping

### DIFF
--- a/Content.Server/Defusable/Systems/DefusableSystem.cs
+++ b/Content.Server/Defusable/Systems/DefusableSystem.cs
@@ -123,6 +123,10 @@ public sealed class DefusableSystem : SharedDefusableSystem
     /// Triad, Ensures defusable bombs are marked as activated when their timer starts.
     private void OnActiveTimer(EntityUid uid, DefusableComponent comp, ref ActiveTimerTriggerEvent args)
     {
+        var xform = Transform(uid);
+        if (!xform.Anchored)
+            _transform.AnchorEntity(uid, xform);
+
         SetBolt(comp, true);
         SetActivated(comp, true);
     }

--- a/Content.Server/Defusable/Systems/DefusableSystem.cs
+++ b/Content.Server/Defusable/Systems/DefusableSystem.cs
@@ -40,6 +40,7 @@ public sealed class DefusableSystem : SharedDefusableSystem
         SubscribeLocalEvent<DefusableComponent, GetVerbsEvent<AlternativeVerb>>(OnGetAltVerbs);
         SubscribeLocalEvent<DefusableComponent, AnchorAttemptEvent>(OnAnchorAttempt);
         SubscribeLocalEvent<DefusableComponent, UnanchorAttemptEvent>(OnUnanchorAttempt);
+        SubscribeLocalEvent<DefusableComponent, ActiveTimerTriggerEvent>(OnActiveTimer); // Triad added timer event
     }
 
     #region Subscribed Events
@@ -117,6 +118,13 @@ public sealed class DefusableSystem : SharedDefusableSystem
         _popup.PopupEntity(msg, uid, args.User);
 
         return true;
+    }
+
+    /// Triad, Ensures defusable bombs are marked as activated when their timer starts.
+    private void OnActiveTimer(EntityUid uid, DefusableComponent comp, ref ActiveTimerTriggerEvent args)
+    {
+        SetBolt(comp, true);
+        SetActivated(comp, true);
     }
 
     #endregion

--- a/Resources/Prototypes/Entities/Structures/Machines/bombs.yml
+++ b/Resources/Prototypes/Entities/Structures/Machines/bombs.yml
@@ -18,6 +18,12 @@
     - type: Defusable
     - type: Rotatable
     - type: Explosive
+    # Triad Start
+    - type: TimerStartOnSignal
+    - type: DeviceLinkSink
+      ports:
+        - Timer
+    # Triad End
       explosionType: Default
       totalIntensity: 20.0
       intensitySlope: 5
@@ -27,7 +33,7 @@
     # Unless, of course, you want the 90 seconds regardless. I can't stop you.
     - type: OnUseTimerTrigger
       delay: 180
-      delayOptions: [180, 240, 300, 600, 900]
+      delayOptions: [120, 180, 240, 300, 600, 900] # Triad Added 120
       initialBeepDelay: 0
       beepSound: /Audio/Machines/timer.ogg
     - type: Anchorable

--- a/Resources/Prototypes/Entities/Structures/Machines/bombs.yml
+++ b/Resources/Prototypes/Entities/Structures/Machines/bombs.yml
@@ -132,7 +132,18 @@
       totalIntensity: 4000.0
       intensitySlope: 3
       maxIntensity: 400
-
+    - type: Destructible # Triad
+      thresholds:
+      - trigger:
+          !type:DamageTrigger
+          damage: 125
+        behaviors:
+        - !type:DoActsBehavior
+          acts: ["Destruction"]
+        - !type:ExplodeBehavior
+    - type: Anchorable
+      delay: 300 # Triad, try to unanchor this chucklenuts
+        
 - type: entity
   parent: SyndicateBomb
   id: SyndicateBombFake

--- a/Resources/Prototypes/Entities/Structures/Machines/bombs.yml
+++ b/Resources/Prototypes/Entities/Structures/Machines/bombs.yml
@@ -17,13 +17,13 @@
       alwaysRandomize: true
     - type: Defusable
     - type: Rotatable
-    - type: Explosive
     # Triad Start
     - type: TimerStartOnSignal
     - type: DeviceLinkSink
       ports:
         - Timer
     # Triad End
+    - type: Explosive
       explosionType: Default
       totalIntensity: 20.0
       intensitySlope: 5

--- a/Resources/Prototypes/Entities/Structures/Machines/bombs.yml
+++ b/Resources/Prototypes/Entities/Structures/Machines/bombs.yml
@@ -32,8 +32,8 @@
     # If you nerf the syndicate bomb in any major way, this should probably drop down to at least 100s (not 90s to compensate for slower movement speed & less lag in SS14)
     # Unless, of course, you want the 90 seconds regardless. I can't stop you.
     - type: OnUseTimerTrigger
-      delay: 180
-      delayOptions: [120, 180, 240, 300, 600, 900] # Triad Added 120
+      delay: 120 # Triad defaults to 2 minute on start
+      delayOptions: [30, 60, 120, 180, 240, 300, 600, 900] # Triad Added 30,60,120
       initialBeepDelay: 0
       beepSound: /Audio/Machines/timer.ogg
     - type: Anchorable

--- a/Resources/Prototypes/_Mono/Entities/Structures/Machines/bombs.yml
+++ b/Resources/Prototypes/_Mono/Entities/Structures/Machines/bombs.yml
@@ -33,10 +33,10 @@
        thresholds:
        - trigger:
           !type:DamageTrigger
-          damage: 1250
+          damage: 200 # Triad, make this lower so it breaks faster
          behaviors:
          - !type:DoActsBehavior
            acts: ["Destruction"]
          - !type:ExplodeBehavior
      - type: Anchorable
-       delay: 180
+       delay: 200 # Triad, 200 < 180

--- a/Resources/Prototypes/_Triad/Entities/Structures/Wallmounts/timer.yml
+++ b/Resources/Prototypes/_Triad/Entities/Structures/Wallmounts/timer.yml
@@ -38,17 +38,6 @@
     interfaces:
       enum.SignalTimerUiKey.Key:
         type: SignalTimerBoundUserInterface
-  - type: Construction
-    graph: Timer
-    node: signal
-    containers:
-    - board
-  - type: ContainerContainer
-    containers:
-      board: !type:Container
-  - type: ContainerFill
-    containers:
-      board: [ SignalTimerElectronics ]
 
 # These screen timers though, are good for making countdowns on bombing timer, blow some stuff up
 - type: entity
@@ -71,11 +60,3 @@
     sprite: Structures/Wallmounts/signalscreen.rsi
     state: signalscreen
     noRot: true
-  - type: Construction
-    graph: Timer
-    node: screen
-    containers:
-    - board
-  - type: ContainerFill
-    containers:
-      board: [ ScreenTimerElectronics ]

--- a/Resources/Prototypes/_Triad/Entities/Structures/Wallmounts/timer.yml
+++ b/Resources/Prototypes/_Triad/Entities/Structures/Wallmounts/timer.yml
@@ -4,7 +4,7 @@
   id: AlwaysPoweredSignalTimer
   name: signal timer
   suffix: Always powered
-  description: It's a timer for sending timed signals to things.
+  description: It's a timer for sending timed signals to things. though you probably shouldnt see this
   placement:
     mode: SnapgridCenter
     snap:
@@ -56,7 +56,7 @@
   parent: AlwaysPoweredSignalTimer
   name: screen timer
   suffix: Always powered
-  description: It's a timer for sending timed signals to things, with a built-in screen.
+  description: if you see the timer counting down, you probably should run
   components:
   - type: SignalTimer
     canEditLabel: true

--- a/Resources/Prototypes/_Triad/Entities/Structures/Wallmounts/timer.yml
+++ b/Resources/Prototypes/_Triad/Entities/Structures/Wallmounts/timer.yml
@@ -1,0 +1,81 @@
+# These signal timers are to be used for making a timer related event on click or any when mapping
+# Example when making a station bombing sequence or a timer for puzzles/parkour timing n etc, go wild
+- type: entity
+  id: AlwaysPoweredSignalTimer
+  name: signal timer
+  suffix: Always powered
+  description: It's a timer for sending timed signals to things.
+  placement:
+    mode: SnapgridCenter
+    snap:
+    - Wallmount
+  components:
+  - type: StationAiWhitelist
+  - type: Transform
+    anchored: true
+  - type: WallMount
+    arc: 360
+  - type: Clickable
+  - type: InteractionOutline
+  - type: Sprite
+    drawdepth: SmallObjects
+    sprite: Structures/Wallmounts/switch.rsi
+    state: on
+  - type: Appearance
+  - type: Rotatable
+  - type: SignalTimer
+    canEditLabel: false
+  - type: DeviceLinkSource
+    ports:
+      - Start
+      - Timer
+  - type: DeviceLinkSink
+    ports:
+      - Trigger
+  - type: ActivatableUI
+    key: enum.SignalTimerUiKey.Key
+  - type: UserInterface
+    interfaces:
+      enum.SignalTimerUiKey.Key:
+        type: SignalTimerBoundUserInterface
+  - type: Construction
+    graph: Timer
+    node: signal
+    containers:
+    - board
+  - type: ContainerContainer
+    containers:
+      board: !type:Container
+  - type: ContainerFill
+    containers:
+      board: [ SignalTimerElectronics ]
+
+# These screen timers though, are good for making countdowns on bombing timer, blow some stuff up
+- type: entity
+  id: AlwaysPoweredScreenTimer
+  parent: AlwaysPoweredSignalTimer
+  name: screen timer
+  suffix: Always powered
+  description: It's a timer for sending timed signals to things, with a built-in screen.
+  components:
+  - type: SignalTimer
+    canEditLabel: true
+  - type: TextScreenVisuals
+    color: FloralWhite
+    textOffset: 0,6
+    timerOffset: 0,6
+    textLength: 5
+    rows: 1
+  - type: Sprite
+    drawdepth: WallMountedItems
+    sprite: Structures/Wallmounts/signalscreen.rsi
+    state: signalscreen
+    noRot: true
+  - type: Construction
+    graph: Timer
+    node: screen
+    containers:
+    - board
+  - type: ContainerFill
+    containers:
+      board: [ ScreenTimerElectronics ]


### PR DESCRIPTION
## About the PR
<!-- What did you change? -->
<!-- If this is a code change, summarize at high level how your new code works. This makes it easier to review. -->
Adds a timer trigger for syndicate bomb and added an always powered version of screen timer for mapping functions

## Why / Balance
<!-- Discuss how this would affect game balance or explain why it was changed. Link any relevant discussions or issues. -->
this will expand the vast possibilities for timed based events in Dungeons, Events & PoI, example of bombing, trapping, delayed trap, asynchronous bombing sequence

## Media
<!-- Attach media if the PR makes ingame changes (clothing, items, features, etc). 
Small fixes/refactors are exempt. Media may be used in SS14 progress reports with credit. -->
<img width="418" height="182" alt="image" src="https://github.com/user-attachments/assets/e177a510-da82-4e14-9f45-0cc894bacf0d" />
<img width="277" height="338" alt="image" src="https://github.com/user-attachments/assets/4820ce35-42dc-4d21-aea1-18ac06f34b2b" />
<img width="360" height="236" alt="image" src="https://github.com/user-attachments/assets/267c1adf-28f7-40e8-be26-c24a52cb5e86" />


## Requirements
<!-- Confirm the following by placing an X in the brackets [X]: -->
- [x] I have read relevant guidelines/documentation to this PR found on [our devwiki](https://monolith-station.github.io/mono-docs/).
- [x] I have added media to this PR or it does not require an ingame showcase.
- [x] I can confirm this PR contains either no AI-generated content, or AI-generated content that meets our guidelines.
<!-- You should understand that not following the above may get your PR closed at maintainer’s discretion -->
<!-- When using AI, make sure you are already proficient in creating whatever content you are attempting to generate and that you already have experience contributing to SS14. This means using AI to enhance your preexisting workflow, not vibecoding. -->

## How to test
<!-- Describe the way it can be tested -->
spawn syndicate bomb, use multitool and link to something, should show linking ui for timer trigger
on triggering it should be activated, anchored and bolted

alternative is the Screen timer that works without any form of power, especially for mapping

## Breaking changes
<!-- List any breaking changes, including namespaces, public class/method/field changes, prototype renames; and provide instructions for fixing them. -->
all cleared

**Changelog**
<!-- Add a Changelog entry to make players aware of new features or changes that could affect gameplay.
Make sure to read the guidelines and take this Changelog template out of the comment block in order for it to show up.
Changelog must have a :cl: symbol, so the bot recognizes the changes and adds them to the game's changelog.
Remove this symbol for non-player facing PRs.-->
🆑 
- add: Added screen timers & triggers that can and should only be used in mapping
- tweak: Hard bombs can now be linked to a trigger
- tweak: more timer options for Hard bombs and now defaults at 120