### PR TITLE
Shuttle Service IFF Flags (Port of Frontier #3164)

### DIFF
--- a/Content.Client/Shuttles/UI/MapScreen.xaml.cs
+++ b/Content.Client/Shuttles/UI/MapScreen.xaml.cs
@@ -393,9 +393,13 @@ public sealed partial class MapScreen : BoxContainer
                         : _detection.HandleUnknownMassLabel(grid.Owner)
                     : _entManager.GetComponent<MetaDataComponent>(grid.Owner).EntityName;
 
+                // Frontier: prepend the advertised-service flag tag (only when the label isn't hidden) so it survives truncation
+                var serviceFlagsPrefix = (!hideLabel && iffComp != null) ? _shuttles.GetServiceFlagsPrefix(iffComp.ServiceFlags) : string.Empty;
+
                 var gridObj = new GridMapObject()
                 {
-                    Name = name, // Mono
+                    Name = serviceFlagsPrefix + name, // Frontier service flags + Mono name
+                    ServiceFlags = iffComp?.ServiceFlags ?? ServiceFlags.None, // Frontier
                     Entity = grid.Owner,
                     HideButton = iffComp != null && (iffComp.Flags & IFFFlags.HideLabelAlways) != 0x0,
                 };

--- a/Content.Client/Shuttles/UI/NavScreen.xaml
+++ b/Content.Client/Shuttles/UI/NavScreen.xaml
@@ -99,11 +99,13 @@
                             TextAlign="Center"
                             StyleClasses="ButtonSquare"
                             ToggleMode="True"/>
+                    <!-- Frontier: hide player shuttles -->
                     <controls:Button Name="IFFShuttleToggle"
                              Text="{controls:Loc 'shuttle-console-iffshuttles-toggle'}"
                              TextAlign="Center"
                              StyleClasses="ButtonSquare"
                              ToggleMode="True"/>
+                    <!-- End Frontier: hide player shuttles -->
                     <controls:Button Name="DockToggle"
                             Text="{controls:Loc 'shuttle-console-dock-toggle'}"
                             TextAlign="Center"
@@ -182,6 +184,51 @@
                 </controls:BoxContainer>
                     </controls:PanelContainer>
                     <!-- End Frontier - Maximum Shuttle Speed -->
+
+                    <!-- Frontier - Service Flags -->
+                    <controls:PanelContainer Name="ServiceFlagsBox" VerticalExpand="True" HorizontalExpand="True" Margin="4 4 4 4">
+                        <controls:PanelContainer.PanelOverride>
+                            <graphics:StyleBoxFlat BorderThickness="2" BorderColor="#333333" BackgroundColor="#181818"/>
+                        </controls:PanelContainer.PanelOverride>
+                        <controls:BoxContainer Orientation="Vertical" HorizontalExpand="True">
+                            <controls:PanelContainer VerticalExpand="True" HorizontalExpand="True" Margin="2 2 2 6">
+                                <controls:PanelContainer.PanelOverride>
+                                    <graphics:StyleBoxFlat BorderThickness="2" BorderColor="#333333" BackgroundColor="#050505"/>
+                                </controls:PanelContainer.PanelOverride>
+                                <controls:Label Text="{controls:Loc 'shuttle-console-service-flags'}"
+                                       FontColorOverride="#00ff2a"
+                                       VerticalExpand="False"
+                                       HorizontalAlignment="Center"/>
+                            </controls:PanelContainer>
+                            <controls:BoxContainer Orientation="Horizontal" HorizontalExpand="True" Margin="2 0 2 2">
+                                <controls:Button Name="ServiceFlagServices"
+                                                 Text="{controls:Loc 'shuttle-console-service-flag-Services-label'}"
+                                                 TextAlign="Center"
+                                                 ToggleMode="True"
+                                                 ToolTip="{controls:Loc 'shuttle-console-service-flag-Services-description'}"
+                                                 StyleClasses="ButtonSquare"
+                                                 HorizontalExpand="True"
+                                                 MinWidth="60"/>
+                                <controls:Button Name="ServiceFlagTrade"
+                                                 Text="{controls:Loc 'shuttle-console-service-flag-Trade-label'}"
+                                                 TextAlign="Center"
+                                                 ToggleMode="True"
+                                                 ToolTip="{controls:Loc 'shuttle-console-service-flag-Trade-description'}"
+                                                 StyleClasses="ButtonSquare"
+                                                 HorizontalExpand="True"
+                                                 MinWidth="60"/>
+                                <controls:Button Name="ServiceFlagSocial"
+                                                 Text="{controls:Loc 'shuttle-console-service-flag-Social-label'}"
+                                                 TextAlign="Center"
+                                                 ToggleMode="True"
+                                                 ToolTip="{controls:Loc 'shuttle-console-service-flag-Social-description'}"
+                                                 StyleClasses="ButtonSquare"
+                                                 HorizontalExpand="True"
+                                                 MinWidth="60"/>
+                            </controls:BoxContainer>
+                        </controls:BoxContainer>
+                    </controls:PanelContainer>
+                    <!-- End Frontier - Service Flags -->
 
                     <!-- Network Port Buttons -->
                     <controls:PanelContainer VerticalExpand="True" HorizontalExpand="True" Margin="4 4 4 4">

--- a/Content.Client/Shuttles/UI/ShuttleConsoleWindow.xaml
+++ b/Content.Client/Shuttles/UI/ShuttleConsoleWindow.xaml
@@ -3,8 +3,8 @@
                       xmlns:ui="clr-namespace:Content.Client.Shuttles.UI"
                       xmlns:graphics="clr-namespace:Robust.Client.Graphics;assembly=Robust.Client"
                       Title="{Loc 'shuttle-console-window-title'}"
-                      SetSize="1000 910"
-                      MinSize="1000 910">
+                      SetSize="1000 980"
+                      MinSize="1000 980">
     <BoxContainer Orientation="Vertical">
         <PanelContainer VerticalExpand="True" HorizontalExpand="True" Margin="0 8 0 2">
             <PanelContainer.PanelOverride>

--- a/Content.Client/Shuttles/UI/ShuttleMapControl.xaml.cs
+++ b/Content.Client/Shuttles/UI/ShuttleMapControl.xaml.cs
@@ -420,11 +420,13 @@ public sealed partial class ShuttleMapControl : BaseShuttleControl
 
             // Force drawing it at this point.
             // Mono
+            // Frontier: prepend the advertised-service flag tag (only when the label isn't hidden) so the map radar matches the nav radar and map list
+            var serviceFlagsPrefix = (!hideLabel && iffComp != null) ? _shuttles.GetServiceFlagsPrefix(iffComp.ServiceFlags) : string.Empty;
             var iffText = hideLabel ?
                 detectionLevel == DetectionLevel.PartialDetected ?
                     Loc.GetString($"shuttle-console-signature-infrared")
                     : _detection.HandleUnknownMassLabel(grid.Owner)
-                : _shuttles.GetIFFLabel(grid, self: true, component: iffComp);
+                : serviceFlagsPrefix + _shuttles.GetIFFLabel(grid, self: true, component: iffComp);
 
             if (string.IsNullOrEmpty(iffText))
                 continue;

--- a/Content.Client/_NF/Shuttles/BUI/ShuttleConsoleBoundUserInterface.cs
+++ b/Content.Client/_NF/Shuttles/BUI/ShuttleConsoleBoundUserInterface.cs
@@ -3,6 +3,7 @@
 // See AGPLv3.txt for details.
 using Content.Client.Shuttles.UI;
 using Content.Shared._NF.Shuttles.Events;
+using Content.Shared.Shuttles.Components;
 
 namespace Content.Client.Shuttles.BUI
 {
@@ -14,6 +15,7 @@ namespace Content.Client.Shuttles.BUI
             _window.OnInertiaDampeningModeChanged += OnInertiaDampeningModeChanged;
             _window.OnMaxShuttleSpeedChanged += OnMaxShuttleSpeedChanged;
             _window.OnNetworkPortButtonPressed += OnNetworkPortButtonPressed;
+            _window.OnServiceFlagsChanged += OnServiceFlagsChanged; // Frontier
         }
         private void OnInertiaDampeningModeChanged(NetEntity? entityUid, InertiaDampeningMode mode)
         {
@@ -38,6 +40,16 @@ namespace Content.Client.Shuttles.BUI
             {
                 SourcePort = sourcePort,
                 TargetPort = targetPort
+            });
+        }
+
+        // Frontier: service flags
+        private void OnServiceFlagsChanged(NetEntity? entityUid, ServiceFlags flags)
+        {
+            SendMessage(new SetServiceFlagsRequest
+            {
+                ShuttleEntityUid = entityUid,
+                ServiceFlags = flags,
             });
         }
     }

