### PR TITLE
Nerf Gas Station Miners

### DIFF
--- a/Resources/Maps/_Mono/Outpost/colossus_central.yml
+++ b/Resources/Maps/_Mono/Outpost/colossus_central.yml
@@ -4,7 +4,7 @@ meta:
   engineVersion: 271.2.0
   forkId: ""
   forkVersion: ""
-  time: 03/27/2026 19:43:44
+  time: 05/31/2026 13:03:23
   entityCount: 10733
 maps:
 - 1
@@ -300,10 +300,10 @@ entities:
     - type: OccluderTree
     - type: SpreaderGrid
       spreadQueues:
-        MetalFoam: []
-        Puddle: []
         Kudzu: []
         Smoke: []
+        MetalFoam: []
+        Puddle: []
     - type: Shuttle
       dampingModifier: 0.25
     - type: GridPathfinding
@@ -8720,6 +8720,7 @@ entities:
     - type: NavMap
     - type: ShipGridLock
       locked: False
+    - type: ThermalSignature
 - proto: ActionToggleLight
   entities:
   - uid: 4
@@ -29887,14 +29888,6 @@ entities:
     - type: Transform
       pos: 12.5,28.5
       parent: 2
-- proto: ConstructionBox
-  entities:
-  - uid: 3814
-    components:
-    - type: Transform
-      rot: 3.141592653589793 rad
-      pos: -38.5,40.5
-      parent: 2
 - proto: ConveyorBelt
   entities:
   - uid: 3815
@@ -40331,16 +40324,16 @@ entities:
       - Oxygen
     - type: AtmosPipeColor
       color: '#0055CCFF'
-- proto: GasMinerNitrogenStationLarge
+- proto: GasMinerNitrogenTriad
   entities:
-  - uid: 5339
+  - uid: 5340
     components:
     - type: Transform
       pos: -34.5,64.5
       parent: 2
-- proto: GasMinerOxygenStationLarge
+- proto: GasMinerOxygenTriad
   entities:
-  - uid: 5340
+  - uid: 5339
     components:
     - type: Transform
       pos: -36.5,64.5
@@ -55032,6 +55025,14 @@ entities:
     - type: Transform
       pos: -13.5,49.5
       parent: 2
+- proto: NFMagnetBoxConstruction
+  entities:
+  - uid: 3814
+    components:
+    - type: Transform
+      rot: 3.141592653589793 rad
+      pos: -38.5,40.5
+      parent: 2
 - proto: NFPlushieCmo
   entities:
   - uid: 7253
@@ -61845,6 +61846,8 @@ entities:
       rot: -1.5707963267948966 rad
       pos: 14.5,44.5
       parent: 2
+    - type: Fixtures
+      fixtures: {}
 - proto: SinkWide
   entities:
   - uid: 8303
@@ -61853,12 +61856,16 @@ entities:
       rot: -1.5707963267948966 rad
       pos: 9.555361,52.50066
       parent: 2
+    - type: Fixtures
+      fixtures: {}
   - uid: 8304
     components:
     - type: Transform
       rot: -1.5707963267948966 rad
       pos: 17.5,24.5
       parent: 2
+    - type: Fixtures
+      fixtures: {}
 - proto: SmallLightDim
   entities:
   - uid: 8305

--- a/Resources/Maps/_Mono/POI/camelot.yml
+++ b/Resources/Maps/_Mono/POI/camelot.yml
@@ -1,10 +1,10 @@
 meta:
   format: 7
   category: Grid
-  engineVersion: 264.0.0
+  engineVersion: 271.2.0
   forkId: ""
   forkVersion: ""
-  time: 11/30/2025 20:47:51
+  time: 05/31/2026 12:38:35
   entityCount: 11257
 maps: []
 grids:
@@ -3282,6 +3282,11 @@ entities:
             3365: -37,-13
             3429: -28,12
     - type: SpreaderGrid
