### PR TITLE
Fixes Wield Bonus Being Applied Inversely to the M90

### DIFF
--- a/Resources/Prototypes/_Goobstation/Entities/Objects/Weapons/Guns/Rifles/rifles.yml
+++ b/Resources/Prototypes/_Goobstation/Entities/Objects/Weapons/Guns/Rifles/rifles.yml
@@ -186,8 +186,8 @@
   - type: Appearance
   - type: GunRequiresWield
   - type: GunWieldBonus
-    minAngle: 10
-    maxAngle: 8
+    minAngle: -10 # Triad Edit -- Bugfix
+    maxAngle: -8  # Triad Edit -- Bugfix
 
 - type: entity
   name: CS Burner (12.7x99mm)


### PR DESCRIPTION
## About the PR
The M90 currently gets worse when you wield it. Kind of how some things, such as dough, get bigger when you pull on them.
This is not intended behavior so this PR aims to fix this.

## Why / Balance
A bugfix.

## Media
n/A

## Requirements
<!-- Confirm the following by placing an X in the brackets [X]: -->
- [X] I have read relevant guidelines/documentation to this PR found on [our devwiki](https://monolith-station.github.io/mono-docs/).
- [X] I have added media to this PR or it does not require an ingame showcase.
- [X] I can confirm this PR contains either no AI-generated content, or AI-generated content that meets our guidelines.
<!-- You should understand that not following the above may get your PR closed at maintainer’s discretion -->
<!-- When using AI, make sure you are already proficient in creating whatever content you are attempting to generate and that you already have experience contributing to SS14. This means using AI to enhance your preexisting workflow, not vibecoding. -->

## How to test
Spawn in. Rush LPB, die to the guns. Then die to the guns again. Then finally go in. Kill all NPCs. Then go to the loot pool. Be disappointed that its all M90. Use M90. M90 is no longer bad.

## Breaking changes
None


**Changelog**
:cl:
- fix: M90 wield bonus now works properly
