### PR TITLE
Whisper and Subtle Is Not Passively Viewed by Admins

### DIFF
--- a/Content.Client/UserInterface/Systems/Chat/ChatUIController.cs
+++ b/Content.Client/UserInterface/Systems/Chat/ChatUIController.cs
@@ -581,12 +581,6 @@ public sealed partial class ChatUIController : UIController
             CanSendChannels |= ChatSelectChannel.Dead;
         }
 
-        if (_admin.HasFlag(AdminFlags.Pii) && _ghost is { IsGhost: true })
-        {
-            FilterableChannels |= ChatChannel.Subtle;
-            FilterableChannels |= ChatChannel.SubtleOOC;
-        }
-
         // only admins can see / filter asay
         if (_admin.HasFlag(AdminFlags.Adminchat))
         {

--- a/Content.Client/UserInterface/Systems/Chat/ChatUIController.cs
+++ b/Content.Client/UserInterface/Systems/Chat/ChatUIController.cs
@@ -570,7 +570,19 @@ public sealed partial class ChatUIController : UIController
                 CanSendChannels |= ChatSelectChannel.Subtle;
                 CanSendChannels |= ChatSelectChannel.SubtleOOC;
                 FilterableChannels |= ChatChannel.Whisper;
-                // Floofstation section end
+// Triad start
+FilterableChannels |= ChatChannel.Subtle;
+FilterableChannels |= ChatChannel.SubtleOOC;
+FilterableChannels |= ChatChannel.Whisper;
+// Triad end
+CanSendChannels |= ChatSelectChannel.Local;
+CanSendChannels |= ChatSelectChannel.Whisper;
+CanSendChannels |= ChatSelectChannel.Radio;
+CanSendChannels |= ChatSelectChannel.Emotes;
+// Floofstation section - only non-ghosts can chat in those
+CanSendChannels |= ChatSelectChannel.Subtle;
+CanSendChannels |= ChatSelectChannel.SubtleOOC;
+// Floofstation section end
             }
         }
 

--- a/Content.Client/UserInterface/Systems/Chat/ChatUIController.cs
+++ b/Content.Client/UserInterface/Systems/Chat/ChatUIController.cs
@@ -579,10 +579,10 @@ public sealed partial class ChatUIController : UIController
                 CanSendChannels |= ChatSelectChannel.Whisper;
                 CanSendChannels |= ChatSelectChannel.Radio;
                 CanSendChannels |= ChatSelectChannel.Emotes;
-               // Floofstation section - only non-ghosts can chat in those
-               CanSendChannels |= ChatSelectChannel.Subtle;
-               CanSendChannels |= ChatSelectChannel.SubtleOOC;
-               // Floofstation section end
+                // Floofstation section - only non-ghosts can chat in those
+                CanSendChannels |= ChatSelectChannel.Subtle;
+                CanSendChannels |= ChatSelectChannel.SubtleOOC;
+                // Floofstation section end
             }
         }
 

--- a/Content.Client/UserInterface/Systems/Chat/ChatUIController.cs
+++ b/Content.Client/UserInterface/Systems/Chat/ChatUIController.cs
@@ -550,7 +550,6 @@ public sealed partial class ChatUIController : UIController
         {
             // can always hear local / radio / emote / notifications when in the game
             FilterableChannels |= ChatChannel.Local;
-            FilterableChannels |= ChatChannel.Whisper;
             FilterableChannels |= ChatChannel.Radio;
             FilterableChannels |= ChatChannel.Emotes;
             FilterableChannels |= ChatChannel.Notifications;
@@ -564,11 +563,13 @@ public sealed partial class ChatUIController : UIController
             if (_ghost is not {IsGhost: true})
             {
                 CanSendChannels |= ChatSelectChannel.Local;
+                CanSendChannels |= ChatSelectChannel.Whisper;
                 CanSendChannels |= ChatSelectChannel.Radio;
                 CanSendChannels |= ChatSelectChannel.Emotes;
                 // Floofstation section - only non-ghosts can chat in those
                 CanSendChannels |= ChatSelectChannel.Subtle;
                 CanSendChannels |= ChatSelectChannel.SubtleOOC;
+                FilterableChannels |= ChatChannel.Whisper;
                 // Floofstation section end
             }
         }

--- a/Content.Client/UserInterface/Systems/Chat/ChatUIController.cs
+++ b/Content.Client/UserInterface/Systems/Chat/ChatUIController.cs
@@ -569,7 +569,6 @@ public sealed partial class ChatUIController : UIController
                 // Floofstation section - only non-ghosts can chat in those
                 CanSendChannels |= ChatSelectChannel.Subtle;
                 CanSendChannels |= ChatSelectChannel.SubtleOOC;
-                FilterableChannels |= ChatChannel.Whisper;
                 // Triad start
                 FilterableChannels |= ChatChannel.Subtle;
                 FilterableChannels |= ChatChannel.SubtleOOC;