--- a/Content.Client/_NF/Shuttles/UI/NavScreen.xaml.cs
+++ b/Content.Client/_NF/Shuttles/UI/NavScreen.xaml.cs
@@ -2,6 +2,7 @@
 // Copyright (c) 2024 New Frontiers Contributors
 // See AGPLv3.txt for details.
 using Content.Shared._NF.Shuttles.Events;
+using Content.Shared.Shuttles.Components;
 using Robust.Client.UserInterface.Controls;
 using System.Text.RegularExpressions;
 using System;
@@ -14,6 +15,7 @@ namespace Content.Client.Shuttles.UI
         public event Action<NetEntity?, InertiaDampeningMode>? OnInertiaDampeningModeChanged;
         public event Action<float?>? OnMaxShuttleSpeedChanged;
         public event Action<string, string>? OnNetworkPortButtonPressed;
+        public event Action<NetEntity?, ServiceFlags>? OnServiceFlagsChanged; // Frontier
 
         private void NfInitialize()
         {
@@ -48,6 +50,10 @@ namespace Content.Client.Shuttles.UI
             // Send off a request to get the current dampening mode.
             _entManager.TryGetNetEntity(_shuttleEntity, out var shuttle);
             OnInertiaDampeningModeChanged?.Invoke(shuttle, InertiaDampeningMode.Query);
+
+            ServiceFlagServices.OnPressed += _ => ToggleServiceFlags(ServiceFlags.Services);
+            ServiceFlagTrade.OnPressed += _ => ToggleServiceFlags(ServiceFlags.Trade);
+            ServiceFlagSocial.OnPressed += _ => ToggleServiceFlags(ServiceFlags.Social);
         }
 
         private void OnPortButtonPressed(string sourcePort, string targetPort)
