### PR TITLE
Buildable Greebles

### DIFF
--- a/Resources/Prototypes/_Mono/Entities/Structures/Decoration/greeble.yml
+++ b/Resources/Prototypes/_Mono/Entities/Structures/Decoration/greeble.yml
@@ -52,6 +52,11 @@
   - type: GridEdgeMarker
     begin: 0, -0.1
     end: 0, 1.5
+  # Triad changes - Buildable greebles.
+  - type: Construction
+    graph: TriadGreebles
+    node: antenna1
+  # End Triad
 
 - type: entity
   name: antenna
@@ -71,6 +76,11 @@
   - type: GridEdgeMarker
     begin: 0, -0.1
     end: 0, 1.2
+  # Triad changes - Buildable greebles.
+  - type: Construction
+    graph: TriadGreebles
+    node: antenna2
+  # End Triad
 
 - type: entity
   name: ELINT system
@@ -85,6 +95,11 @@
       sprite: _Mono/Structures/Decoration/Greeble/32x32.rsi
       layers:
         - state: elint1
+  # Triad changes - Buildable greebles.
+    - type: Construction
+      graph: TriadGreebles
+      node: elint1
+  # End Triad
 
 - type: entity
   name: radar panel
@@ -99,6 +114,11 @@
       sprite: _Mono/Structures/Decoration/Greeble/64x64.rsi
       layers:
         - state: radarpanel1
+  # Triad changes - Buildable greebles.
+    - type: Construction
+      graph: TriadGreebles
+      node: radarpanel1
+  # End Triad
 
 - type: entity
   name: radar panel
@@ -113,3 +133,8 @@
       sprite: _Mono/Structures/Decoration/Greeble/64x64.rsi
       layers:
         - state: radarpanel2
+  # Triad changes - Buildable greebles.
+    - type: Construction
+      graph: TriadGreebles
+      node: radarpanel2
+  # End Triad

--- a/Resources/Prototypes/_Triad/Recipes/Construction/Graphs/structures/greebles.yml
+++ b/Resources/Prototypes/_Triad/Recipes/Construction/Graphs/structures/greebles.yml
@@ -1,0 +1,107 @@
+- type: constructionGraph
+  id: TriadGreebles
+  start: start
+  graph:
+    - node: start
+      edges:
+        - to: antenna1
+          completed:
+            - !type:SnapToGrid { }
+          steps:
+            - material: MetalRod
+              amount: 10
+              doAfter: 10
+        - to: antenna2
+          completed:
+            - !type:SnapToGrid { }
+          steps:
+            - material: MetalRod
+              amount: 10
+              doAfter: 10
+        - to: elint1
+          completed:
+            - !type:SnapToGrid { }
+          steps:
+            - material: Steel
+              amount: 5
+              doAfter: 5
+        - to: radarpanel1
+          completed:
+            - !type:SnapToGrid { }
+          steps:
+            - material: Steel
+              amount: 10
+              doAfter: 10
+        - to: radarpanel2
+          completed:
+            - !type:SnapToGrid { }
+          steps:
+            - material: Steel
+              amount: 10
+              doAfter: 10
+
+    - node: antenna1
+      entity: GreebleAntenna1
+      edges:
+        - to: start
+          completed:
+            - !type:SpawnPrototype
+              prototype: PartRodMetal1
+              amount: 10
+            - !type:DeleteEntity
+          steps:
+            - tool: Screwing
+              doAfter: 2
+
+    - node: antenna2
+      entity: GreebleAntenna2
+      edges:
+        - to: start
+          completed:
+            - !type:SpawnPrototype
+              prototype: PartRodMetal1
+              amount: 10
+            - !type:DeleteEntity
+          steps:
+            - tool: Screwing
+              doAfter: 2
+
+    - node: elint1
+      entity: GreebleElint1
+      edges:
+        - to: start
+          completed:
+            - !type:SpawnPrototype
+              prototype: SheetSteel1
+              amount: 5
+            - !type:DeleteEntity
+          steps:
+            - tool: Screwing
+              doAfter: 4
+
+    - node: radarpanel1
+      entity: GreebleRadarpanel1
+      edges:
+        - to: start
+          completed:
+            - !type:SpawnPrototype
+              prototype: SheetSteel1
+              amount: 10
+            - !type:DeleteEntity
+          steps:
+            - tool: Screwing
+              doAfter: 4
+
+    - node: radarpanel2
+      entity: GreebleRadarpanel2
+      edges:
+        - to: start
+          completed:
+            - !type:SpawnPrototype
+              prototype: SheetSteel1
+              amount: 10
+            - !type:DeleteEntity
+          steps:
+            - tool: Screwing
+              doAfter: 4
+

--- a/Resources/Prototypes/_Triad/Recipes/Construction/greebles.yml
+++ b/Resources/Prototypes/_Triad/Recipes/Construction/greebles.yml
@@ -45,6 +45,7 @@
   canBuildInImpassable: false
   conditions:
   - !type:TileNotBlocked
+    failIfSpace: false
 
 - type: construction
   id: GreebleRadarpanel1