+      spreadQueues:
+        Kudzu: []
+        MetalFoam: []
+        Smoke: []
+        Puddle: []
     - type: GridAtmosphere
       version: 2
       data:
@@ -4219,6 +4224,7 @@ entities:
     - type: GasTileOverlay
     - type: RadiationGridResistance
     - type: NavMap
+    - type: ThermalSignature
 - proto: AirAlarm
   entities:
   - uid: 3
@@ -37931,14 +37937,14 @@ entities:
       - BZ
     - type: AtmosPipeColor
       color: '#DD0075FF'
-- proto: GasMinerNitrogenStationLarge
+- proto: GasMinerNitrogenTriad
   entities:
   - uid: 5893
     components:
     - type: Transform
       pos: -38.5,-2.5
       parent: 1
-- proto: GasMinerOxygenStation
+- proto: GasMinerOxygenTriad
   entities:
   - uid: 5894
     components:
@@ -56876,57 +56882,77 @@ entities:
       rot: -1.5707963267948966 rad
       pos: -43.5,25.5
       parent: 1
+    - type: Fixtures
+      fixtures: {}
   - uid: 8363
     components:
     - type: Transform
       pos: 3.5,5.5
       parent: 1
+    - type: Fixtures
+      fixtures: {}
   - uid: 8364
     components:
     - type: Transform
       rot: 1.5707963267948966 rad
       pos: -22.5,8.5
       parent: 1
+    - type: Fixtures
+      fixtures: {}
   - uid: 8365
     components:
     - type: Transform
       pos: -24.5,-17.5
       parent: 1
+    - type: Fixtures
+      fixtures: {}
   - uid: 8366
     components:
     - type: Transform
       pos: -26.5,-17.5
       parent: 1
+    - type: Fixtures
+      fixtures: {}
   - uid: 8367
     components:
     - type: Transform
       rot: 3.141592653589793 rad
       pos: -22.5,12.5
       parent: 1
+    - type: Fixtures
+      fixtures: {}
   - uid: 8368
     components:
     - type: Transform
       rot: -1.5707963267948966 rad
       pos: 5.5,-13.5
       parent: 1
+    - type: Fixtures
+      fixtures: {}
   - uid: 8369
     components:
     - type: Transform
       rot: -1.5707963267948966 rad
       pos: -32.5,-16.5
       parent: 1
+    - type: Fixtures
+      fixtures: {}
   - uid: 8370
     components:
     - type: Transform
       rot: -1.5707963267948966 rad
       pos: -38.5,-12.5
       parent: 1
+    - type: Fixtures
+      fixtures: {}
   - uid: 8371
     components:
     - type: Transform
       rot: -1.5707963267948966 rad
       pos: 12.5,-5.5
       parent: 1
+    - type: Fixtures
+      fixtures: {}
 - proto: SmartFridge
   entities:
   - uid: 8372

--- a/Resources/Maps/_Mono/POI/sevastopol.yml
+++ b/Resources/Maps/_Mono/POI/sevastopol.yml
@@ -1,10 +1,10 @@
 meta:
   format: 7
   category: Grid
-  engineVersion: 264.0.0
+  engineVersion: 271.2.0
   forkId: ""
   forkVersion: ""
-  time: 11/04/2025 23:00:23
+  time: 05/31/2026 12:40:29
   entityCount: 3730
 maps: []
 grids:
@@ -1392,6 +1392,11 @@ entities:
             168: 15,5
             429: 16,-1
     - type: SpreaderGrid
+      spreadQueues:
+        Kudzu: []
+        MetalFoam: []
+        Smoke: []
+        Puddle: []
     - type: GridAtmosphere
       version: 2
       data:
@@ -1464,7 +1469,7 @@ entities:
             0: 63247
           1,-5:
             0: 57105
-            4: 4
+            1: 4
           1,0:
             0: 65287
           2,-4:
@@ -1477,7 +1482,7 @@ entities:
             0: 56543
           2,-5:
             0: 13104