@@ -67,10 +73,12 @@ namespace Content.Client.Shuttles.UI
             if (NavRadar.DampeningMode == InertiaDampeningMode.Station)
             {
                 DampenerModeButtons.Visible = false;
+                ServiceFlagsBox.Visible = false;
             }
             else
             {
                 DampenerModeButtons.Visible = true;
+                ServiceFlagsBox.Visible = true;
                 DampenerOff.Pressed = NavRadar.DampeningMode == InertiaDampeningMode.Off;
                 DampenerOn.Pressed = NavRadar.DampeningMode == InertiaDampeningMode.Dampen;
                 AnchorOn.Pressed = NavRadar.DampeningMode == InertiaDampeningMode.Anchor;
@@ -90,7 +98,10 @@ namespace Content.Client.Shuttles.UI
                 {
                     AnchorOn.Disabled = false;
                 }
+
+                ToggleServiceFlags(NavRadar.ServiceFlags, updateButtonsOnly: true); // Frontier
             }
+
         }
 
         // Frontier - Maximum IFF Distance
@@ -105,6 +116,43 @@ namespace Content.Client.Shuttles.UI
             MaximumShuttleSpeedValue.Text = Regex.Replace(MaximumShuttleSpeedValue.Text, "[^0-9]", "");
             float.TryParse(MaximumShuttleSpeedValue.Text, out var speed);
             OnMaxShuttleSpeedChanged?.Invoke(MaximumShuttleSpeedValue.Text == "" ? null : speed);
+        }
+
+        // Frontier - Service Flags
+        private void ToggleServiceFlags(ServiceFlags flags, bool updateButtonsOnly = false)
+        {
+            if (!updateButtonsOnly)
+            {
+                // Special handling for ServiceFlags.None
+                if (flags == ServiceFlags.None)
+                {
+                    // If None is being toggled, set it to None (clear all other flags)
+                    // No need to check if None is already set since that check will always be false
+                    NavRadar.ServiceFlags = ServiceFlags.None;
+                }
+                else
+                {
+                    // Toggle the requested flag
+                    NavRadar.ServiceFlags ^= flags;
+
+                    // If any flag other than None is set, make sure None is unset
+                    if (NavRadar.ServiceFlags != 0)
+                    {
+                        NavRadar.ServiceFlags &= ~ServiceFlags.None; // This is redundant since None is 0
+                    }
+                    // If toggling resulted in no flags, set None
+                    else
+                    {
+                        NavRadar.ServiceFlags = ServiceFlags.None;
+                    }
+                }
+                _entManager.TryGetNetEntity(_shuttleEntity, out var shuttle);
+                OnServiceFlagsChanged?.Invoke(shuttle, NavRadar.ServiceFlags);
+            }
+
+            ServiceFlagServices.Pressed = NavRadar.ServiceFlags.HasFlag(ServiceFlags.Services);
+            ServiceFlagTrade.Pressed = NavRadar.ServiceFlags.HasFlag(ServiceFlags.Trade);
+            ServiceFlagSocial.Pressed = NavRadar.ServiceFlags.HasFlag(ServiceFlags.Social);
         }
 
         private void NfAddShuttleDesignation(EntityUid? shuttle)

--- a/Content.Client/_NF/Shuttles/UI/ShuttleConsoleWindow.xaml.cs
+++ b/Content.Client/_NF/Shuttles/UI/ShuttleConsoleWindow.xaml.cs
@@ -2,6 +2,7 @@
 // Copyright (c) 2024 New Frontiers Contributors
 // See AGPLv3.txt for details.
 using Content.Shared._NF.Shuttles.Events;
