### PR TITLE
MRE (Meals, Really Excessive) Replacement and Removal

### DIFF
--- a/Resources/Prototypes/Catalog/Cargo/cargo_food.yml
+++ b/Resources/Prototypes/Catalog/Cargo/cargo_food.yml
@@ -20,16 +20,17 @@
   category: cargoproduct-category-name-food
   group: market
 
-- type: cargoProduct
-  id: FoodMRE
-  abstract: true # Frontier
-  icon:
-    sprite: Objects/Consumable/Food/snacks.rsi
-    state: nutribrick
-  product: CrateFoodMRE
-  cost: 1000
-  category: cargoproduct-category-name-food
-  group: market
+# Triad: removed the MRE crate from the cargo market
+#- type: cargoProduct
+#  id: FoodMRE
+#  abstract: true # Frontier
+#  icon:
+#    sprite: Objects/Consumable/Food/snacks.rsi
+#    state: nutribrick
+#  product: CrateFoodMRE
+#  cost: 1000
+#  category: cargoproduct-category-name-food
+#  group: market
 
 - type: cargoProduct
   id: FoodCook

--- a/Resources/Prototypes/Catalog/VendingMachines/Inventories/sustenance.yml
+++ b/Resources/Prototypes/Catalog/VendingMachines/Inventories/sustenance.yml
@@ -5,7 +5,8 @@
     FoodSnackNutribrick: 5
     FoodSnackMREBrownie: 5
     FoodCondimentPacketKetchup: 5
-    MonoMRE: 10 # Mono
+    # Triad: removed the MRE package from the sustenance vendor
+    # MonoMRE: 10 # Mono
   contrabandInventory:
     FoodTinMRE: 3
     FoodTinBeans: 3

--- a/Resources/Prototypes/Entities/Markers/Spawners/Random/salvage.yml
+++ b/Resources/Prototypes/Entities/Markers/Spawners/Random/salvage.yml
@@ -24,7 +24,8 @@
         - CrateServiceJanitorialSupplies
         - CrateHydroponicsSeedsMedicinal
         - CrateEmergencyInternals
-        - CrateFoodMRE
+        # Triad: removed the MRE crate from the salvage loot pool
+        # - CrateFoodMRE
         - CrateMaterialTextiles
         - CrateMedicalSupplies
         - CrateEngineeringCableBulk

--- a/Resources/Prototypes/_Mono/Catalogs/Fills/Boxes/emergency.yml
+++ b/Resources/Prototypes/_Mono/Catalogs/Fills/Boxes/emergency.yml
@@ -11,7 +11,7 @@
     - id: SpaceMedipen
     - id: EmergencyMedipen
     - id: Flare
-      amount: 2
+      amount: 1 # Triad: dropped from 2 to free a grid cell for the split MRE bar + water bottle below
     # Triad: revert Mono's combined MRE package to a single bar + water bottle
     # - id: MonoMRE # Mono - replace PSB and water bottle w/ MRE
     - id: FoodMREPSB
@@ -53,7 +53,7 @@
       - id: SpaceMedipen
       - id: EmergencyMedipen
       - id: Flare
-        amount: 2
+        amount: 1 # Triad: dropped from 2 to free a grid cell for the split MRE bar + water bottle below
       # Triad: revert Mono's combined MRE package to a single bar + water bottle
       # - id: MonoMRE # Mono - replace PSB and water bottle w/ MRE
       - id: FoodMREPSB
@@ -72,7 +72,7 @@
       - id: SpaceMedipen
       - id: EmergencyMedipen
       - id: Flare
-        amount: 2
+        amount: 1 # Triad: dropped from 2 to free a grid cell for the split MRE bar + water bottle below
       # Triad: revert Mono's combined MRE package to a single bar + water bottle
       # - id: MonoMRE # Mono - replace PSB and water bottle w/ MRE
       - id: FoodMREPSB

--- a/Resources/Prototypes/_Mono/Catalogs/Fills/Boxes/emergency.yml
+++ b/Resources/Prototypes/_Mono/Catalogs/Fills/Boxes/emergency.yml
@@ -12,7 +12,10 @@
     - id: EmergencyMedipen
     - id: Flare
       amount: 2
-    - id: MonoMRE # Mono - replace PSB and water bottle w/ MRE
+    # Triad: revert Mono's combined MRE package to a single bar + water bottle
+    # - id: MonoMRE # Mono - replace PSB and water bottle w/ MRE
+    - id: FoodMREPSB
+    - id: DrinkWaterBottleFull
     - id: CrowbarPocket
     - id: HandHeldMassScanner
   - type: Item