-            1: 32768
+            2: 32768
             3: 128
           2,0:
             0: 65501
@@ -1490,7 +1495,7 @@ entities:
           3,-1:
             0: 50191
           3,-5:
-            1: 4096
+            2: 4096
             0: 34816
             3: 16
           3,0:
@@ -1550,7 +1555,7 @@ entities:
           -3,4:
             0: 2189
           -3,2:
-            2: 34944
+            4: 34944
           -2,1:
             0: 63628
           -2,3:
@@ -1644,28 +1649,28 @@ entities:
           -5,6:
             0: 12
           -3,5:
-            4: 34952
+            1: 34952
           -3,6:
-            4: 8
+            1: 8
           -2,5:
-            4: 4369
+            1: 4369
             0: 52428
           -2,6:
-            4: 1
+            1: 1
             0: 68
             6: 16384
           -2,7:
             6: 17476
-            4: 34952
+            1: 34952
           -2,8:
             6: 1092
-            4: 8
+            1: 8
           -1,5:
             0: 30576
           -1,6:
             0: 9010
           -1,7:
-            4: 7
+            1: 7
           -1,4:
             6: 61152
           5,-6:
@@ -1705,47 +1710,6 @@ entities:
           - 0
           - 0
           - 0
-        - volume: 2500
-          temperature: 293.15
-          moles:
-          - 0
-          - 6666.982
-          - 0
-          - 0
-          - 0
-          - 0
-          - 0
-          - 0
-          - 0
-          - 0
-          - 0
-          - 0
-        - volume: 2500
-          temperature: 293.15
-          moles:
-          - 0
-          - 0
-          - 0
-          - 6666.982
-          - 0
-          - 0
-          - 0
-          - 0
-          - 0
-          - 0
-          - 0
-          - 0
-        - volume: 2500
-          temperature: 293.15
-          moles:
-          - 6666.982
-          - 0
-          - 0
-          - 0
-          - 0
-          - 0
-          - 0
-          - 0
           - 0
           - 0
           - 0
@@ -1753,6 +1717,67 @@ entities:
         - volume: 2500
           immutable: True
           moles:
+          - 0
+          - 0
+          - 0
+          - 0
+          - 0
+          - 0
+          - 0
+          - 0
+          - 0
+          - 0
+          - 0
+          - 0
+          - 0
+          - 0
+          - 0
+          - 0
+        - volume: 2500
+          temperature: 293.15
+          moles:
+          - 0
+          - 6666.982
+          - 0
+          - 0
+          - 0
+          - 0
+          - 0
+          - 0
+          - 0
+          - 0
+          - 0
+          - 0
+          - 0
+          - 0
+          - 0
+          - 0
+        - volume: 2500
+          temperature: 293.15
+          moles:
+          - 6666.982
+          - 0
+          - 0
+          - 0
+          - 0
+          - 0
+          - 0
+          - 0
+          - 0
+          - 0
+          - 0
+          - 0
+          - 0
+          - 0
+          - 0
+          - 0
+        - volume: 2500
+          temperature: 293.15
+          moles:
+          - 0
+          - 0
+          - 0
+          - 6666.982
           - 0
           - 0
           - 0
@@ -1780,6 +1805,10 @@ entities:
           - 0
           - 0
           - 0
+          - 0
+          - 0
+          - 0
+          - 0
         - volume: 2500
           temperature: 293.15
           moles:
@@ -1795,9 +1824,14 @@ entities:
           - 0
           - 0
           - 0
+          - 0
+          - 0
+          - 0
+          - 0
         chunkSize: 4
     - type: GasTileOverlay
     - type: RadiationGridResistance
+    - type: ThermalSignature
 - proto: AirAlarm
   entities:
   - uid: 2
@@ -11563,22 +11597,20 @@ entities:
       rot: 3.141592653589793 rad
       pos: -5.5,35.5
       parent: 1