+using Content.Shared.Shuttles.Components;
 
 namespace Content.Client.Shuttles.UI
 {
@@ -10,12 +11,17 @@ namespace Content.Client.Shuttles.UI
         public event Action<NetEntity?, InertiaDampeningMode>? OnInertiaDampeningModeChanged;
         public event Action<float?>? OnMaxShuttleSpeedChanged;
         public event Action<string, string>? OnNetworkPortButtonPressed;
+        public event Action<NetEntity?, ServiceFlags>? OnServiceFlagsChanged; // Frontier
 
         private void NfInitialize()
         {
             NavContainer.OnInertiaDampeningModeChanged += (entity, mode) =>
             {
                 OnInertiaDampeningModeChanged?.Invoke(entity, mode);
+            };
+            NavContainer.OnServiceFlagsChanged += (entity, flags) => // Frontier
+            {
+                OnServiceFlagsChanged?.Invoke(entity, flags);
             };
 
             NavContainer.OnMaxShuttleSpeedChanged += (maxSpeed) =>

--- a/Content.Client/_NF/Shuttles/UI/ShuttleNavControl.xaml.cs
+++ b/Content.Client/_NF/Shuttles/UI/ShuttleNavControl.xaml.cs
@@ -16,6 +16,7 @@ namespace Content.Client.Shuttles.UI
     public partial class ShuttleNavControl // Mono
     {
         public InertiaDampeningMode DampeningMode { get; set; }
+        public ServiceFlags ServiceFlags { get; set; } = ServiceFlags.None; // Frontier
 
         /// <summary>
         /// Whether the shuttle is currently in FTL. This is used to disable the Park button
@@ -34,6 +35,7 @@ namespace Content.Client.Shuttles.UI
             }
 
             DampeningMode = state.DampeningMode;
+            ServiceFlags = state.ServiceFlags; // Frontier
 
             // Check if the entity has an FTLComponent which indicates it's in FTL
             if (transform.GridUid != null)

--- a/Content.IntegrationTests/Tests/_NF/Shuttle/SharedShuttleSystemTest.cs
+++ b/Content.IntegrationTests/Tests/_NF/Shuttle/SharedShuttleSystemTest.cs
@@ -57,7 +57,7 @@ public sealed class ServiceFlagsSuffixTests
         }
 
         // Extract the characters between brackets
-        var characters = _shuttle.GetServiceFlagsPrefix(allFlags).Trim('[', ']');
+        var characters = _shuttle.GetServiceFlagsPrefix(allFlags).Trim('[', ']', ' ');
 
         // Check that we have three separate character combinations.
         Assert.Multiple(() =>
@@ -72,7 +72,7 @@ public sealed class ServiceFlagsSuffixTests
 
                 var oneFlagResult = _shuttle.GetServiceFlagsPrefix(flag);
                 // Extract the characters between brackets
-                var oneFlagCharacters = oneFlagResult.Trim('[', ']');
+                var oneFlagCharacters = oneFlagResult.Trim('[', ']', ' ');
                 // Check that we have three separate character combination.
                 Assert.That(oneFlagCharacters.Length, Is.EqualTo(1));
                 Assert.That(characters.Contains(oneFlagCharacters[0]), Is.True);

--- a/Content.IntegrationTests/Tests/_NF/Shuttle/SharedShuttleSystemTest.cs
+++ b/Content.IntegrationTests/Tests/_NF/Shuttle/SharedShuttleSystemTest.cs
@@ -43,7 +43,7 @@ public sealed class ServiceFlagsSuffixTests
     }
 
     [Test]
-    public void GetServiceFlagsPrefix_MultipleFlagsUniqueChars_ReturnsFirstCharacters()
+    public void GetServiceFlagsPrefix_MultipleFlags_ReturnsDistinctShortforms()
     {
         // Assemble all enum values into one
         var valueCount = 0;
@@ -71,7 +71,7 @@ public sealed class ServiceFlagsSuffixTests
                     continue;
 
                 var oneFlagResult = _shuttle.GetServiceFlagsPrefix(flag);
-                // Extract the characters between brackets and split by '|'
+                // Extract the characters between brackets
                 var oneFlagCharacters = oneFlagResult.Trim('[', ']');
                 // Check that we have three separate character combination.
                 Assert.That(oneFlagCharacters.Length, Is.EqualTo(1));

--- a/Content.IntegrationTests/Tests/_NF/Shuttle/SharedShuttleSystemTest.cs
+++ b/Content.IntegrationTests/Tests/_NF/Shuttle/SharedShuttleSystemTest.cs
@@ -1,0 +1,82 @@
+﻿using Content.IntegrationTests.Pair;
+using Content.Shared.Shuttles.Components;
+using Content.Shared.Shuttles.Systems;
+using Robust.Shared.GameObjects;
+
+namespace Content.IntegrationTests.Tests._NF.Shuttle;
+
+[TestFixture]
+[FixtureLifeCycle(LifeCycle.InstancePerTestCase)]
+public sealed class ServiceFlagsSuffixTests
+{
+    TestPair _pair;
+    SharedShuttleSystem _shuttle;
+
+    [SetUp]
+    public async Task Setup()
+    {
+        _pair = await PoolManager.GetServerClient();
+        var server = _pair.Server;
+
+        var entManager = server.ResolveDependency<IEntityManager>();
+        _shuttle = entManager.System<SharedShuttleSystem>();
+    }
+
+    [TearDown]
+    public async Task TearDownInternal()
+    {
+        await _pair.CleanReturnAsync();
+    }
+
+    [Test]
+    public void GetServiceFlagsPrefix_None_ReturnsEmptyString()
+    {
+        var result = _shuttle.GetServiceFlagsPrefix(ServiceFlags.None);
+        Assert.That(result, Is.EqualTo(string.Empty));
+    }
+
+    [Test]
+    public void GetServiceFlagsPrefix_SingleFlag_ReturnsSingleCharacter()
+    {
+        var result = _shuttle.GetServiceFlagsPrefix(ServiceFlags.Services);
+        Assert.That(result.Length, Is.Positive);
+    }
+
+    [Test]
+    public void GetServiceFlagsPrefix_MultipleFlagsUniqueChars_ReturnsFirstCharacters()
+    {
+        // Assemble all enum values into one
+        var valueCount = 0;
+        var allFlags = ServiceFlags.None;
+        foreach (var flag in Enum.GetValues<ServiceFlags>())
+        {
+            if (flag == ServiceFlags.None)
+                continue;
+            allFlags |= flag;
+            valueCount++;
+        }
+
+        // Extract the characters between brackets
+        var characters = _shuttle.GetServiceFlagsPrefix(allFlags).Trim('[', ']');
+
+        // Check that we have three separate character combinations.
+        Assert.Multiple(() =>
+        {
+            Assert.That(characters, Is.Unique);
+            Assert.That(characters.Length, Is.EqualTo(valueCount));
+
+            foreach (var flag in Enum.GetValues<ServiceFlags>())
+            {
+                if (flag == ServiceFlags.None)
+                    continue;
+
+                var oneFlagResult = _shuttle.GetServiceFlagsPrefix(flag);
+                // Extract the characters between brackets and split by '|'
+                var oneFlagCharacters = oneFlagResult.Trim('[', ']');
+                // Check that we have three separate character combination.
+                Assert.That(oneFlagCharacters.Length, Is.EqualTo(1));
+                Assert.That(characters.Contains(oneFlagCharacters[0]), Is.True);
+            }
+        });
+    }
+}

--- a/Content.Server/Shuttles/Systems/ShuttleConsoleSystem.cs
+++ b/Content.Server/Shuttles/Systems/ShuttleConsoleSystem.cs
@@ -409,7 +409,7 @@ public sealed partial class ShuttleConsoleSystem : SharedShuttleConsoleSystem
         }
         else
         {
-            navState = new NavInterfaceState(0f, null, null, new Dictionary<NetEntity, List<DockingPortState>>(), InertiaDampeningMode.Dampen); // Frontier: inertia dampening);
+            navState = new NavInterfaceState(0f, null, null, new Dictionary<NetEntity, List<DockingPortState>>(), InertiaDampeningMode.Dampen, ServiceFlags.None); // Frontier: inertia dampening);
             mapState = new ShuttleMapInterfaceState(
                 FTLState.Invalid,
                 default,
@@ -524,7 +524,7 @@ public sealed partial class ShuttleConsoleSystem : SharedShuttleConsoleSystem
     public NavInterfaceState GetNavState(Entity<RadarConsoleComponent?, TransformComponent?> entity, Dictionary<NetEntity, List<DockingPortState>> docks)
     {
         if (!Resolve(entity, ref entity.Comp1, ref entity.Comp2, false))
-            return new NavInterfaceState(SharedRadarConsoleSystem.DefaultMaxRange, null, null, docks, Shared._NF.Shuttles.Events.InertiaDampeningMode.Dampen); // Frontier: add inertia dampening
+            return new NavInterfaceState(SharedRadarConsoleSystem.DefaultMaxRange, null, null, docks, Shared._NF.Shuttles.Events.InertiaDampeningMode.Dampen, ServiceFlags.None); // Frontier: add inertia dampening
 
         // Get port names from the console component if available
         var portNames = new Dictionary<string, string>();
@@ -549,7 +549,7 @@ public sealed partial class ShuttleConsoleSystem : SharedShuttleConsoleSystem
         Dictionary<string, string>? portNames = null)
     {
         if (!Resolve(entity, ref entity.Comp1, ref entity.Comp2, false))
-            return new NavInterfaceState(SharedRadarConsoleSystem.DefaultMaxRange, GetNetCoordinates(coordinates), angle, docks, InertiaDampeningMode.Dampen); // Frontier: add inertial dampening
+            return new NavInterfaceState(SharedRadarConsoleSystem.DefaultMaxRange, GetNetCoordinates(coordinates), angle, docks, InertiaDampeningMode.Dampen, ServiceFlags.None); // Frontier: add inertial dampening
 
         return new NavInterfaceState(
             entity.Comp1.MaxRange,
@@ -557,6 +557,7 @@ public sealed partial class ShuttleConsoleSystem : SharedShuttleConsoleSystem
             angle,
             docks,
             _shuttle.NfGetInertiaDampeningMode(entity), // Frontier: inertia dampening
+            _shuttle.NfGetServiceFlags(entity), // Frontier: service flags
             portNames);
     }
 

--- a/Content.Server/_NF/Shuttles/Systems/ShuttleSystem.cs
+++ b/Content.Server/_NF/Shuttles/Systems/ShuttleSystem.cs
@@ -21,6 +21,7 @@ public sealed partial class ShuttleSystem
     {
         SubscribeLocalEvent<ShuttleConsoleComponent, SetInertiaDampeningRequest>(OnSetInertiaDampening);
         SubscribeLocalEvent<ShuttleConsoleComponent, SetMaxShuttleSpeedRequest>(OnSetMaxShuttleSpeed);
+        SubscribeLocalEvent<ShuttleConsoleComponent, SetServiceFlagsRequest>(NfSetServiceFlags); // Frontier
     }
 
     private bool SetInertiaDampening(EntityUid uid, PhysicsComponent physicsComponent, ShuttleComponent shuttleComponent, TransformComponent transform, InertiaDampeningMode mode)
@@ -139,6 +140,46 @@ public sealed partial class ShuttleSystem
                 SetInertiaDampening(uid, physicsComponent, shuttleComponent, transform, component.DampeningMode);
             }
         }
+    }
+
+    /// <summary>
+    /// Get the current service flags for this grid.
+    /// </summary>
+    public ServiceFlags NfGetServiceFlags(EntityUid uid)
+    {
+        var transform = Transform(uid);
+        // Get the grid entity from the console transform
+        if (!transform.GridUid.HasValue)
+            return ServiceFlags.None;
+
+        var gridUid = transform.GridUid.Value;
+
+        // Set the service flags on the IFFComponent.
+        if (!EntityManager.TryGetComponent<IFFComponent>(gridUid, out var iffComponent))
+            return ServiceFlags.None;
+
+        return iffComponent.ServiceFlags;
+    }
+
+    /// <summary>
+    /// Set the service flags for this grid.
+    /// </summary>
+    public void NfSetServiceFlags(EntityUid uid, ShuttleConsoleComponent component, SetServiceFlagsRequest args)
+    {
+        var transform = Transform(uid);
+        // Get the grid entity from the console transform
+        if (!transform.GridUid.HasValue)
+            return;
+
+        var gridUid = transform.GridUid.Value;
+
+        // Set the service flags on the IFFComponent.
+        if (!EntityManager.TryGetComponent<IFFComponent>(gridUid, out var iffComponent))
+            return;
+
+        iffComponent.ServiceFlags = args.ServiceFlags;
+        _console.RefreshShuttleConsoles(gridUid);
+        Dirty(gridUid, iffComponent);
     }
 
 }

