### PR TITLE
Port Upstream: Make Seed Non-Unique On Sample #42527

### DIFF
--- a/Content.Server/Botany/Systems/PlantHolderSystem.cs
+++ b/Content.Server/Botany/Systems/PlantHolderSystem.cs
@@ -283,6 +283,7 @@ public sealed class PlantHolderSystem : EntitySystem
             {
                 healthOverride = component.Health;
             }
+            component.Seed.Unique = false;
             var packetSeed = component.Seed;
             var seed = _botany.SpawnSeedPacket(packetSeed, Transform(args.User).Coordinates, args.User, healthOverride);
             _randomHelper.RandomOffset(seed, 0.25f);


### PR DESCRIPTION

## About the PR
Ports upstreams space-wizards/space-station-14/pull/42527/.
Makes clipped seeds no longer mutate with the plant in the tray.
## Why / Balance
Prevents some forms of mutation cheesing.
Allows clipping to save snapshots of plants, rather than needing to dig the plant out of tray.
## Technical details
Adds one line of code, to fix duplicated effects on seeds after sample.
## How to test
-Load Dev Environment.
-Before, clipping a seed and continuing to mutate the plant in tray, would reflect the mutations on the seed packet.
-Now, changes to the tray plant do not reflect in the clipped seed.

## Requirements
<!-- Confirm the following by placing an X in the brackets [X]: -->
- [X] I have read relevant guidelines/documentation to this PR found on [our devwiki](https://monolith-station.github.io/mono-docs/).
- [X] I have added media to this PR or it does not require an ingame showcase.
- [X] I can confirm this PR contains either no AI-generated content, or AI-generated content that meets our guidelines.
<!-- You should understand that not following the above may get your PR closed at maintainer’s discretion -->
<!-- When using AI, make sure you are already proficient in creating whatever content you are attempting to generate and that you already have experience contributing to SS14. This means using AI to enhance your preexisting workflow, not vibecoding. -->

**Changelog**
:cl:
- fix: Fixed seed packets being affected by the original plant even after clipping.