@@ -62,6 +63,7 @@
   canBuildInImpassable: false
   conditions:
   - !type:TileNotBlocked
+    failIfSpace: false
 
 - type: construction
   id: GreebleRadarpanel2
@@ -79,3 +81,4 @@
   canBuildInImpassable: false
   conditions:
   - !type:TileNotBlocked
+    failIfSpace: false

--- a/Resources/Prototypes/_Triad/Recipes/Construction/greebles.yml
+++ b/Resources/Prototypes/_Triad/Recipes/Construction/greebles.yml
@@ -1,0 +1,81 @@
+# These are all decorative.
+- type: construction
+  id: GreebleAntenna1
+  name: antenna
+  graph: TriadGreebles
+  startNode: start
+  targetNode: antenna1
+  category: construction-category-furniture
+  description: Like antennas to hell. Usually part of a ship or station's UHF communication systems. This is decorative.
+  icon:
+    sprite: _Mono/Structures/Decoration/Greeble/antennae.rsi
+    state: antenna1
+  objectType: Structure
+  placementMode: SnapgridCenter
+  canBuildInImpassable: true
+
+- type: construction
+  id: GreebleAntenna2
+  name: antenna
+  graph: TriadGreebles
+  startNode: start
+  targetNode: antenna2
+  category: construction-category-furniture
+  description: Like antennas to hell. Usually part of a ship or station's UHF communication systems. This is decorative.
+  icon:
+    sprite: _Mono/Structures/Decoration/Greeble/antennae.rsi
+    state: antenna2
+  objectType: Structure
+  placementMode: SnapgridCenter
+  canBuildInImpassable: true
+
+- type: construction
+  id: GreebleElint1
+  name: ELINT system
+  graph: TriadGreebles
+  startNode: start
+  targetNode: elint1
+  category: construction-category-structures
+  description: Used for reading noncommunication electromagnetic radiation and their properties, such as radar signals. Who gives a shit? This is decorative.
+  icon:
+    sprite: _Mono/Structures/Decoration/Greeble/32x32.rsi
+    state: elint1
+  objectType: Structure
+  placementMode: SnapgridCenter
+  canBuildInImpassable: false
+  conditions:
+  - !type:TileNotBlocked
+
+- type: construction
+  id: GreebleRadarpanel1
+  name: radar panel
+  graph: TriadGreebles
+  startNode: start
+  targetNode: radarpanel1
+  category: construction-category-furniture
+  description: Some kind of protective fiberglass panelling. Seen in various systems, such as weather and altitude mapping to military early-warning systems. If it's powerful enough, you might get cancer a bit faster! This is decorative.
+  icon:
+    sprite: _Mono/Structures/Decoration/Greeble/64x64.rsi
+    state: radarpanel1
+  objectType: Structure
+  placementMode: SnapgridCenter
+  canBuildInImpassable: false
+  conditions:
+  - !type:TileNotBlocked
+
+- type: construction
+  id: GreebleRadarpanel2
+  name: radar panel
+  graph: TriadGreebles
+  startNode: start
+  targetNode: radarpanel2
+  category: construction-category-furniture
+  description: Some kind of protective fiberglass panelling. Seen in various systems, such as weather and altitude mapping to military early-warning systems. If it's powerful enough, you might get cancer a bit faster! This is decorative.
+  icon:
+    sprite: _Mono/Structures/Decoration/Greeble/64x64.rsi
+    state: radarpanel2
+  objectType: Structure
+  placementMode: SnapgridCenter
+  canBuildInImpassable: false
+  conditions:
+  - !type:TileNotBlocked


### PR DESCRIPTION
## About the PR
This PR makes the decorative ship greebles buildable. 10 steel for the radar panels, 10 rods for the antennae, and 5 steel for the ELINT

## Why / Balance
It's decoration

## Media
<img width="435" height="630" alt="image" src="https://github.com/user-attachments/assets/542bdfb6-5585-498b-a92e-85ffb271b5a1" />

<img width="463" height="410" alt="image" src="https://github.com/user-attachments/assets/a62a4bc3-9418-4434-9048-2e5c5c4b5873" />


## Requirements
<!-- Confirm the following by placing an X in the brackets [X]: -->
- [X] I have read relevant guidelines/documentation to this PR found on [our devwiki](https://monolith-station.github.io/mono-docs/).
- [X] I have added media to this PR or it does not require an ingame showcase.
- [X] I can confirm this PR contains either no AI-generated content, or AI-generated content that meets our guidelines.
<!-- You should understand that not following the above may get your PR closed at maintainer’s discretion -->
<!-- When using AI, make sure you are already proficient in creating whatever content you are attempting to generate and that you already have experience contributing to SS14. This means using AI to enhance your preexisting workflow, not vibecoding. -->

## How to test
1. Build both antennas, the ELINT, and radar panel next to a space tile (facing into space, on lattice). They have an offset that the construction ghost can't show but that's okay
2. Deconstruct them. They return their resources

**Changelog**
:cl: Minerva
- add: Decorative ship greebles are now constructable and deconstructable: antennas, radar panels, and ELINT. These still have no function. Be aware that they have an offset the construction ghost doesn't show, allowing you to build "off the grid".