--- a/Content.Server/_NF/Shuttles/Systems/ShuttleSystem.cs
+++ b/Content.Server/_NF/Shuttles/Systems/ShuttleSystem.cs
@@ -154,7 +154,7 @@ public sealed partial class ShuttleSystem
 
         var gridUid = transform.GridUid.Value;
 
-        // Set the service flags on the IFFComponent.
+        // Get the service flags from the IFFComponent.
         if (!EntityManager.TryGetComponent<IFFComponent>(gridUid, out var iffComponent))
             return ServiceFlags.None;
 
@@ -177,9 +177,8 @@ public sealed partial class ShuttleSystem
         if (!EntityManager.TryGetComponent<IFFComponent>(gridUid, out var iffComponent))
             return;
 
-        iffComponent.ServiceFlags = args.ServiceFlags;
-        _console.RefreshShuttleConsoles(gridUid);
-        Dirty(gridUid, iffComponent);
+        SetServiceFlags(gridUid, args.ServiceFlags, iffComponent); // honor the ReadOnly POI IFF guard instead of writing the field directly
+        _console.RefreshShuttleConsoles(gridUid); // push updated nav state to the shuttle consoles
     }
 
 }

--- a/Content.Shared/Shuttles/BUIStates/NavInterfaceState.cs
+++ b/Content.Shared/Shuttles/BUIStates/NavInterfaceState.cs
@@ -1,6 +1,7 @@
 using Robust.Shared.Map;
 using Robust.Shared.Serialization;
