### PR TITLE
Add Avali and Hydrakin Cubes

### DIFF
--- a/Resources/Prototypes/Recipes/Lathes/Packs/animal_cubes.yml
+++ b/Resources/Prototypes/Recipes/Lathes/Packs/animal_cubes.yml
@@ -39,4 +39,6 @@
   - ResomiCube
   - GoblinCube
   - ChitinidCube
-#  - ProtogenCube #mono: retired
+  - AvaliCube # Triad
+  - HydrakinCube # Triad
+  - ProtogenCube #mono: retired; Triad: untired

--- a/Resources/Prototypes/_Goobstation/Entities/Objects/Specific/rehydrateable.yml
+++ b/Resources/Prototypes/_Goobstation/Entities/Objects/Specific/rehydrateable.yml
@@ -160,7 +160,7 @@
   - type: Rehydratable
     possibleSpawns:
     - MobTajaranRandom
-
+# Triad changes
 - type: entity
   parent: MonkeyCube
   id: AvaliCube # Triad
@@ -172,9 +172,10 @@
 
 - type: entity
   parent: MonkeyCube
-  id: HydrakinCube # Triad
+  id: HydrakinCube
   name: hydrakin cube
   components:
   - type: Rehydratable
     possibleSpawns:
     - MobHydrakinRandom
+# End Triad

--- a/Resources/Prototypes/_Goobstation/Entities/Objects/Specific/rehydrateable.yml
+++ b/Resources/Prototypes/_Goobstation/Entities/Objects/Specific/rehydrateable.yml
@@ -146,11 +146,12 @@
   parent: MonkeyCube
   id: ProtogenCube
   name: protogen cube
-  suffix: DO NOT MAP #mono: retired
+#  suffix: DO NOT MAP #mono: retired; Triad: Untired
   components:
   - type: Rehydratable
     possibleSpawns:
     - MobProtogenRandom # mono end
+
 - type: entity
   parent: MonkeyCube
   id: TajaranCube
@@ -159,3 +160,21 @@
   - type: Rehydratable
     possibleSpawns:
     - MobTajaranRandom
+
+- type: entity
+  parent: MonkeyCube
+  id: AvaliCube # Triad
+  name: avali cube
+  components:
+  - type: Rehydratable
+    possibleSpawns:
+    - MobAvaliRandom
+
+- type: entity
+  parent: MonkeyCube
+  id: HydrakinCube # Triad
+  name: hydrakin cube
+  components:
+  - type: Rehydratable
+    possibleSpawns:
+    - MobHydrakinRandom

--- a/Resources/Prototypes/_Goobstation/Recipes/Lathes/rehydrateable.yml
+++ b/Resources/Prototypes/_Goobstation/Recipes/Lathes/rehydrateable.yml
@@ -175,9 +175,9 @@
   materials:
     Biomass: 70
     Plasma: 250
-
+# Triad changes
 - type: latheRecipe
-  id: AvaliCube # Triad
+  id: AvaliCube
   result: AvaliCube
   categories:
   - Species
@@ -187,7 +187,7 @@
     Plasma: 250
 
 - type: latheRecipe
-  id: HydrakinCube # Triad
+  id: HydrakinCube
   result: HydrakinCube
   categories:
   - Species
@@ -195,3 +195,4 @@
   materials:
     Biomass: 80
     Plasma: 250
+# End Triad

--- a/Resources/Prototypes/_Goobstation/Recipes/Lathes/rehydrateable.yml
+++ b/Resources/Prototypes/_Goobstation/Recipes/Lathes/rehydrateable.yml
@@ -175,3 +175,23 @@
   materials:
     Biomass: 70
     Plasma: 250
+
+- type: latheRecipe
+  id: AvaliCube # Triad
+  result: AvaliCube
+  categories:
+  - Species
+  completetime: 30
+  materials:
+    Biomass: 80
+    Plasma: 250
+
+- type: latheRecipe
+  id: HydrakinCube # Triad
+  result: HydrakinCube
+  categories:
+  - Species
+  completetime: 30
+  materials:
+    Biomass: 80
+    Plasma: 250

--- a/Resources/Prototypes/_StarLight/Entities/Mobs/Player/avali.yml
+++ b/Resources/Prototypes/_StarLight/Entities/Mobs/Player/avali.yml
@@ -5,3 +5,15 @@
   id: MobAvali
 
 #chirp!
+
+- type: entity # Triad
+  parent: MobAvali
+  id: MobAvaliRandom
+  name: Urist McSpaceRaptor
+  suffix: Random Appearance
+  components:
+  - type: RandomHumanoidAppearance
+  - type: RandomMetadata
+    nameSegments:
+    - names_avali_first
+    - names_avali_packs


### PR DESCRIPTION
## About the PR
Add Avali and Hydrakin cubes to the biocube generator. Additionally, restore protogen cubes.

## Why / Balance
Missing species.


**Changelog**
<!-- Add a Changelog entry to make players aware of new features or changes that could affect gameplay.
Make sure to read the guidelines and take this Changelog template out of the comment block in order for it to show up.
Changelog must have a :cl: symbol, so the bot recognizes the changes and adds them to the game's changelog.
Remove this symbol for non-player facing PRs.-->
:cl:
- add: Avali, Protogen and Hydrakin cubes have been added to the biocube fabricator.