-- proto: GasMinerNitrogen
+- proto: GasMinerNitrogenTriad
   entities:
   - uid: 1652
     components:
     - type: Transform
       pos: 12.5,-16.5
       parent: 1
-- proto: GasMinerOxygen
+- proto: GasMinerOxygenTriad
   entities:
   - uid: 1653
     components:
     - type: Transform
       pos: 12.5,-18.5
       parent: 1
-- proto: GasMinerOxygenStationLarge
-  entities:
   - uid: 1654
     components:
     - type: Transform
@@ -17395,8 +17427,8 @@ entities:
       parent: 1
     missingComponents:
     - Destructible
-    - Anchorable
     - Damageable
+    - Anchorable
 - proto: ShuttersNormal
   entities:
   - uid: 3218
@@ -17860,6 +17892,8 @@ entities:
       rot: 3.141592653589793 rad
       pos: 14.5,-1.5
       parent: 1
+    - type: Fixtures
+      fixtures: {}
 - proto: SMESAdvanced
   entities:
   - uid: 1414

--- a/Resources/Maps/_NF/POI/medical.yml
+++ b/Resources/Maps/_NF/POI/medical.yml
@@ -4,7 +4,7 @@ meta:
   engineVersion: 271.2.0
   forkId: ""
   forkVersion: ""
-  time: 03/27/2026 19:48:27
+  time: 05/31/2026 12:41:42
   entityCount: 4338
 maps: []
 grids:
@@ -142,10 +142,10 @@ entities:
     - type: OccluderTree
     - type: SpreaderGrid
       spreadQueues:
-        MetalFoam: []
-        Puddle: []
         Kudzu: []
+        MetalFoam: []
         Smoke: []
+        Puddle: []
     - type: Shuttle
       dampingModifier: 0.25
     - type: GridPathfinding
@@ -3406,6 +3406,7 @@ entities:
     - type: RadiationGridResistance
     - type: ShipGridLock
       locked: False
+    - type: ThermalSignature
 - proto: ActionToggleInternals
   entities:
   - uid: 4
@@ -4804,7 +4805,7 @@ entities:
       pos: -6.5,5.5
       parent: 1
     - type: Door
-      secondsUntilStateChange: -60898.684
+      secondsUntilStateChange: -60951.418
       state: Opening
     - type: DeviceLinkSource
       lastSignals:
@@ -5005,7 +5006,7 @@ entities:
       pos: 1.5,21.5
       parent: 1
     - type: Door
-      secondsUntilStateChange: -38606.23
+      secondsUntilStateChange: -38658.965
       state: Opening
     - type: DeviceLinkSource
       lastSignals:
@@ -13942,14 +13943,14 @@ entities:
       parent: 1
     - type: AtmosPipeColor
       color: '#990000FF'
-- proto: GasMinerNitrogenStationLarge
+- proto: GasMinerNitrogenTriad
   entities:
   - uid: 1749
     components:
     - type: Transform
       pos: 4.5,13.5
       parent: 1
-- proto: GasMinerOxygenStationLarge
+- proto: GasMinerOxygenTriad
   entities:
   - uid: 1750
     components:
@@ -27509,6 +27510,8 @@ entities:
     - type: Transform
       pos: -17.5,35.5
       parent: 1
+    - type: Fixtures
+      fixtures: {}
 - proto: SinkWide
   entities:
   - uid: 3504
@@ -27516,17 +27519,23 @@ entities:
     - type: Transform
       pos: 5.5,36.5
       parent: 1
+    - type: Fixtures
+      fixtures: {}
   - uid: 3505
     components:
     - type: Transform
       rot: 1.5707963267948966 rad
       pos: -26.5,11.5
       parent: 1
+    - type: Fixtures
+      fixtures: {}
   - uid: 3506
     components:
     - type: Transform
       pos: -10.5,9.5
       parent: 1
+    - type: Fixtures
+      fixtures: {}
 - proto: SmartFridgeMedical
   entities:
   - uid: 3507