-using Content.Shared._NF.Shuttles.Events; // Frontier - InertiaDampeningMode access
+using Content.Shared._NF.Shuttles.Events;
+using Content.Shared.Shuttles.Components; // Frontier - InertiaDampeningMode access
 
 namespace Content.Shared.Shuttles.BUIStates;
 
@@ -42,6 +43,11 @@ public sealed class NavInterfaceState
     /// Frontier: settable coordinate visibility
     /// </summary>
     public bool HideCoords = false;
+
+    /// <summary>
+    /// Service Flags
+    /// </summary>
+    public ServiceFlags ServiceFlags { get; set; } // Frontier
     // End Frontier fields
 
     public NavInterfaceState(
@@ -50,6 +56,7 @@ public sealed class NavInterfaceState
         Angle? angle,
         Dictionary<NetEntity, List<DockingPortState>> docks,
         InertiaDampeningMode dampeningMode, // Frontier: add dampeningMode
+        ServiceFlags serviceFlags, // Frontier
         Dictionary<string, string>? networkPortNames = null)
     {
         MaxRange = maxRange;
@@ -57,6 +64,7 @@ public sealed class NavInterfaceState
         Angle = angle;
         Docks = docks;
         DampeningMode = dampeningMode; // Frontier
+        ServiceFlags = serviceFlags; // Frontier
         NetworkPortNames = networkPortNames ?? new Dictionary<string, string>();
     }
 }

--- a/Content.Shared/Shuttles/Components/IFFComponent.cs
+++ b/Content.Shared/Shuttles/Components/IFFComponent.cs
@@ -21,6 +21,12 @@ public sealed partial class IFFComponent : Component
     public IFFFlags Flags = IFFFlags.None;
 
     /// <summary>
+    /// Frontier: Shuttle service flags.
+    /// </summary>
+    [ViewVariables(VVAccess.ReadWrite), DataField, AutoNetworkedField]
+    public ServiceFlags ServiceFlags = ServiceFlags.None;
+
+    /// <summary>
     /// Color for this to show up on IFF.
     /// </summary>
     [ViewVariables(VVAccess.ReadWrite), DataField, AutoNetworkedField]
@@ -70,4 +76,16 @@ public enum IFFFlags : byte
     AlwaysShowColor = 16,
 
     // TODO: Need one that hides its outline, just replace it with a bunch of triangles or lines or something.
+}
+
+/// <summary>
+/// Frontier: Shuttle service flags.
+/// </summary>
+[Flags]
+public enum ServiceFlags : byte
+{
+    None = 0,
+    Services = 1,
+    Trade = 2,
+    Social = 4,
 }

--- a/Content.Shared/Shuttles/Systems/SharedShuttleSystem.IFF.cs
+++ b/Content.Shared/Shuttles/Systems/SharedShuttleSystem.IFF.cs
@@ -140,8 +140,9 @@ public abstract partial class SharedShuttleSystem
     }
 
     /// <summary>
