### PR TITLE
Adjust Guardian Damage From 0 to 2

### DIFF
--- a/Resources/Prototypes/Entities/Objects/Weapons/Guns/Projectiles/hitscan.yml
+++ b/Resources/Prototypes/Entities/Objects/Weapons/Guns/Projectiles/hitscan.yml
@@ -95,6 +95,16 @@
       types:
         Heat: 0 # Triad 1->0
 
+- type: entity  # Triad - With firerate 8, kill an unarmored person in 6.25 seconds
+  parent: BasicHitscan
+  id: RadLaserGuardian
+  categories: [ HideSpawnMenu ]
+  components:
+  - type: HitscanBasicDamage
+    damage:
+      types:
+        Heat: 2
+
 - type: entity
   parent: BasicHitscan
   id: XrayLaser

--- a/Resources/Prototypes/_NF/Entities/Mobs/NPCs/mob_hostile_rogue_ai.yml
+++ b/Resources/Prototypes/_NF/Entities/Mobs/NPCs/mob_hostile_rogue_ai.yml
@@ -1036,7 +1036,7 @@
   - type: Stamina
     critThreshold: 600
   - type: HitscanBatteryAmmoProvider
-    proto: RedLaserPractice # RedLaser
+    proto: RadLaserGuardian # Triad - 2 damage, 16 DPS
     fireCost: 10
   - type: Gun
     showExamineText: false


### PR DESCRIPTION
## About the PR
Guardians used the practice laser to do damage which was set to 0 in #113 
Added a unique laser type for the Guardian doing 2 damage of the previous 1, buffing it.

## Why / Balance
A DPS of 8 meant that the guardian needed 12.5 seconds to kill an unarmored human if every shot hits. A hunter drone has a DPS of 17.6, killing a person in 5.7 seconds. Making it 16 DPS means that a player has 6.25 seconds of face tanking before dying unarmored.

Assuming a player is wearing a merc hardsuit which you can get from start it is now 9 seconds of standing still and surviving.
If a player is using a laser rifle of a DPS of 32 then the boss would die in 14 seconds.

These numbers of course are just cases where the player and boss both stand still and hit each other without strategy and moving. It should be a proper boss to fear now.

**Changelog**
<!-- Add a Changelog entry to make players aware of new features or changes that could affect gameplay.
Make sure to read the guidelines and take this Changelog template out of the comment block in order for it to show up.
Changelog must have a :cl: symbol, so the bot recognizes the changes and adds them to the game's changelog.
Remove this symbol for non-player facing PRs.-->
:cl:
- tweak: Guardian Unit DPS buffed from 8 to 16
- fix: Guardian Unit doing 0 damage