@@ -32489,7 +32498,7 @@ entities:
       lastSignals:
         DoorStatus: True
     - type: Door
-      secondsUntilStateChange: -9482.565
+      secondsUntilStateChange: -9535.302
       state: Opening
     - type: Airlock
       autoClose: False

--- a/Resources/Prototypes/Entities/Structures/Piping/Atmospherics/miners.yml
+++ b/Resources/Prototypes/Entities/Structures/Piping/Atmospherics/miners.yml
@@ -63,6 +63,16 @@
     - type: GasMiner
       maxExternalPressure: 4500
 
+- type: entity # Triad
+  name: O2 gas miner
+  parent: GasMinerOxygen
+  id: GasMinerOxygenTriad
+  suffix: Triad, 9000kPa
+  components:
+    - type: GasMiner
+      maxExternalPressure: 9000
+      spawnAmount: 6
+
 - type: entity
   name: N2 gas miner
   parent: GasMinerBase
@@ -90,6 +100,16 @@
     - type: GasMiner
       maxExternalPressure: 4500
 
+- type: entity # Triad
+  name: N2 gas miner
+  parent: GasMinerNitrogen
+  id: GasMinerNitrogenTriad
+  suffix: Triad, 9000kPa
+  components:
+    - type: GasMiner
+      maxExternalPressure: 9000
+      spawnAmount: 24
+
 - type: entity
   name: CO2 gas miner
   parent: GasMinerBase
@@ -105,7 +125,8 @@
   components:
     - type: GasMiner
       spawnGas: Plasma
-      maxExternalPressure: 50 # Mono
+      maxExternalPressure: 9000 # Mono, Triad: 50 to 9000
+      spawnAmount: 6 # Triad
 
 - type: entity
   name: tritium gas miner


### PR DESCRIPTION
## About the PR
Added a triad version oxy and nitrogen miner with 6 and 24 moles respectively. Fast enough to fill a 7x7 room in 3 and a half minutes but also not fast enough to make significant constant production on frezon and the likes. 

## Why / Balance
Previous miners were making 400 moles a second and even with an unoptimized setup a fellow great atmosian was able to generate 33 million in one shift through frezon production. 

I decided to leave in the station miners for two reasons. 1: Make replacing air less annoying really. It is not uncommon for large ships to siphon large quantity of air for refills of atmosphere. 2: Stations like sevastapol still remain an interesting site for atmosians to visit to siphon gas from without breaking the economy too hard. Instead you need to wait 75 minutes for 27k moles of plasma and 54k for oxygen. Since it is a contested site it is not unlikely for another player to just scoop it up while you are doing asteroid gas mining.

## Requirements
<!-- Confirm the following by placing an X in the brackets [X]: -->
- [ X] I have read relevant guidelines/documentation to this PR found on [our devwiki](https://monolith-station.github.io/mono-docs/).
- [ X] I have added media to this PR or it does not require an ingame showcase.
- [ X] I can confirm this PR contains either no AI-generated content, or AI-generated content that meets our guidelines.
<!-- You should understand that not following the above may get your PR closed at maintainer’s discretion -->
<!-- When using AI, make sure you are already proficient in creating whatever content you are attempting to generate and that you already have experience contributing to SS14. This means using AI to enhance your preexisting workflow, not vibecoding. -->

## How to test
Load release
Take gas analyzer
Witness the new and glorious moles per second

## Breaking changes
<!-- List any breaking changes, including namespaces, public class/method/field changes, prototype renames; and provide instructions for fixing them. -->

**Changelog**
<!-- Add a Changelog entry to make players aware of new features or changes that could affect gameplay.
Make sure to read the guidelines and take this Changelog template out of the comment block in order for it to show up.
Changelog must have a :cl: symbol, so the bot recognizes the changes and adds them to the game's changelog.
Remove this symbol for non-player facing PRs.-->
:cl:
- tweak: Adjusted oxy, plasma and nitrogen station miners from 400mol/s to 6, 6 and 24 respectively