-    /// Turns the service flags into a bracketed glyph tag for display, e.g. [M] for Medical.
-    /// Handles duplicate first characters by using the first two characters of the flag name.
+    /// Turns the set service flags into a bracketed tag for display.
+    /// Each set flag contributes its localized shortform string, falling back to the
+    /// first character of the flag name when no shortform string is defined.
     /// Rendered at the front of the IFF label so it isn't trimmed when the scan list truncates names.
     /// </summary>
     /// <param name="flags">The IFF flags to render.</param>

--- a/Content.Shared/Shuttles/Systems/SharedShuttleSystem.IFF.cs
+++ b/Content.Shared/Shuttles/Systems/SharedShuttleSystem.IFF.cs
@@ -143,7 +143,7 @@ public abstract partial class SharedShuttleSystem
     /// Turns the set service flags into a bracketed tag for display.
     /// Each set flag contributes its localized shortform string, falling back to the
     /// first character of the flag name when no shortform string is defined.
-    /// Rendered at the front of the IFF label so it isn't trimmed when the scan list truncates names.
+    /// Rendered at the front of the IFF label, with a trailing space before the name, so the tag isn't trimmed when the scan list truncates names.
     /// </summary>
     /// <param name="flags">The IFF flags to render.</param>
     /// <returns>The string to display, or empty when no flags are set.</returns>
@@ -163,7 +163,7 @@ public abstract partial class SharedShuttleSystem
             else
                 outputString = string.Concat(outputString, flag.ToString()[0]); // Fallback: use first character of string
         }
-        return $"[{outputString}]";
+        return $"[{outputString}] ";
     }
 
     [PublicAPI]

--- a/Content.Shared/Shuttles/Systems/SharedShuttleSystem.IFF.cs
+++ b/Content.Shared/Shuttles/Systems/SharedShuttleSystem.IFF.cs
@@ -68,7 +68,9 @@ public abstract partial class SharedShuttleSystem
             }
         }
 
-        var labelText = string.IsNullOrEmpty(entName) ? Loc.GetString("shuttle-console-unknown") : entName;
+        // Frontier: prepend the advertised-service flag tag so it survives label truncation in the scan list
+        var prefix = component != null ? GetServiceFlagsPrefix(component.ServiceFlags) : string.Empty;
+        var labelText = prefix + (string.IsNullOrEmpty(entName) ? Loc.GetString("shuttle-console-unknown") : entName);
 
         // Add company info if available
         if (companyName != null && companyColor != null)
@@ -113,6 +115,54 @@ public abstract partial class SharedShuttleSystem
         component.Flags |= flags;
         Dirty(gridUid, component);
         UpdateIFFInterfaces(gridUid, component);
+    }
+
+    /// <summary>
+    /// Frontier: Service flags
+    /// Sets the service flags for this grid to appear as on radar.
+    /// </summary>
+    /// <param name="gridUid">The grid to set the flags for.</param>
+    /// <param name="flags">The flags to set.</param>
+    /// <param name="component">The IFF component to set the flags for.</param>
+    public void SetServiceFlags(EntityUid gridUid, ServiceFlags flags, IFFComponent? component = null)
+    {
+        component ??= EnsureComp<IFFComponent>(gridUid);
+
+        if (component.ReadOnly) // Frontier: POI IFF protection
+            return; // Frontier: POI IFF protection
+
+        if (component.ServiceFlags == flags)
+            return;
+
+        component.ServiceFlags = flags;
+        Dirty(gridUid, component);
+        UpdateIFFInterfaces(gridUid, component);
+    }
+
+    /// <summary>
+    /// Turns the service flags into a bracketed glyph tag for display, e.g. [M] for Medical.
+    /// Handles duplicate first characters by using the first two characters of the flag name.
+    /// Rendered at the front of the IFF label so it isn't trimmed when the scan list truncates names.
+    /// </summary>
+    /// <param name="flags">The IFF flags to render.</param>
+    /// <returns>The string to display, or empty when no flags are set.</returns>
+    public string GetServiceFlagsPrefix(ServiceFlags flags)
+    {
+        if (flags == ServiceFlags.None)
+            return string.Empty;
+
+        string outputString = "";
+        foreach (var flag in Enum.GetValues<ServiceFlags>())
+        {
+            if (flag == ServiceFlags.None || !flags.HasFlag(flag))
+                continue;
+
+            if (Loc.TryGetString($"shuttle-console-service-flag-{flag}-shortform", out var flagString))
+                outputString = string.Concat(outputString, flagString);
+            else
+                outputString = string.Concat(outputString, flag.ToString()[0]); // Fallback: use first character of string
+        }
+        return $"[{outputString}]";
     }
 
     [PublicAPI]

--- a/Content.Shared/Shuttles/UI/MapObjects/GridMapObject.cs
+++ b/Content.Shared/Shuttles/UI/MapObjects/GridMapObject.cs
@@ -1,8 +1,13 @@
+using Content.Shared.Shuttles.Components;
+
 namespace Content.Shared.Shuttles.UI.MapObjects;
 
 public record struct GridMapObject : IMapObject
 {
     public string Name { get; set; }
+
+    // Frontier: Service flags
+    public ServiceFlags ServiceFlags { get; set; }
     public bool HideButton { get; init; }
     public EntityUid Entity;
 }

