### PR TITLE
Remove Forced Accents From Most Clothings

### DIFF
--- a/Resources/Prototypes/Entities/Clothing/Head/hats.yml
+++ b/Resources/Prototypes/Entities/Clothing/Head/hats.yml
@@ -46,8 +46,8 @@
     sprite: Clothing/Head/Hats/beret_french.rsi
   - type: Clothing
     sprite: Clothing/Head/Hats/beret_french.rsi
-  - type: AddAccentClothing
-    accent: FrenchAccent
+  #- type: AddAccentClothing # Triad removal - Remove forced accents
+  #  accent: FrenchAccent
   - type: Tag
     tags:
     - ClothMade
@@ -454,8 +454,8 @@
     sprite: Clothing/Head/Hats/sombrero.rsi
   - type: Clothing
     sprite: Clothing/Head/Hats/sombrero.rsi
-  - type: AddAccentClothing
-    accent: SpanishAccent
+  #- type: AddAccentClothing # Triad removal - Remove forced accents
+  #  accent: SpanishAccent
 
 - type: entity
   parent: ClothingHeadBase
@@ -520,8 +520,8 @@
   - type: Clothing
     sprite: Clothing/Head/Hats/ushanka.rsi
   - type: Appearance
-  - type: AddAccentClothing
-    accent: RussianAccent
+  #- type: AddAccentClothing # Triad removal - Remove forced accents
+  #  accent: RussianAccent
   - type: Foldable
     canFoldInsideContainer: true
   - type: FoldableClothing
@@ -1041,9 +1041,9 @@
       sprite: Clothing/Head/Hats/cowboyhatbrown.rsi
     - type: Clothing
       sprite: Clothing/Head/Hats/cowboyhatbrown.rsi
-    - type: AddAccentClothing
-      accent: ReplacementAccent
-      replacement: cowboy
+    #- type: AddAccentClothing # Triad removal - Remove forced accents
+    #  accent: ReplacementAccent
+    #  replacement: cowboy
 
 - type: entity
   parent: ClothingHeadHatCowboyBrown

--- a/Resources/Prototypes/Entities/Clothing/Head/misc.yml
+++ b/Resources/Prototypes/Entities/Clothing/Head/misc.yml
@@ -168,8 +168,8 @@
     sprite: Clothing/Head/Misc/fancycrown.rsi
   - type: StaticPrice
     price: 3000
-  - type: AddAccentClothing
-    accent: MobsterAccent
+  #- type: AddAccentClothing # Triad removal - Remove forced accents
+  #  accent: MobsterAccent
   - type: NFTreasure # Frontier
 
 - type: entity

--- a/Resources/Prototypes/Entities/Clothing/Masks/masks.yml
+++ b/Resources/Prototypes/Entities/Clothing/Masks/masks.yml
@@ -675,9 +675,9 @@
     sprite: Clothing/Mask/italian_moustache.rsi
   - type: Item
     storedRotation: -90
-  - type: AddAccentClothing
-    accent: ReplacementAccent
-    replacement: italian
+  #- type: AddAccentClothing # Triad removal - Remove forced accents
+  #  accent: ReplacementAccent
+  #  replacement: italian
 
 - type: entity
   parent: ClothingMaskBase

--- a/Resources/Prototypes/Entities/Clothing/OuterClothing/misc.yml
+++ b/Resources/Prototypes/Entities/Clothing/OuterClothing/misc.yml
@@ -118,8 +118,8 @@
     sprite: Clothing/OuterClothing/Misc/classicponcho.rsi
   - type: Clothing
     sprite: Clothing/OuterClothing/Misc/classicponcho.rsi
-  - type: AddAccentClothing
-    accent: SpanishAccent
+  #- type: AddAccentClothing # Triad removal - Remove forced accents
+  #  accent: SpanishAccent
 
 - type: entity
   parent: [ClothingOuterBase]
@@ -153,8 +153,8 @@
     sprite: Clothing/OuterClothing/Misc/poncho.rsi
   - type: Clothing
     sprite: Clothing/OuterClothing/Misc/poncho.rsi
-  - type: AddAccentClothing
-    accent: SpanishAccent
+  #- type: AddAccentClothing # Triad removal - Remove forced accents
+  #  accent: SpanishAccent
 
 - type: entity
   parent: ClothingOuterBase

--- a/Resources/Prototypes/Entities/Clothing/Uniforms/jumpsuits.yml
+++ b/Resources/Prototypes/Entities/Clothing/Uniforms/jumpsuits.yml
@@ -1084,8 +1084,8 @@
     sprite: Clothing/Uniforms/Jumpsuit/pirate.rsi
   - type: Clothing
     sprite: Clothing/Uniforms/Jumpsuit/pirate.rsi
-  - type: AddAccentClothing
-    accent: PirateAccent
+  #- type: AddAccentClothing # Triad removal - Remove forced accents
+  #  accent: PirateAccent
   - type: SuitSensor # Frontier
     randomMode: false # Frontier
     mode: SensorOff # Frontier

--- a/Resources/Prototypes/_Mono/Entities/Clothing/OuterClothing/Coats/medical.yml
+++ b/Resources/Prototypes/_Mono/Entities/Clothing/OuterClothing/Coats/medical.yml
@@ -8,5 +8,5 @@
     sprite: Clothing/OuterClothing/Coats/david_jacket.rsi
   - type: Clothing
     sprite: Clothing/OuterClothing/Coats/david_jacket.rsi
-  - type: AddAccentClothing
-    accent: StreetpunkAccent
+  #- type: AddAccentClothing # Triad removal - Remove forced accents
+  #  accent: StreetpunkAccent


### PR DESCRIPTION
## About the PR
This PR comments out about every non-essential forced accent, excluding the "meme items" like the doggy and cat ears. Also excluding items like muzzles, cluwne masks, and facehugger plushies which are *supposed to* have this their accents

## Why / Balance
This is an MRP server and wearing a piece of clothing should not magically make you speak another way. Except for the meme items. Fashion without a silly not-character-fitting forced accent
This is the way Frontier does it, I believe

## Media
<img width="283" height="369" alt="image" src="https://github.com/user-attachments/assets/0b1186c8-7b7f-48d4-8ab8-ddc2d9c22c18" />

## Requirements
<!-- Confirm the following by placing an X in the brackets [X]: -->
- [X] I have read relevant guidelines/documentation to this PR found on [our devwiki](https://monolith-station.github.io/mono-docs/).
- [X] I have added media to this PR or it does not require an ingame showcase.
- [X] I can confirm this PR contains either no AI-generated content, or AI-generated content that meets our guidelines.
<!-- You should understand that not following the above may get your PR closed at maintainer’s discretion -->
<!-- When using AI, make sure you are already proficient in creating whatever content you are attempting to generate and that you already have experience contributing to SS14. This means using AI to enhance your preexisting workflow, not vibecoding. -->

## How to test
1. Go through changes and try out the items

**Changelog**
:cl: Minerva
- tweak: Forced accents have been removed from most clothings. Some exceptions were made such as cat/doggy ears, muzzles, and cluwne masks.