### PR TITLE
Booze Dispenser Vodka Fix

### DIFF
--- a/Resources/Prototypes/Entities/Objects/Consumable/Drinks/drinks_bottles.yml
+++ b/Resources/Prototypes/Entities/Objects/Consumable/Drinks/drinks_bottles.yml
@@ -496,7 +496,7 @@
   - type: Tag
     tags:
     - VodkaBounty
-    - DrinkBottle
+    - DrinkBottle # Triad
 
 - type: entity
   parent: [DrinkBottleVisualsAll, DrinkBottleGlassBaseFull]

--- a/Resources/Prototypes/Entities/Objects/Consumable/Drinks/drinks_bottles.yml
+++ b/Resources/Prototypes/Entities/Objects/Consumable/Drinks/drinks_bottles.yml
@@ -496,6 +496,7 @@
   - type: Tag
     tags:
     - VodkaBounty
+    - DrinkBottle
 
 - type: entity
   parent: [DrinkBottleVisualsAll, DrinkBottleGlassBaseFull]


### PR DESCRIPTION
## About the PR
Fixes vodka not being able to fit in the booze dispenser, despite being part of the fill.
<!-- What did you change? -->
<!-- If this is a code change, summarize at high level how your new code works. This makes it easier to review. -->
## Why / Balance
Booze goes in booze dispenser.
<!-- Discuss how this would affect game balance or explain why it was changed. Link any relevant discussions or issues. -->
## Requirements
<!-- Confirm the following by placing an X in the brackets [X]: -->
- [X] I have read relevant guidelines/documentation to this PR found on [our devwiki](https://monolith-station.github.io/mono-docs/).
- [X] I have added media to this PR or it does not require an ingame showcase.
- [X] I can confirm this PR contains either no AI-generated content, or AI-generated content that meets our guidelines.
<!-- You should understand that not following the above may get your PR closed at maintainer’s discretion -->
<!-- When using AI, make sure you are already proficient in creating whatever content you are attempting to generate and that you already have experience contributing to SS14. This means using AI to enhance your preexisting workflow, not vibecoding. -->
## How to test
-Pull vodka bottle out of booze dispenser.
-Put bottle back in.

**Changelog**

:cl:
- fix: Vodka bottles now fit in the booze dispenser.