--- a/Content.Shared/_NF/Shuttles/Events/SetServiceFlagsRequest.cs
+++ b/Content.Shared/_NF/Shuttles/Events/SetServiceFlagsRequest.cs
@@ -1,0 +1,19 @@
+﻿// New Frontiers - This file is licensed under AGPLv3
+// Copyright (c) 2024 New Frontiers Contributors
+// See AGPLv3.txt for details.
+
+using Content.Shared.Shuttles.Components;
+using Robust.Shared.Serialization;
+
+namespace Content.Shared._NF.Shuttles.Events
+{
+    /// <summary>
+    /// Raised on the client when it wishes to change the inertial dampening of a ship.
+    /// </summary>
+    [Serializable, NetSerializable]
+    public sealed class SetServiceFlagsRequest : BoundUserInterfaceMessage
+    {
+        public NetEntity? ShuttleEntityUid { get; set; }
+        public ServiceFlags ServiceFlags { get; set; }
+    }
+}

--- a/Content.Shared/_NF/Shuttles/Events/SetServiceFlagsRequest.cs
+++ b/Content.Shared/_NF/Shuttles/Events/SetServiceFlagsRequest.cs
@@ -8,7 +8,7 @@ using Robust.Shared.Serialization;
 namespace Content.Shared._NF.Shuttles.Events
 {
     /// <summary>
-    /// Raised on the client when it wishes to change the inertial dampening of a ship.
+    /// Raised on the client when it wishes to change the advertised service flags of a ship.
     /// </summary>
     [Serializable, NetSerializable]
     public sealed class SetServiceFlagsRequest : BoundUserInterfaceMessage

--- a/Resources/Locale/en-US/_NF/shuttles/console.ftl
+++ b/Resources/Locale/en-US/_NF/shuttles/console.ftl
@@ -35,3 +35,17 @@ shuttle-console-device-button-5 = Port 5
 shuttle-console-device-button-6 = Port 6
 shuttle-console-device-button-7 = Port 7
 shuttle-console-device-button-8 = Port 8
+
+# Frontier - Service Flags
+shuttle-console-service-flags = Advertise Features
+shuttle-console-service-flag-Services-label = Services
+shuttle-console-service-flag-Trade-label = Shopping
+shuttle-console-service-flag-Social-label = Social
+
+shuttle-console-service-flag-Services-shortform = ♫
+shuttle-console-service-flag-Trade-shortform = $
+shuttle-console-service-flag-Social-shortform = ☺
+
+shuttle-console-service-flag-Services-description = Services (e.g. medical, dining, engineering) offered onboard.
+shuttle-console-service-flag-Trade-description = Goods sold onboard.
+shuttle-console-service-flag-Social-description = A social space to gather and hang out.


### PR DESCRIPTION
## About the PR
Ports Frontier's shuttle service-flag feature (NF #3164) onto the Monolith shuttle console. Pilots can toggle **Services / Shopping / Social** from the nav console; the choice tags the ship's IFF label on the nav and map radar so others can see what a docked ship offers at a glance.

## Why / Balance
Lets players spot where to get something (a medbay, a shop, a place to hang out) without having to call it over the radio. The flags are opt-in, default to none, only apply to shuttles, and carry no mechanical effect beyond the label tag.

This is adapted to the Monolith console rather than adopting Frontier's wholesale: Mono's company-name IFF label, detection/hide-label handling, dampener styling and the max-shuttle-speed box are all preserved, with the service flags grafted on in their own panel. The service tag is rendered at the *front* of the label (e.g. `[♫$☺] CIV-845`) so it survives name truncation in the scan list, and is suppressed on hidden/undetected grids.

## Media
<img width="757" height="746" alt="image" src="https://github.com/user-attachments/assets/c10c9fa2-5ad9-4557-82bd-d3eceb314ae8" />
<img width="757" height="750" alt="image" src="https://github.com/user-attachments/assets/201b69de-598f-493c-aad5-71d3b7c27f08" />


## Requirements
- [x] I have read relevant guidelines/documentation to this PR found on [our devwiki](https://monolith-station.github.io/mono-docs/).
- [x] I have added media to this PR or it does not require an ingame showcase.
- [x] I can confirm this PR contains either no AI-generated content, or AI-generated content that meets our guidelines.

## How to test
1. Board or buy a shuttle and open its shuttle console.
2. In the **Advertise Features** panel, toggle Services / Shopping / Social. Confirm the corresponding glyph tag appears at the front of the ship's designation on the nav radar.
3. Open another console (or the map view) and confirm the tag shows on that grid's blip too.
4. Toggle flags off and confirm the tag clears.
5. Close and reopen the console; confirm the flags persist.
6. Confirm the buttons only do anything on a shuttle (a station console shouldn't expose them).

## Breaking changes
`NavInterfaceState`'s constructor now takes a `ServiceFlags` argument (before the optional `networkPortNames`); any other caller constructing it directly must pass the new parameter. `SharedShuttleSystem.GetServiceFlagsPrefix` is the new helper name for the flag-tag string.

:cl:
- add: Shuttle consoles can now advertise Services, Shopping, and Social, tagging the ship's IFF label on the radar so others can see what it offers.