@@ -51,7 +54,10 @@
       - id: EmergencyMedipen
       - id: Flare
         amount: 2
-      - id: MonoMRE # Mono - replace PSB and water bottle w/ MRE
+      # Triad: revert Mono's combined MRE package to a single bar + water bottle
+      # - id: MonoMRE # Mono - replace PSB and water bottle w/ MRE
+      - id: FoodMREPSB
+      - id: DrinkWaterBottleFull
       - id: CrowbarPocket
       - id: HandHeldMassScanner
 
@@ -67,6 +73,9 @@
       - id: EmergencyMedipen
       - id: Flare
         amount: 2
-      - id: MonoMRE # Mono - replace PSB and water bottle w/ MRE
+      # Triad: revert Mono's combined MRE package to a single bar + water bottle
+      # - id: MonoMRE # Mono - replace PSB and water bottle w/ MRE
+      - id: FoodMREPSB
+      - id: DrinkWaterBottleFull
       - id: CrowbarPocket
       - id: HandHeldMassScanner

--- a/Resources/Prototypes/_Triad/Catalog/Fills/Boxes/emergency.yml
+++ b/Resources/Prototypes/_Triad/Catalog/Fills/Boxes/emergency.yml
@@ -9,7 +9,7 @@
       - id: SpaceMedipen
       - id: EmergencyMedipen
       - id: Flare
-        amount: 2
+        amount: 1 # Triad: dropped from 2 to free a grid cell for the split MRE bar + water bottle below
       # Triad: one MRE bar + water bottle instead of the full MonoMRE package
       - id: FoodMREPSB
       - id: DrinkWaterBottleFull

--- a/Resources/Prototypes/_Triad/Catalog/Fills/Boxes/emergency.yml
+++ b/Resources/Prototypes/_Triad/Catalog/Fills/Boxes/emergency.yml
@@ -10,6 +10,8 @@
       - id: EmergencyMedipen
       - id: Flare
         amount: 2
-      - id: MonoMRE # Mono - replace PSB and water bottle w/ MRE
+      # Triad: one MRE bar + water bottle instead of the full MonoMRE package
+      - id: FoodMREPSB
+      - id: DrinkWaterBottleFull
       - id: CrowbarPocket
       - id: HandHeldMassScanner


### PR DESCRIPTION
## About the PR
Trims the default survival ration. Each survival box used to hand out a full MRE package (two ration bricks, a bar, and a water bottle) on use; it now gives a single MRE bar and a bottle of water. MRE crates are also pulled from the salvage loot pool, the cargo market, and the sustenance vendor.

## Why / Balance
I've seen multiple complaints of a lack of kitchen culture here on the server where it's sorely missed from other forks. MREs allowing people to basically never interact with this part of the game for any reason (either on their own or visiting someone's kitchen to give them patronage) is sort of bogus in my opinion. Off the standard MRE that comes in the Survival Box you can go for literal hours without going hungry.

If this doesn't have the effect I think it will we can re-adjust in a few weeks to a month but I implore you to consider this as I think this is a small change that will have an outsized impact.

## Media
Imagine eating this? You can do better...

<img width="1024" height="768" alt="image" src="https://github.com/user-attachments/assets/5ebd9c1f-3b66-4433-aa92-bf23fe0d30fc" />

## Requirements
- [X] I have read relevant guidelines/documentation to this PR found on [our devwiki](https://monolith-station.github.io/mono-docs/).
- [X] I have added media to this PR or it does not require an ingame showcase.
- [X] I can confirm this PR contains either no AI-generated content, or AI-generated content that meets our guidelines.

## How to test
1. Spawn in with a survival loadout (any of oxygen / nitrogen / water vapor). Open the survival box: it should hold one MRE bar (`FoodMREPSB`) and one water bottle (`DrinkWaterBottleFull`) instead of a single `MonoMRE` package.
2. Open the cargo console: the MRE crate should no longer be orderable.
3. Run a salvage expedition / trigger `SalvageMaterialCrateSpawner`: no MRE crate in the drop pool.
4. Check a sustenance vending machine: no MRE package in stock.

## Breaking changes
None. The `MonoMRE`, `CrateFoodMRE`, and `FoodMRE` prototypes still exist; they are only removed from the default boxes, loot pool, cargo, and vendor. Upstream/`_Mono` lines are commented with `# Triad:` markers rather than deleted.

**Changelog**
:cl:
- tweak: Survival boxes now start with a single MRE bar and a bottle of water instead of a full MRE package.
- remove: MRE crates no longer appear in salvage loot or the cargo market, and the MRE package was pulled from the sustenance vending machine.