--- a/Content.Client/UserInterface/Systems/Chat/ChatUIController.cs
+++ b/Content.Client/UserInterface/Systems/Chat/ChatUIController.cs
@@ -592,7 +592,10 @@ CanSendChannels |= ChatSelectChannel.SubtleOOC;
             FilterableChannels |= ChatChannel.Dead;
             CanSendChannels |= ChatSelectChannel.Dead;
         }
-
+        if (_admin.HasFlag(AdminFlags.Pii) && _ghost is { IsGhost: true })
+        {
+            FilterableChannels |= ChatChannel.Whisper;
+        }
         // only admins can see / filter asay
         if (_admin.HasFlag(AdminFlags.Adminchat))
         {

--- a/Content.Client/UserInterface/Systems/Chat/ChatUIController.cs
+++ b/Content.Client/UserInterface/Systems/Chat/ChatUIController.cs
@@ -592,6 +592,7 @@ public sealed partial class ChatUIController : UIController
             FilterableChannels |= ChatChannel.Dead;
             CanSendChannels |= ChatSelectChannel.Dead;
         }
+
         if (_admin.HasFlag(AdminFlags.Pii) && _ghost is { IsGhost: true })
         {
             FilterableChannels |= ChatChannel.Whisper;

--- a/Content.Client/UserInterface/Systems/Chat/ChatUIController.cs
+++ b/Content.Client/UserInterface/Systems/Chat/ChatUIController.cs
@@ -597,6 +597,7 @@ public sealed partial class ChatUIController : UIController
         {
             FilterableChannels |= ChatChannel.Whisper;
         }
+        
         // only admins can see / filter asay
         if (_admin.HasFlag(AdminFlags.Adminchat))
         {

--- a/Content.Client/UserInterface/Systems/Chat/ChatUIController.cs
+++ b/Content.Client/UserInterface/Systems/Chat/ChatUIController.cs
@@ -553,16 +553,12 @@ public sealed partial class ChatUIController : UIController
             FilterableChannels |= ChatChannel.Radio;
             FilterableChannels |= ChatChannel.Emotes;
             FilterableChannels |= ChatChannel.Notifications;
-            // Floofstation section
-            FilterableChannels |= ChatChannel.Subtle;
-            FilterableChannels |= ChatChannel.SubtleOOC;
-            // Floofstation section end
 
             // Can only send local / radio / emote when attached to a non-ghost entity.
             // TODO: this logic is iffy (checking if controlling something that's NOT a ghost), is there a better way to check this?
             if (_ghost is not {IsGhost: true})
             {
-                // Triad start
+                // Triad start - only non-ghosts can see subtle, whisper, and subtle OOC
                 FilterableChannels |= ChatChannel.Subtle;
                 FilterableChannels |= ChatChannel.SubtleOOC;
                 FilterableChannels |= ChatChannel.Whisper;
@@ -589,7 +585,7 @@ public sealed partial class ChatUIController : UIController
         {
             FilterableChannels |= ChatChannel.Whisper;
         }
-        
+
         // only admins can see / filter asay
         if (_admin.HasFlag(AdminFlags.Adminchat))
         {

--- a/Content.Client/UserInterface/Systems/Chat/ChatUIController.cs
+++ b/Content.Client/UserInterface/Systems/Chat/ChatUIController.cs
@@ -564,7 +564,6 @@ public sealed partial class ChatUIController : UIController
             if (_ghost is not {IsGhost: true})
             {
                 CanSendChannels |= ChatSelectChannel.Local;
-                CanSendChannels |= ChatSelectChannel.Whisper;
                 CanSendChannels |= ChatSelectChannel.Radio;
                 CanSendChannels |= ChatSelectChannel.Emotes;
                 // Floofstation section - only non-ghosts can chat in those

--- a/Content.Client/UserInterface/Systems/Chat/ChatUIController.cs
+++ b/Content.Client/UserInterface/Systems/Chat/ChatUIController.cs
@@ -562,10 +562,6 @@ public sealed partial class ChatUIController : UIController
             // TODO: this logic is iffy (checking if controlling something that's NOT a ghost), is there a better way to check this?
             if (_ghost is not {IsGhost: true})
             {
-                // Floofstation section - only non-ghosts can chat in those
-                CanSendChannels |= ChatSelectChannel.Subtle;
-                CanSendChannels |= ChatSelectChannel.SubtleOOC;
-                // Floofstation end
                 // Triad start
                 FilterableChannels |= ChatChannel.Subtle;
                 FilterableChannels |= ChatChannel.SubtleOOC;

--- a/Content.Client/UserInterface/Systems/Chat/ChatUIController.cs
+++ b/Content.Client/UserInterface/Systems/Chat/ChatUIController.cs
@@ -570,19 +570,19 @@ public sealed partial class ChatUIController : UIController
                 CanSendChannels |= ChatSelectChannel.Subtle;
                 CanSendChannels |= ChatSelectChannel.SubtleOOC;
                 FilterableChannels |= ChatChannel.Whisper;
-// Triad start
-FilterableChannels |= ChatChannel.Subtle;
-FilterableChannels |= ChatChannel.SubtleOOC;
-FilterableChannels |= ChatChannel.Whisper;
-// Triad end
-CanSendChannels |= ChatSelectChannel.Local;
-CanSendChannels |= ChatSelectChannel.Whisper;
-CanSendChannels |= ChatSelectChannel.Radio;
-CanSendChannels |= ChatSelectChannel.Emotes;
-// Floofstation section - only non-ghosts can chat in those
-CanSendChannels |= ChatSelectChannel.Subtle;
-CanSendChannels |= ChatSelectChannel.SubtleOOC;
-// Floofstation section end
+                // Triad start
+                FilterableChannels |= ChatChannel.Subtle;
+                FilterableChannels |= ChatChannel.SubtleOOC;
+                FilterableChannels |= ChatChannel.Whisper;
+                // Triad end
+                CanSendChannels |= ChatSelectChannel.Local;
+                CanSendChannels |= ChatSelectChannel.Whisper;
+                CanSendChannels |= ChatSelectChannel.Radio;
+                CanSendChannels |= ChatSelectChannel.Emotes;
+               // Floofstation section - only non-ghosts can chat in those
+               CanSendChannels |= ChatSelectChannel.Subtle;
+               CanSendChannels |= ChatSelectChannel.SubtleOOC;
+               // Floofstation section end
             }
         }
 

--- a/Content.Client/UserInterface/Systems/Chat/ChatUIController.cs
+++ b/Content.Client/UserInterface/Systems/Chat/ChatUIController.cs
@@ -562,13 +562,10 @@ public sealed partial class ChatUIController : UIController
             // TODO: this logic is iffy (checking if controlling something that's NOT a ghost), is there a better way to check this?
             if (_ghost is not {IsGhost: true})
             {
-                CanSendChannels |= ChatSelectChannel.Local;
-                CanSendChannels |= ChatSelectChannel.Whisper;
-                CanSendChannels |= ChatSelectChannel.Radio;
-                CanSendChannels |= ChatSelectChannel.Emotes;
                 // Floofstation section - only non-ghosts can chat in those
                 CanSendChannels |= ChatSelectChannel.Subtle;
                 CanSendChannels |= ChatSelectChannel.SubtleOOC;
+                // Floofstation end
                 // Triad start
                 FilterableChannels |= ChatChannel.Subtle;
                 FilterableChannels |= ChatChannel.SubtleOOC;


### PR DESCRIPTION
## About the PR
<!-- What did you change? -->
<!-- If this is a code change, summarize at high level how your new code works. This makes it easier to review. -->
Removes admins in aGhost from having subtle and subtle OOC so that people engaging in ERP can do such in privacy and admins don't risk being exposed to things passively that may make them uncomfortable

Removes whisper from ghosts so that people can chat quietly in privacy about their own personal RP

## Why / Balance
<!-- Discuss how this would affect game balance or explain why it was changed. Link any relevant discussions or issues. -->
We have consent rules for a reason, and we do not know what consent settings a ghost has and will be passively viewing by virtue of being a ghost.  This has been complained about multiple times.

This allows players to feel like their privacy is being respected, whilst if there are consent breaches or issues, a player can aHelp and administration still has access to the logs to see what happened.  They're simply not passively exposed to it.

## Media
<!-- Attach media if the PR makes ingame changes (clothing, items, features, etc). 
Small fixes/refactors are exempt. Media may be used in SS14 progress reports with credit. -->

## Requirements
<!-- Confirm the following by placing an X in the brackets [X]: -->
- [X] I have read relevant guidelines/documentation to this PR found on [our devwiki](https://monolith-station.github.io/mono-docs/).
- [X] I have added media to this PR or it does not require an ingame showcase.
- [X] I can confirm this PR contains either no AI-generated content, or AI-generated content that meets our guidelines.
<!-- You should understand that not following the above may get your PR closed at maintainer’s discretion -->
<!-- When using AI, make sure you are already proficient in creating whatever content you are attempting to generate and that you already have experience contributing to SS14. This means using AI to enhance your preexisting workflow, not vibecoding. -->

## How to test
<!-- Describe the way it can be tested -->

## Breaking changes
<!-- List any breaking changes, including namespaces, public class/method/field changes, prototype renames; and provide instructions for fixing them. -->

**Changelog**
<!-- Add a Changelog entry to make players aware of new features or changes that could affect gameplay.
Make sure to read the guidelines and take this Changelog template out of the comment block in order for it to show up.
Changelog must have a :cl: symbol, so the bot recognizes the changes and adds them to the game's changelog.
Remove this symbol for non-player facing PRs.-->
:cl:
- remove: Ghosts can no longer see whisper due to privacy concerns.
- remove: Admin ghosts can no longer see subtle and subtle OOC.