### PR TITLE
Made Skub Persist on Ship Save

### DIFF
--- a/Resources/Prototypes/Entities/Objects/Fun/skub.yml
+++ b/Resources/Prototypes/Entities/Objects/Fun/skub.yml
@@ -36,3 +36,4 @@
     hidden: true
   - type: UseDelay
     delay: 2.0
+  - type: HLPersistOnShipSave # Triad


### PR DESCRIPTION
## About the PR
I made it so that Skub persists when you save your ship.
I did this by adding the "HLPersistOnShipSave" component to the Skub Entity.

## Why / Balance
Decorative Item/Fun, mostly inconsequential 

## Media
<img width="480" height="268" alt="image" src="https://github.com/user-attachments/assets/e8e420aa-5725-4acc-8f66-331f96357ed2" />


## Requirements
<!-- Confirm the following by placing an X in the brackets [X]: -->
- [X ] I have read relevant guidelines/documentation to this PR found on [our devwiki](https://monolith-station.github.io/mono-docs/).
- [ X] I have added media to this PR or it does not require an ingame showcase.
- [ X] I can confirm this PR contains either no AI-generated content, or AI-generated content that meets our guidelines.
<!-- You should understand that not following the above may get your PR closed at maintainer’s discretion -->
<!-- When using AI, make sure you are already proficient in creating whatever content you are attempting to generate and that you already have experience contributing to SS14. This means using AI to enhance your preexisting workflow, not vibecoding. -->

## How to test
Spawn a Skub, Buy a ship, put it on the ship, save the ship, then load the ship.

## Breaking changes
<!-- List any breaking changes, including namespaces, public class/method/field changes, prototype renames; and provide instructions for fixing them. -->

**Changelog**
:cl:
- tweak: Skub now persists on ship save.

