### PR TITLE
RPD Update 3: Third Times the Charm

### DIFF
--- a/Content.Client/RCD/RCDConstructionGhostSystem.cs
+++ b/Content.Client/RCD/RCDConstructionGhostSystem.cs
@@ -1,5 +1,6 @@
 using Content.Client.Construction;
 using Content.Client.RPD;
+using Content.Shared.Atmos.Components;
 using Content.Shared.Hands.Components;
 using Content.Shared.Input;
 using Content.Shared.Interaction;
@@ -10,12 +11,14 @@ using Content.Shared.RCD.Systems;
 using Content.Shared.RPD;
 using Content.Shared.RPD.Components;
 using Robust.Client.Graphics;
+using Robust.Client.Input;
 using Robust.Client.Placement;
 using Robust.Client.Player;
 using Robust.Shared.Enums;
 using Robust.Shared.Input;
 using Robust.Shared.Input.Binding;
 using Robust.Shared.Map;
+using Robust.Shared.Maths;
 using Robust.Shared.Player;
 using Robust.Shared.Prototypes;
 
@@ -30,6 +33,11 @@ public sealed class RCDConstructionGhostSystem : EntitySystem
     [Dependency] private readonly RCDSystem _rcdSystem = default!;
     [Dependency] private readonly IEyeManager _eyeManager = default!;
     [Dependency] private readonly IOverlayManager _overlayManager = default!;
+    // Triad: deconstruct mode computes its own cursor-aimed layer (no placement mode runs), so it needs cursor +
+    // grid access the construct placement mode gets for free.
+    [Dependency] private readonly IInputManager _inputManager = default!;
+    [Dependency] private readonly IMapManager _mapManager = default!;
+    [Dependency] private readonly SharedTransformSystem _transformSystem = default!;
 
     private string _placementMode = typeof(AlignRCDConstruction).Name;
     // Triad: RPD port from funky-station — pipe-layer-aware ghost for RPDs + mirror-prototype flip toggle.
@@ -40,8 +48,8 @@ public sealed class RCDConstructionGhostSystem : EntitySystem
     private EntityUid? _lastHeldRcd;
     // End Triad
     private Direction _placementDirection = default;
-    // Triad: last eye rotation streamed while deconstructing; null forces a resend on tool swap / re-equip.
-    private float? _lastSentEyeRotation;
+    // Triad: last pipe layer pushed while deconstructing; null forces a resend on tool swap / re-equip.
+    private AtmosPipeLayer? _lastSentLayer;
 
     // Triad: RPD port from funky-station — bind R (EditorFlipObject) to toggle the mirrored variant of the
     // currently selected RCD recipe (e.g. gas filter flipped). Mirror state is networked to the server via
@@ -131,7 +139,7 @@ public sealed class RCDConstructionGhostSystem : EntitySystem
             // Triad: drop the cached flip state so we don't leak it onto whatever tool the player picks up next.
             _lastHeldRcd = null;
             _useMirrorPrototype = false;
-            _lastSentEyeRotation = null;
+            _lastSentLayer = null;
             // End Triad
             return;
         }
@@ -142,7 +150,7 @@ public sealed class RCDConstructionGhostSystem : EntitySystem
         {
             _lastHeldRcd = heldEntity;
             _useMirrorPrototype = rcd.UseMirrorPrototype;
-            _lastSentEyeRotation = null; // Triad: force a fresh eye-rotation send for the newly held tool.
+            _lastSentLayer = null; // Triad: force a fresh layer send for the newly held tool.
         }
         // End Triad
 
@@ -156,10 +164,10 @@ public sealed class RCDConstructionGhostSystem : EntitySystem
             if (placerIsRCD)
                 _placementManager.Clear();
 
-            // Triad: no placement mode runs in deconstruct mode, so stream eye rotation here the way the construct
-            // placement mode does — the server reproduces the operator's cursor-aimed pipe layer from it to pick
-            // which covered pipe to chew. On change only, to stay off the per-frame network path.
-            StreamEyeRotation(heldEntity.Value);
+            // Triad: no placement mode runs in deconstruct mode, so compute the cursor-aimed pipe layer here the way
+            // the construct placement mode does and push it. The server uses it to pick which covered pipe to chew.
+            // On change only, to stay off the per-frame network path.
+            StreamLayer(heldEntity.Value);
             return;
         }
         // End Triad
@@ -213,16 +221,31 @@ public sealed class RCDConstructionGhostSystem : EntitySystem
         _placementManager.BeginPlacing(newObjInfo);
     }
 
-    // Triad: mirror of AlignRPDAtmosPipeLayers.UpdateEyeRotation for deconstruct mode, which runs no placement mode.
-    // Streams the local eye rotation to the server (on change) so RPDSystem can compute the cursor-aimed pipe layer
-    // when resolving which covered pipe to deconstruct.
-    private void StreamEyeRotation(EntityUid heldEntity)
+    // Triad: deconstruct runs no placement mode, so compute the cursor-aimed pipe layer here (mirroring the construct
+    // placement mode's math) and push it on change. The server uses it to pick which covered pipe to chew.
+    private void StreamLayer(EntityUid heldEntity)
     {
-        var rotation = (float) _eyeManager.CurrentEye.Rotation.Theta;
-        if (_lastSentEyeRotation == rotation)
+        var mouseScreen = _inputManager.MouseScreenPosition;
+        if (!mouseScreen.IsValid)
             return;
 
-        _lastSentEyeRotation = rotation;
-        RaiseNetworkEvent(new RPDEyeRotationEvent(GetNetEntity(heldEntity), rotation));
+        var mouseMap = _eyeManager.PixelToMap(mouseScreen.Position);
+        if (!_mapManager.TryFindGridAt(mouseMap, out var gridUid, out var grid))
+            return;
+
+        var localPos = System.Numerics.Vector2.Transform(mouseMap.Position, _transformSystem.GetInvWorldMatrix(gridUid));
+        var tileSize = grid.TileSize;
+        var indices = new Vector2i((int) MathF.Floor(localPos.X / tileSize), (int) MathF.Floor(localPos.Y / tileSize));
+        var tileCenterLocal = new System.Numerics.Vector2((indices.X + 0.5f) * tileSize, (indices.Y + 0.5f) * tileSize);
+        var mouseDiff = localPos - tileCenterLocal;
+
+        var gridRotation = _transformSystem.GetWorldRotation(gridUid);
+        var layer = RPDLayerMath.PickLayer(mouseDiff, _eyeManager.CurrentEye.Rotation, gridRotation);
+
+        if (_lastSentLayer == layer)
+            return;
+
+        _lastSentLayer = layer;
+        RaiseNetworkEvent(new RPDLayerSelectEvent(GetNetEntity(heldEntity), layer));
     }
 }

--- a/Content.Client/RCD/RCDConstructionGhostSystem.cs
+++ b/Content.Client/RCD/RCDConstructionGhostSystem.cs
@@ -155,6 +155,11 @@ public sealed class RCDConstructionGhostSystem : EntitySystem
         {
             if (placerIsRCD)
                 _placementManager.Clear();
+
+            // Triad: no placement mode runs in deconstruct mode, so stream eye rotation here the way the construct
+            // placement mode does — the server reproduces the operator's cursor-aimed pipe layer from it to pick
+            // which covered pipe to chew. On change only, to stay off the per-frame network path.
+            StreamEyeRotation(heldEntity.Value);
             return;
         }
         // End Triad

--- a/Content.Client/RCD/RCDConstructionGhostSystem.cs
+++ b/Content.Client/RCD/RCDConstructionGhostSystem.cs
@@ -155,11 +155,6 @@ public sealed class RCDConstructionGhostSystem : EntitySystem
         {
             if (placerIsRCD)
                 _placementManager.Clear();
-
-            // Triad: no placement mode runs in deconstruct mode, so stream eye rotation here the way the construct
-            // placement mode does — the server reproduces the operator's cursor-aimed pipe layer from it to pick
-            // which covered pipe to chew. On change only, to stay off the per-frame network path.
-            StreamEyeRotation(heldEntity.Value);
             return;
         }
         // End Triad

--- a/Content.Client/RPD/AlignRPDAtmosPipeLayers.cs
+++ b/Content.Client/RPD/AlignRPDAtmosPipeLayers.cs
@@ -50,18 +50,12 @@ public sealed class AlignRPDAtmosPipeLayers : PlacementMode
 
     private const float SearchBoxSize = 2f;
     private const float PlaceColorBaseAlpha = 0.5f;
-    private const float GuideRadius = 0.1f;
-
-    // 7 px from tile center on a 32 px tile — leaves room for three guide circles without overlapping the
-    // central one.
-    private const float GuideOffsetInTileUnits = 7f / 32f;
 
     // Per-instance (not static) so a tool swap doesn't leave stale layer/rotation state behind. A new placement
     // session starts at Primary with no eye rotation cached, forcing the first send.
     private EntityCoordinates _mouseCoordsRaw = default;
     private AtmosPipeLayer _currentLayer = AtmosPipeLayer.Primary;
     private AtmosPipeLayer? _lastSentLayer = null;
-    private readonly Color _guideColor = new(0, 0, 0.5785f);
 
     public AlignRPDAtmosPipeLayers(PlacementManager pMan) : base(pMan)
     {
@@ -89,18 +83,10 @@ public sealed class AlignRPDAtmosPipeLayers : PlacementMode
 
         if (pManager.PlacementType == PlacementTypes.None)
         {
-            // Draw three guide dots: center (Primary), and two flanking dots along the camera-relative cardinal
-            // axis (Secondary on the NE/E side, Tertiary on SW/W). The flip via `multi` keeps the guides on a
-            // consistent screen-relative axis as the grid rotates.
+            // Three guide dots showing the cursor-quadrant layer aim; see RPDLayerGuide.
             var gridRotation = _transformSystem.GetWorldRotation(gridUid.Value);
             var worldPosition = _mapSystem.LocalToWorld(gridUid.Value, grid, MouseCoords.Position);
-            var direction = (_eyeManager.CurrentEye.Rotation + gridRotation + Math.PI / 2).GetCardinalDir();
-            var multi = (direction == Direction.North || direction == Direction.South) ? -1f : 1f;
-            var offset = gridRotation.RotateVec(new Vector2(multi * GuideOffsetInTileUnits, GuideOffsetInTileUnits));
-
-            args.WorldHandle.DrawCircle(worldPosition, GuideRadius, _guideColor);
-            args.WorldHandle.DrawCircle(worldPosition + offset, GuideRadius, _guideColor);
-            args.WorldHandle.DrawCircle(worldPosition - offset, GuideRadius, _guideColor);
+            RPDLayerGuide.Draw(args.WorldHandle, worldPosition, gridRotation, _eyeManager.CurrentEye.Rotation);
         }
 
         base.Render(args);

--- a/Content.Client/RPD/AlignRPDAtmosPipeLayers.cs
+++ b/Content.Client/RPD/AlignRPDAtmosPipeLayers.cs
@@ -60,7 +60,7 @@ public sealed class AlignRPDAtmosPipeLayers : PlacementMode
     // session starts at Primary with no eye rotation cached, forcing the first send.
     private EntityCoordinates _mouseCoordsRaw = default;
     private AtmosPipeLayer _currentLayer = AtmosPipeLayer.Primary;
-    private float? _currentEyeRotation = null;
+    private AtmosPipeLayer? _lastSentLayer = null;
     private readonly Color _guideColor = new(0, 0, 0.5785f);
 
     public AlignRPDAtmosPipeLayers(PlacementManager pMan) : base(pMan)
@@ -144,23 +144,23 @@ public sealed class AlignRPDAtmosPipeLayers : PlacementMode
         {
             if (newLayer != _currentLayer)
                 _currentLayer = newLayer;
-            UpdateEyeRotation(heldEntity, _eyeManager.CurrentEye.Rotation);
+            SendLayer(heldEntity);
         }
 
         UpdatePlacer(_currentLayer);
     }
 
     /// <summary>
-    /// Sends eye rotation to the server only when it changes. Because <see cref="_currentEyeRotation"/> is an
-    /// instance field initialized to <c>null</c>, the first call in a new placement session always sends — fixing
-    /// the stale-eye-rotation-after-tool-swap window the static version had.
+    /// Sends the cursor-aimed pipe layer to the server only when it changes. The layer is exactly what the ghost
+    /// displays, so the commit lands on the layer the operator sees. Instance field initialized to <c>null</c>
+    /// forces the first send in a new placement session, fixing the stale-after-tool-swap window the old version had.
     /// </summary>
-    private void UpdateEyeRotation(EntityUid heldEntity, Angle eyeRotation)
+    private void SendLayer(EntityUid heldEntity)
     {
-        if (_currentEyeRotation == eyeRotation.Theta)
+        if (_lastSentLayer == _currentLayer)
             return;
-        _currentEyeRotation = (float) eyeRotation.Theta;
-        _entityNetwork.SendSystemNetworkMessage(new RPDEyeRotationEvent(_entityManager.GetNetEntity(heldEntity), _currentEyeRotation));
+        _lastSentLayer = _currentLayer;
+        _entityNetwork.SendSystemNetworkMessage(new RPDLayerSelectEvent(_entityManager.GetNetEntity(heldEntity), _currentLayer));
     }
 
     private void UpdatePlacer(AtmosPipeLayer layer)

--- a/Content.Client/RPD/RPDDeconstructLayerGuideOverlay.cs
+++ b/Content.Client/RPD/RPDDeconstructLayerGuideOverlay.cs
@@ -40,11 +40,6 @@ public sealed class RPDDeconstructLayerGuideOverlay : Overlay
     private readonly SharedMapSystem _mapSystem;
     private readonly SharedTransformSystem _transform;
 
-    // Mirror the construct guide's geometry and color (AlignRPDAtmosPipeLayers) so both previews read identically.
-    private const float GuideRadius = 0.1f;
-    private const float GuideOffsetInTileUnits = 7f / 32f;
-    private readonly Color _guideColor = new(0, 0, 0.5785f);
-
     public override OverlaySpace Space => OverlaySpace.WorldSpace;
 
     public RPDDeconstructLayerGuideOverlay()
@@ -99,15 +94,8 @@ public sealed class RPDDeconstructLayerGuideOverlay : Overlay
         var tileCenterLocal = new Vector2((indices.X + 0.5f) * tileSize, (indices.Y + 0.5f) * tileSize);
         var worldPosition = _mapSystem.LocalToWorld(gridUid, grid, tileCenterLocal);
 
-        // Flank the center dot along a screen-relative axis, flipping with grid rotation so the dots stay put on
-        // screen as the grid turns (identical math to AlignRPDAtmosPipeLayers.Render).
+        // Three guide dots showing the cursor-quadrant layer aim; see RPDLayerGuide.
         var gridRotation = _transform.GetWorldRotation(gridUid);
-        var direction = (_eye.CurrentEye.Rotation + gridRotation + Math.PI / 2).GetCardinalDir();
-        var multi = (direction == Direction.North || direction == Direction.South) ? -1f : 1f;
-        var offset = gridRotation.RotateVec(new Vector2(multi * GuideOffsetInTileUnits, GuideOffsetInTileUnits));
-
-        args.WorldHandle.DrawCircle(worldPosition, GuideRadius, _guideColor);
-        args.WorldHandle.DrawCircle(worldPosition + offset, GuideRadius, _guideColor);
-        args.WorldHandle.DrawCircle(worldPosition - offset, GuideRadius, _guideColor);
+        RPDLayerGuide.Draw(args.WorldHandle, worldPosition, gridRotation, _eye.CurrentEye.Rotation);
     }
 }

--- a/Content.Client/RPD/RPDLayerGuide.cs
+++ b/Content.Client/RPD/RPDLayerGuide.cs
@@ -1,0 +1,38 @@
+// SPDX-FileCopyrightText: 2026 Triad Sector
+//
+// SPDX-License-Identifier: AGPL-3.0-or-later
+
+using System.Numerics;
+using Robust.Client.Graphics;
+using Robust.Shared.Enums;
+using Robust.Shared.Maths;
+
+namespace Content.Client.RPD;
+
+/// <summary>
+/// Triad: shared draw for the RPD's three pipe-layer aim dots, center = Primary, two flanking = Secondary (NE/E)
+/// and Tertiary (SW/W) on a screen-relative axis that flips with grid rotation. Used by the construct placement
+/// preview (<see cref="AlignRPDAtmosPipeLayers"/>) and the deconstruct overlay
+/// (<see cref="RPDDeconstructLayerGuideOverlay"/>) so both read identically. The upstream hand-placement mode
+/// (AlignAtmosPipeLayers) keeps its own copy; we don't modify upstream for this.
+/// </summary>
+public static class RPDLayerGuide
+{
+    private const float Radius = 0.1f;
+
+    // 7 px from tile center on a 32 px tile: room for three dots without overlapping the central one.
+    private const float OffsetInTileUnits = 7f / 32f;
+
+    private static readonly Color GuideColor = new(0, 0, 0.5785f);
+
+    public static void Draw(DrawingHandleWorld handle, Vector2 tileCenterWorld, Angle gridRotation, Angle eyeRotation)
+    {
+        var direction = (eyeRotation + gridRotation + Math.PI / 2).GetCardinalDir();
+        var multi = (direction == Direction.North || direction == Direction.South) ? -1f : 1f;
+        var offset = gridRotation.RotateVec(new Vector2(multi * OffsetInTileUnits, OffsetInTileUnits));
+
+        handle.DrawCircle(tileCenterWorld, Radius, GuideColor);
+        handle.DrawCircle(tileCenterWorld + offset, Radius, GuideColor);
+        handle.DrawCircle(tileCenterWorld - offset, Radius, GuideColor);
+    }
+}

--- a/Content.IntegrationTests/Tests/RPD/RPDCoexistenceTest.cs
+++ b/Content.IntegrationTests/Tests/RPD/RPDCoexistenceTest.cs
@@ -1,0 +1,54 @@
+#nullable enable
+using Content.Server.Atmos.EntitySystems;
+using Content.Shared.Atmos;
+using Content.Shared.Atmos.Components;
+using Content.Shared.Coordinates;
+using Robust.Shared.GameObjects;
+using Robust.Shared.Map;
+using Robust.Shared.Map.Components;
+using Robust.Shared.Maths;
+
+namespace Content.IntegrationTests.Tests.RPD;
+
+[TestFixture]
+public sealed class RPDCoexistenceTest
+{
+    // A straight pipe spawns longitudinal (North|South). Its alt-layer prototypes carry pipeLayer 1/2.
+    private const string Straight = "GasPipeStraight";
+
+    [Test]
+    public async Task DifferentLayerCoexists()
+    {
+        await using var pair = await PoolManager.GetServerClient();
+        var server = pair.Server;
+        var entMan = server.ResolveDependency<IEntityManager>();
+        var mapMan = server.ResolveDependency<IMapManager>();
+        var mapSys = entMan.System<SharedMapSystem>();
+        var overlap = entMan.System<PipeRestrictOverlapSystem>();
+
+        await server.WaitAssertion(() =>
+        {
+            mapSys.CreateMap(out var mapId);
+            var grid = mapMan.CreateGridEntity(mapId);
+            mapSys.SetTile(grid, new Vector2i(0, 0), new Tile(1));
+            entMan.SpawnEntity(Straight, grid.Owner.ToCoordinates(0, 0)); // Primary, anchored
+
+            // Same proto, same rotation, DIFFERENT layer => no overlap, coexists.
+            Assert.That(
+                overlap.WouldPlacementOverlap((grid.Owner, grid.Comp), new Vector2i(0, 0), Straight, Angle.Zero, AtmosPipeLayer.Secondary),
+                Is.False, "a Secondary pipe should coexist with a Primary pipe on the same tile");
+
+            // Same proto, same rotation, SAME layer => overlap, rejected.
+            Assert.That(
+                overlap.WouldPlacementOverlap((grid.Owner, grid.Comp), new Vector2i(0, 0), Straight, Angle.Zero, AtmosPipeLayer.Primary),
+                Is.True, "a second Primary pipe should conflict on the same tile");
+
+            // Same layer, PERPENDICULAR (rotate 90 deg) => directions don't intersect, coexists.
+            Assert.That(
+                overlap.WouldPlacementOverlap((grid.Owner, grid.Comp), new Vector2i(0, 0), Straight, Angle.FromDegrees(90), AtmosPipeLayer.Primary),
+                Is.False, "a perpendicular pipe on the same layer should coexist (no shared direction)");
+        });
+
+        await pair.CleanReturnAsync();
+    }
+}

--- a/Content.IntegrationTests/Tests/RPD/RPDCoexistenceTest.cs
+++ b/Content.IntegrationTests/Tests/RPD/RPDCoexistenceTest.cs
@@ -87,4 +87,46 @@ public sealed class RPDCoexistenceTest
 
         await pair.CleanReturnAsync();
     }
+
+    [Test]
+    public async Task RpdValidationAllowsDifferentLayerRejectsSame()
+    {
+        await using var pair = await PoolManager.GetServerClient();
+        var server = pair.Server;
+        var entMan = server.ResolveDependency<IEntityManager>();
+        var mapMan = server.ResolveDependency<IMapManager>();
+        var mapSys = entMan.System<SharedMapSystem>();
+        var layers = entMan.System<AtmosPipeLayersSystem>();
+        var rcd = entMan.System<Content.Shared.RCD.Systems.RCDSystem>();
+
+        await server.WaitAssertion(() =>
+        {
+            mapSys.CreateMap(out var mapId);
+            var grid = mapMan.CreateGridEntity(mapId);
+            mapSys.SetTile(grid, new Vector2i(0, 0), new Tile(1));
+            var existing = entMan.SpawnEntity(Straight, grid.Owner.ToCoordinates(0, 0)); // Primary
+
+            var user = entMan.SpawnEntity(null, grid.Owner.ToCoordinates(0, 0));
+            var rpdTool = entMan.SpawnEntity("RPD", grid.Owner.ToCoordinates(0, 0));
+            // The RPD's default recipe (first available) is a layer-capable pipe, and CurrentLayer defaults to
+            // Primary. We drive the two cases by moving the EXISTING pipe's layer, avoiding any access-restricted
+            // write to RPDComponent/RCDComponent from the test.
+            var rcdComp = entMan.GetComponent<Content.Shared.RCD.Components.RCDComponent>(rpdTool);
+
+            Assert.That(rcd.TryGetMapGridData(grid.Owner.ToCoordinates(0, 0), user, out var data), Is.True);
+
+            // RPD (Primary) over an existing Primary pipe on the same tile is rejected.
+            Assert.That(rcd.IsConstructionLocationValid(rpdTool, rcdComp, data!.Value, user, popMsgs: false), Is.False,
+                "RPD should reject placing on a tile already occupied at the same pipe layer");
+
+            // Move the existing pipe to Secondary; the RPD (still Primary) now coexists, so placement is valid.
+            var existingLayers = entMan.GetComponent<AtmosPipeLayersComponent>(existing);
+            layers.SetPipeLayer((existing, existingLayers), AtmosPipeLayer.Secondary);
+
+            Assert.That(rcd.IsConstructionLocationValid(rpdTool, rcdComp, data!.Value, user, popMsgs: false), Is.True,
+                "RPD should allow placing on a tile whose pipe sits on a different layer");
+        });
+
+        await pair.CleanReturnAsync();
+    }
 }

--- a/Content.IntegrationTests/Tests/RPD/RPDCoexistenceTest.cs
+++ b/Content.IntegrationTests/Tests/RPD/RPDCoexistenceTest.cs
@@ -51,4 +51,40 @@ public sealed class RPDCoexistenceTest
 
         await pair.CleanReturnAsync();
     }
+
+    [Test]
+    public async Task ScrewdriverdLayerIsRespected()
+    {
+        await using var pair = await PoolManager.GetServerClient();
+        var server = pair.Server;
+        var entMan = server.ResolveDependency<IEntityManager>();
+        var mapMan = server.ResolveDependency<IMapManager>();
+        var mapSys = entMan.System<SharedMapSystem>();
+        var layers = entMan.System<AtmosPipeLayersSystem>();
+        var overlap = entMan.System<PipeRestrictOverlapSystem>();
+
+        await server.WaitAssertion(() =>
+        {
+            mapSys.CreateMap(out var mapId);
+            var grid = mapMan.CreateGridEntity(mapId);
+            mapSys.SetTile(grid, new Vector2i(0, 0), new Tile(1));
+            var pipe = entMan.SpawnEntity(Straight, grid.Owner.ToCoordinates(0, 0)); // Primary
+
+            // Move the existing pipe to Secondary via the layer system (proto stays GasPipeStraight).
+            var pipeLayers = entMan.GetComponent<AtmosPipeLayersComponent>(pipe);
+            layers.SetPipeLayer((pipe, pipeLayers), AtmosPipeLayer.Secondary);
+
+            // A new Secondary now conflicts (live layer match), even though protos differ.
+            Assert.That(
+                overlap.WouldPlacementOverlap((grid.Owner, grid.Comp), new Vector2i(0, 0), Straight, Angle.Zero, AtmosPipeLayer.Secondary),
+                Is.True, "placement must use the existing pipe's live layer, not its prototype layer");
+
+            // Primary is now free.
+            Assert.That(
+                overlap.WouldPlacementOverlap((grid.Owner, grid.Comp), new Vector2i(0, 0), Straight, Angle.Zero, AtmosPipeLayer.Primary),
+                Is.False, "Primary should be free after the existing pipe moved to Secondary");
+        });
+
+        await pair.CleanReturnAsync();
+    }
 }

--- a/Content.IntegrationTests/Tests/RPD/RPDDeconstructTargetTest.cs
+++ b/Content.IntegrationTests/Tests/RPD/RPDDeconstructTargetTest.cs
@@ -89,4 +89,37 @@ public sealed class RPDDeconstructTargetTest
 
         await pair.CleanReturnAsync();
     }
+
+    [Test]
+    public async Task DeconstructAimWinsOverDirectlyClickedLayeredPipe()
+    {
+        await using var pair = await PoolManager.GetServerClient();
+        var server = pair.Server;
+        var entMan = server.ResolveDependency<IEntityManager>();
+        var mapMan = server.ResolveDependency<IMapManager>();
+        var mapSys = entMan.System<SharedMapSystem>();
+        var rcd = entMan.System<Content.Shared.RCD.Systems.RCDSystem>();
+        var rpd = entMan.System<RPDSystem>();
+
+        await server.WaitAssertion(() =>
+        {
+            mapSys.CreateMap(out var mapId);
+            var grid = mapMan.CreateGridEntity(mapId);
+            mapSys.SetTile(grid, new Vector2i(0, 0), new Tile(1));
+            var primary = entMan.SpawnEntity("GasPipeStraight", grid.Owner.ToCoordinates(0, 0));
+            var secondary = entMan.SpawnEntity("GasPipeStraightAlt1", grid.Owner.ToCoordinates(0, 0));
+            var rpdTool = entMan.SpawnEntity("RPD", grid.Owner.ToCoordinates(0, 0));
+            var rpdComp = entMan.GetComponent<RPDComponent>(rpdTool);
+
+            Assert.That(rcd.TryGetMapGridData(grid.Owner.ToCoordinates(0, 0), rpdTool, out var data), Is.True);
+
+            // The cursor grabbed the Primary pipe directly, but the operator aims Secondary -> aim wins.
+            rpd.SetLayer((rpdTool, rpdComp), AtmosPipeLayer.Secondary);
+            var ev = new RCDDeconstructTargetResolveEvent(data!.Value, primary);
+            entMan.EventBus.RaiseLocalEvent(rpdTool, ref ev);
+            Assert.That(ev.Target, Is.EqualTo(secondary), "aim should override a directly-clicked layered pipe");
+        });
+
+        await pair.CleanReturnAsync();
+    }
 }

--- a/Content.IntegrationTests/Tests/RPD/RPDDeconstructTargetTest.cs
+++ b/Content.IntegrationTests/Tests/RPD/RPDDeconstructTargetTest.cs
@@ -1,0 +1,59 @@
+#nullable enable
+using Content.Server.RPD;
+using Content.Shared.Atmos;
+using Content.Shared.Atmos.Components;
+using Content.Shared.Coordinates;
+using Content.Shared.RCD;
+using Content.Shared.RPD.Components;
+using Content.Shared.RPD.Systems;
+using Robust.Shared.GameObjects;
+using Robust.Shared.Map;
+using Robust.Shared.Maths;
+
+namespace Content.IntegrationTests.Tests.RPD;
+
+[TestFixture]
+public sealed class RPDDeconstructTargetTest
+{
+    [Test]
+    public async Task DeconstructTargetsAimedLayer()
+    {
+        await using var pair = await PoolManager.GetServerClient();
+        var server = pair.Server;
+        var entMan = server.ResolveDependency<IEntityManager>();
+        var mapMan = server.ResolveDependency<IMapManager>();
+        var mapSys = entMan.System<SharedMapSystem>();
+        var rcd = entMan.System<Content.Shared.RCD.Systems.RCDSystem>();
+        var rpd = entMan.System<RPDSystem>();
+
+        await server.WaitAssertion(() =>
+        {
+            mapSys.CreateMap(out var mapId);
+            var grid = mapMan.CreateGridEntity(mapId);
+            mapSys.SetTile(grid, new Vector2i(0, 0), new Tile(1));
+
+            // Two coexisting pipes on the same tile: Primary and Secondary (alt-layer prototype on layer 1).
+            var primary = entMan.SpawnEntity("GasPipeStraight", grid.Owner.ToCoordinates(0, 0));
+            var secondary = entMan.SpawnEntity("GasPipeStraightAlt1", grid.Owner.ToCoordinates(0, 0));
+
+            var rpdTool = entMan.SpawnEntity("RPD", grid.Owner.ToCoordinates(0, 0));
+            var rpdComp = entMan.GetComponent<RPDComponent>(rpdTool);
+
+            Assert.That(rcd.TryGetMapGridData(grid.Owner.ToCoordinates(0, 0), rpdTool, out var data), Is.True);
+
+            // Aim at Secondary -> resolve picks the Secondary pipe.
+            rpd.SetLayer((rpdTool, rpdComp), AtmosPipeLayer.Secondary);
+            var r1 = new RCDDeconstructTargetResolveEvent(data!.Value, null);
+            entMan.EventBus.RaiseLocalEvent(rpdTool, ref r1);
+            Assert.That(r1.Target, Is.EqualTo(secondary), "aiming Secondary should target the Secondary pipe");
+
+            // Aim at Primary -> resolve picks the Primary pipe.
+            rpd.SetLayer((rpdTool, rpdComp), AtmosPipeLayer.Primary);
+            var r2 = new RCDDeconstructTargetResolveEvent(data!.Value, null);
+            entMan.EventBus.RaiseLocalEvent(rpdTool, ref r2);
+            Assert.That(r2.Target, Is.EqualTo(primary), "aiming Primary should target the Primary pipe");
+        });
+
+        await pair.CleanReturnAsync();
+    }
+}

--- a/Content.IntegrationTests/Tests/RPD/RPDDeconstructTargetTest.cs
+++ b/Content.IntegrationTests/Tests/RPD/RPDDeconstructTargetTest.cs
@@ -56,4 +56,37 @@ public sealed class RPDDeconstructTargetTest
 
         await pair.CleanReturnAsync();
     }
+
+    [Test]
+    public async Task RpdAdmitsItsWhitelistForDeconstruct()
+    {
+        await using var pair = await PoolManager.GetServerClient();
+        var server = pair.Server;
+        var entMan = server.ResolveDependency<IEntityManager>();
+        var mapMan = server.ResolveDependency<IMapManager>();
+        var mapSys = entMan.System<SharedMapSystem>();
+
+        await server.WaitAssertion(() =>
+        {
+            mapSys.CreateMap(out var mapId);
+            var grid = mapMan.CreateGridEntity(mapId);
+            mapSys.SetTile(grid, new Vector2i(0, 0), new Tile(1));
+            var pipe = entMan.SpawnEntity("GasPipeStraight", grid.Owner.ToCoordinates(0, 0));
+            var rpdTool = entMan.SpawnEntity("RPD", grid.Owner.ToCoordinates(0, 0));
+            var user = entMan.SpawnEntity(null, grid.Owner.ToCoordinates(0, 0));
+
+            // The RPD admits a pipe (rpd: true, deconstructable: false) without RCD knowing what an RPD is.
+            var a1 = new RCDDeconstructAttemptEvent(pipe, user, false);
+            entMan.EventBus.RaiseLocalEvent(rpdTool, ref a1);
+            Assert.That(a1.Admitted, Is.True, "RPD should admit an rpd-deconstructable pipe");
+            Assert.That(a1.Cancelled, Is.False);
+
+            // The RPD refuses a tile (null target).
+            var a2 = new RCDDeconstructAttemptEvent(null, user, false);
+            entMan.EventBus.RaiseLocalEvent(rpdTool, ref a2);
+            Assert.That(a2.Cancelled, Is.True, "RPD should refuse a null (tile) target");
+        });
+
+        await pair.CleanReturnAsync();
+    }
 }

--- a/Content.IntegrationTests/Tests/RPD/RPDVentLayerTest.cs
+++ b/Content.IntegrationTests/Tests/RPD/RPDVentLayerTest.cs
@@ -19,7 +19,8 @@ public sealed class RPDVentLayerTest
 {
     private const string Straight = "GasPipeStraight"; // longitudinal (North|South), Primary
 
-    // Every Vents-category RPD recipe target and its expected alt-layer wiring.
+    // Every layer-capable RPD recipe target (Vents + AtmosphericUtility categories, both mirror
+    // prototypes included) and its expected alt-layer wiring.
     private static readonly (string Base, string Alt1, string Alt2)[] Devices =
     {
         ("GasVentPump", "GasVentPumpAlt1", "GasVentPumpAlt2"),
@@ -27,6 +28,12 @@ public sealed class RPDVentLayerTest
         ("GasVentScrubber", "GasVentScrubberAlt1", "GasVentScrubberAlt2"),
         ("GasOutletInjector", "GasOutletInjectorAlt1", "GasOutletInjectorAlt2"),
         ("GasDualPortVentPump", "GasDualPortVentPumpAlt1", "GasDualPortVentPumpAlt2"),
+        ("GasFilter", "GasFilterAlt1", "GasFilterAlt2"),
+        ("GasFilterFlipped", "GasFilterFlippedAlt1", "GasFilterFlippedAlt2"),
+        ("GasMixer", "GasMixerAlt1", "GasMixerAlt2"),
+        ("GasMixerFlipped", "GasMixerFlippedAlt1", "GasMixerFlippedAlt2"),
+        ("PressureControlledValve", "PressureControlledValveAlt1", "PressureControlledValveAlt2"),
+        ("GasPort", "GasPortAlt1", "GasPortAlt2"),
     };
 
     [Test]

--- a/Content.IntegrationTests/Tests/RPD/RPDVentLayerTest.cs
+++ b/Content.IntegrationTests/Tests/RPD/RPDVentLayerTest.cs
@@ -1,0 +1,167 @@
+#nullable enable
+using System.Linq;
+using Content.Server.NodeContainer.Nodes;
+using Content.Shared.NodeContainer;
+using Content.Shared.Atmos;
+using Content.Shared.Atmos.Components;
+using Content.Shared.Atmos.EntitySystems;
+using Content.Shared.Coordinates;
+using Robust.Shared.GameObjects;
+using Robust.Shared.Map;
+using Robust.Shared.Map.Components;
+using Robust.Shared.Maths;
+using Robust.Shared.Prototypes;
+
+namespace Content.IntegrationTests.Tests.RPD;
+
+[TestFixture]
+public sealed class RPDVentLayerTest
+{
+    private const string Straight = "GasPipeStraight"; // longitudinal (North|South), Primary
+
+    // Every Vents-category RPD recipe target and its expected alt-layer wiring.
+    private static readonly (string Base, string Alt1, string Alt2)[] Devices =
+    {
+        ("GasVentPump", "GasVentPumpAlt1", "GasVentPumpAlt2"),
+        ("GasPassiveVent", "GasPassiveVentAlt1", "GasPassiveVentAlt2"),
+        ("GasVentScrubber", "GasVentScrubberAlt1", "GasVentScrubberAlt2"),
+        ("GasOutletInjector", "GasOutletInjectorAlt1", "GasOutletInjectorAlt2"),
+        ("GasDualPortVentPump", "GasDualPortVentPumpAlt1", "GasDualPortVentPumpAlt2"),
+    };
+
+    [Test]
+    public async Task AlternativePrototypesResolve()
+    {
+        await using var pair = await PoolManager.GetServerClient();
+        var server = pair.Server;
+        var protoMan = server.ResolveDependency<IPrototypeManager>();
+        var compFactory = server.ResolveDependency<IComponentFactory>();
+        var entMan = server.ResolveDependency<IEntityManager>();
+        var layers = entMan.System<SharedAtmosPipeLayersSystem>();
+
+        await server.WaitAssertion(() =>
+        {
+            Assert.Multiple(() =>
+            {
+                foreach (var (baseId, alt1, alt2) in Devices)
+                {
+                    Assert.That(protoMan.TryIndex<EntityPrototype>(baseId, out var baseProto), Is.True, $"{baseId} missing");
+                    Assert.That(baseProto!.TryGetComponent<AtmosPipeLayersComponent>(out var comp, compFactory), Is.True,
+                        $"{baseId} has no AtmosPipeLayersComponent");
+
+                    Assert.That(layers.TryGetAlternativePrototype(comp!, AtmosPipeLayer.Secondary, out var secondary), Is.True,
+                        $"{baseId} has no Secondary alternative");
+                    Assert.That(secondary.Id, Is.EqualTo(alt1));
+
+                    Assert.That(layers.TryGetAlternativePrototype(comp!, AtmosPipeLayer.Tertiary, out var tertiary), Is.True,
+                        $"{baseId} has no Tertiary alternative");
+                    Assert.That(tertiary.Id, Is.EqualTo(alt2));
+
+                    // The alt proto must carry its layer as prototype data: the layer has to be live before the
+                    // anchor-time overlap check at spawn, which is the whole reason these are separate prototypes.
+                    Assert.That(protoMan.TryIndex<EntityPrototype>(alt1, out var alt1Proto), Is.True, $"{alt1} missing");
+                    Assert.That(alt1Proto!.TryGetComponent<AtmosPipeLayersComponent>(out var alt1Comp, compFactory), Is.True);
+                    Assert.That(alt1Comp!.CurrentPipeLayer, Is.EqualTo(AtmosPipeLayer.Secondary), $"{alt1} pipeLayer");
+
+                    Assert.That(protoMan.TryIndex<EntityPrototype>(alt2, out var alt2Proto), Is.True, $"{alt2} missing");
+                    Assert.That(alt2Proto!.TryGetComponent<AtmosPipeLayersComponent>(out var alt2Comp, compFactory), Is.True);
+                    Assert.That(alt2Comp!.CurrentPipeLayer, Is.EqualTo(AtmosPipeLayer.Tertiary), $"{alt2} pipeLayer");
+                }
+            });
+        });
+
+        await pair.CleanReturnAsync();
+    }
+
+    [Test]
+    public async Task AltVentCoexistsWithPrimaryPipe()
+    {
+        await using var pair = await PoolManager.GetServerClient();
+        var server = pair.Server;
+        var entMan = server.ResolveDependency<IEntityManager>();
+        var mapMan = server.ResolveDependency<IMapManager>();
+        var mapSys = entMan.System<SharedMapSystem>();
+
+        await server.WaitAssertion(() =>
+        {
+            mapSys.CreateMap(out var mapId);
+            var grid = mapMan.CreateGridEntity(mapId);
+            mapSys.SetTile(grid, new Vector2i(0, 0), new Tile(1));
+            entMan.SpawnEntity(Straight, grid.Owner.ToCoordinates(0, 0)); // North|South @ Primary
+
+            // South-facing Secondary vent over a Primary pipe: layers differ, so the anchor-time overlap
+            // check must let it stay, and its node must come up on Secondary before node groups form.
+            var vent = entMan.SpawnEntity("GasVentPumpAlt1", grid.Owner.ToCoordinates(0, 0));
+
+            Assert.Multiple(() =>
+            {
+                Assert.That(entMan.GetComponent<TransformComponent>(vent).Anchored, Is.True,
+                    "a Secondary vent should anchor over a Primary pipe");
+                Assert.That(entMan.GetComponent<AtmosPipeLayersComponent>(vent).CurrentPipeLayer,
+                    Is.EqualTo(AtmosPipeLayer.Secondary));
+
+                var nodes = entMan.GetComponent<NodeContainerComponent>(vent).Nodes.Values.OfType<PipeNode>().ToList();
+                Assert.That(nodes, Is.Not.Empty, "vent has no pipe nodes");
+                Assert.That(nodes.All(n => n.CurrentPipeLayer == AtmosPipeLayer.Secondary), Is.True,
+                    "vent pipe node must be on the aimed layer at startup");
+            });
+        });
+
+        await pair.CleanReturnAsync();
+    }
+
+    [Test]
+    public async Task SameLayerVentOverlapUnanchors()
+    {
+        await using var pair = await PoolManager.GetServerClient();
+        var server = pair.Server;
+        var entMan = server.ResolveDependency<IEntityManager>();
+        var mapMan = server.ResolveDependency<IMapManager>();
+        var mapSys = entMan.System<SharedMapSystem>();
+
+        await server.WaitAssertion(() =>
+        {
+            mapSys.CreateMap(out var mapId);
+            var grid = mapMan.CreateGridEntity(mapId);
+            mapSys.SetTile(grid, new Vector2i(0, 0), new Tile(1));
+            entMan.SpawnEntity(Straight, grid.Owner.ToCoordinates(0, 0)); // North|South @ Primary
+
+            // Same layer, shared South direction: the startup overlap guard must still fire for vents.
+            var vent = entMan.SpawnEntity("GasVentPump", grid.Owner.ToCoordinates(0, 0));
+
+            Assert.That(entMan.GetComponent<TransformComponent>(vent).Anchored, Is.False,
+                "a Primary vent sharing a direction with a Primary pipe must be rejected at anchor time");
+        });
+
+        await pair.CleanReturnAsync();
+    }
+
+    [Test]
+    public async Task SpawnRotationIsSeenByAnchorCheck()
+    {
+        await using var pair = await PoolManager.GetServerClient();
+        var server = pair.Server;
+        var entMan = server.ResolveDependency<IEntityManager>();
+        var mapMan = server.ResolveDependency<IMapManager>();
+        var mapSys = entMan.System<SharedMapSystem>();
+
+        await server.WaitAssertion(() =>
+        {
+            mapSys.CreateMap(out var mapId);
+            var grid = mapMan.CreateGridEntity(mapId);
+            mapSys.SetTile(grid, new Vector2i(0, 0), new Tile(1));
+            entMan.SpawnEntity(Straight, grid.Owner.ToCoordinates(0, 0)); // North|South @ Primary
+
+            // Same layer but rotated out of conflict (vent port faces East). RCDSystem now passes the recipe
+            // rotation into SpawnAttachedTo; this asserts the engine applies it before the anchor-time check,
+            // which previously judged everything south-facing.
+            var vent = entMan.SpawnAttachedTo("GasVentPump", grid.Owner.ToCoordinates(0, 0),
+                rotation: Direction.East.ToAngle());
+
+            Assert.That(entMan.GetComponent<TransformComponent>(vent).Anchored, Is.True,
+                "an East-facing Primary vent does not share a direction with a North-South pipe and must anchor");
+        });
+
+        await pair.CleanReturnAsync();
+    }
+}

--- a/Content.Server/Atmos/EntitySystems/PipeRestrictOverlapSystem.cs
+++ b/Content.Server/Atmos/EntitySystems/PipeRestrictOverlapSystem.cs
@@ -10,6 +10,8 @@ using Content.Shared.NodeContainer;
 using JetBrains.Annotations;
 using Robust.Server.GameObjects;
 using Robust.Shared.Map.Components;
+using Robust.Shared.Maths;
+using Robust.Shared.Prototypes;
 
 namespace Content.Server.Atmos.EntitySystems;
 
@@ -21,6 +23,7 @@ public sealed class PipeRestrictOverlapSystem : EntitySystem
     [Dependency] private readonly MapSystem _map = default!;
     [Dependency] private readonly PopupSystem _popup = default!;
     [Dependency] private readonly TransformSystem _xform = default!;
+    [Dependency] private readonly IPrototypeManager _proto = default!;
 
     private readonly List<EntityUid> _anchoredEntities = new();
     private EntityQuery<NodeContainerComponent> _nodeContainerQuery;
@@ -121,5 +124,51 @@ public sealed class PipeRestrictOverlapSystem : EntitySystem
                     yield return (pipeNode.OriginalPipeDirection.RotatePipeDirection(pipe.Comp2.LocalRotation), pipeNode.CurrentPipeLayer);
             }
         }
+    }
+
+    /// <summary>
+    /// Would a pipe of <paramref name="proto"/>, rotated by <paramref name="rotation"/>, on
+    /// <paramref name="layer"/>, overlap any anchored pipe already on this tile? Same predicate as
+    /// <see cref="PipeNodesOverlap"/>: a shared pipe direction AND the same layer. The layer is passed
+    /// explicitly because a screwdriver'd pipe's layer can diverge from its prototype and the placing
+    /// tool's chosen layer is the one that matters. Used by the RPD to pre-check a placement before spawn.
+    /// </summary>
+    public bool WouldPlacementOverlap(Entity<MapGridComponent> grid, Vector2i tile, EntProtoId proto, Angle rotation, AtmosPipeLayer layer)
+    {
+        if (!_proto.TryIndex(proto, out var entProto)
+            || !entProto.TryGetComponent<NodeContainerComponent>(out var nodes, EntityManager.ComponentFactory))
+            return false;
+
+        // Directions the would-be pipe occupies, in grid frame.
+        var placedDirs = PipeDirection.None;
+        foreach (var node in nodes.Nodes.Values)
+        {
+            if (node is PipeNode pipeNode)
+                placedDirs |= pipeNode.OriginalPipeDirection.RotatePipeDirection(rotation);
+        }
+
+        if (placedDirs == PipeDirection.None)
+            return false;
+
+        _anchoredEntities.Clear();
+        _map.GetAnchoredEntities((grid.Owner, grid.Comp), tile, _anchoredEntities);
+
+        foreach (var other in _anchoredEntities)
+        {
+            if (!_nodeContainerQuery.TryComp(other, out var otherNc))
+                continue;
+
+            foreach (var node in otherNc.Nodes.Values)
+            {
+                if (node is not PipeNode otherNode)
+                    continue;
+
+                var otherDir = otherNode.OriginalPipeDirection.RotatePipeDirection(Transform(other).LocalRotation);
+                if ((placedDirs & otherDir) != 0 && layer == otherNode.CurrentPipeLayer)
+                    return true;
+            }
+        }
+
+        return false;
     }
 }

--- a/Content.Server/RPD/RPDConflictSystem.cs
+++ b/Content.Server/RPD/RPDConflictSystem.cs
@@ -1,0 +1,52 @@
+using Content.Server.Atmos.EntitySystems;
+using Content.Shared.Atmos.Components;
+using Content.Shared.Atmos.EntitySystems;
+using Content.Shared.Popups;
+using Content.Shared.RCD;
+using Content.Shared.RPD.Components;
+using Robust.Shared.Map.Components;
+using Robust.Shared.Maths;
+using Robust.Shared.Prototypes;
+
+namespace Content.Server.RPD;
+
+/// <summary>
+/// Server-side RPD half: answers <see cref="RCDConstructionAttemptEvent"/> with the layer-aware pipe overlap rule
+/// (<see cref="PipeRestrictOverlapSystem.WouldPlacementOverlap"/>), so a same-(direction, layer) placement is
+/// rejected before spawn. Server-side because the overlap query reads server pipe-node data.
+/// </summary>
+public sealed class RPDConflictSystem : EntitySystem
+{
+    [Dependency] private readonly IPrototypeManager _proto = default!;
+    [Dependency] private readonly PipeRestrictOverlapSystem _overlap = default!;
+    [Dependency] private readonly SharedAtmosPipeLayersSystem _pipeLayers = default!;
+    [Dependency] private readonly SharedPopupSystem _popup = default!;
+
+    public override void Initialize()
+    {
+        base.Initialize();
+        SubscribeLocalEvent<RPDComponent, RCDConstructionAttemptEvent>(OnConstructAttempt);
+    }
+
+    private void OnConstructAttempt(Entity<RPDComponent> ent, ref RCDConstructionAttemptEvent args)
+    {
+        if (args.Recipe.NoLayers || string.IsNullOrEmpty(args.Recipe.Prototype))
+            return;
+
+        if (!_proto.TryIndex<EntityPrototype>(args.Recipe.Prototype, out var baseProto)
+            || !baseProto.TryGetComponent<AtmosPipeLayersComponent>(out var pipeLayers, EntityManager.ComponentFactory))
+            return;
+
+        // Resolve the layer-specific prototype (base proto IS the Primary variant).
+        var proto = args.Recipe.Prototype!;
+        if (_pipeLayers.TryGetAlternativePrototype(pipeLayers, ent.Comp.CurrentLayer, out var alt))
+            proto = alt.Id;
+
+        if (_overlap.WouldPlacementOverlap((args.MapGridData.GridUid, args.MapGridData.Component), args.MapGridData.Position, proto, args.Direction.ToAngle(), ent.Comp.CurrentLayer))
+        {
+            if (args.ShowPopups)
+                _popup.PopupEntity(Loc.GetString("rcd-component-cannot-build-on-occupied-tile-message"), ent, args.User);
+            args.Cancelled = true;
+        }
+    }
+}

--- a/Content.Server/RPD/RPDPipeColorSystem.cs
+++ b/Content.Server/RPD/RPDPipeColorSystem.cs
@@ -1,0 +1,40 @@
+using Content.Server.Atmos.Piping.Components;
+using Content.Server.Atmos.Piping.EntitySystems;
+using Content.Shared.RCD;
+using Content.Shared.RPD;
+using Content.Shared.RPD.Components;
+
+namespace Content.Server.RPD;
+
+/// <summary>
+/// Server-side RPD half: stains a freshly built pipe/atmos device with the operator's selected palette color via
+/// the canonical <see cref="AtmosPipeColorComponent"/>. Server-side because that component (and its setter) live on
+/// the server; setting it is what makes the color real, it serializes with the ship save and drives the atmos
+/// monitoring console, where an appearance-only write would be lost on reload and read white on consoles.
+/// </summary>
+public sealed class RPDPipeColorSystem : EntitySystem
+{
+    [Dependency] private readonly AtmosPipeColorSystem _pipeColor = default!;
+
+    public override void Initialize()
+    {
+        base.Initialize();
+        SubscribeLocalEvent<RPDComponent, RCDObjectSpawnedEvent>(OnObjectSpawned);
+    }
+
+    private void OnObjectSpawned(Entity<RPDComponent> ent, ref RCDObjectSpawnedEvent args)
+    {
+        // The default palette slot means "keep the prototype color"; nothing to stain.
+        if (ent.Comp.PipeColor == RPDPalette.DefaultKey)
+            return;
+
+        if (!RPDPalette.Colors.TryGetValue(ent.Comp.PipeColor, out var palette) || palette is not { } color)
+            return;
+
+        // Entities without the component (air alarms, air sensors) have no pipe color to set, so they skip.
+        if (!TryComp<AtmosPipeColorComponent>(args.Spawned, out var pipeColor))
+            return;
+
+        _pipeColor.SetColor(args.Spawned, pipeColor, color);
+    }
+}

--- a/Content.Shared/Atmos/EntitySystems/SharedAtmosPipeLayersSystem.cs
+++ b/Content.Shared/Atmos/EntitySystems/SharedAtmosPipeLayersSystem.cs
@@ -119,14 +119,18 @@ public abstract partial class SharedAtmosPipeLayersSystem : EntitySystem
         if (ent.Comp.NumberOfPipeLayers <= 1 || ent.Comp.PipeLayersLocked)
             return;
 
+        // Triad: only the layer-change tool should complain or act. Other tools (e.g. an RPD deconstructing a pipe
+        // its t-ray revealed under a floor) must fall through so their own interaction can run.
+        if (!TryComp<ToolComponent>(args.Used, out var tool) || !_tool.HasQuality(args.Used, ent.Comp.Tool, tool))
+            return;
+
         if (TryComp<SubFloorHideComponent>(ent, out var subFloorHide) && subFloorHide.IsUnderCover)
         {
             _popup.PopupPredicted(Loc.GetString("atmos-pipe-layers-component-cannot-adjust-pipes"), ent, args.User);
             return;
         }
 
-        if (TryComp<ToolComponent>(args.Used, out var tool) && _tool.HasQuality(args.Used, ent.Comp.Tool, tool))
-            _tool.UseTool(args.Used, args.User, ent, ent.Comp.Delay, tool.Qualities, new TrySetNextPipeLayerCompletedEvent());
+        _tool.UseTool(args.Used, args.User, ent, ent.Comp.Delay, tool.Qualities, new TrySetNextPipeLayerCompletedEvent());
     }
 
     private void OnUseInHandEvent(Entity<AtmosPipeLayersComponent> ent, ref UseInHandEvent args)

--- a/Content.Shared/RCD/RCDEvents.cs
+++ b/Content.Shared/RCD/RCDEvents.cs
@@ -70,6 +70,11 @@ public struct RCDDeconstructAttemptEvent
     public readonly EntityUid User;
     public readonly bool ShowPopups;
     public bool Cancelled;
+    /// <summary>
+    /// Set by a sibling handler (RPD) to admit a target RCD would otherwise reject (e.g. an <c>rpd: true</c>,
+    /// <c>deconstructable: false</c> pipe), so RCDSystem doesn't need to know what an RPD is.
+    /// </summary>
+    public bool Admitted;
 
     public RCDDeconstructAttemptEvent(EntityUid? target, EntityUid user, bool showPopups)
     {
@@ -77,6 +82,7 @@ public struct RCDDeconstructAttemptEvent
         User = user;
         ShowPopups = showPopups;
         Cancelled = false;
+        Admitted = false;
     }
 }
 

--- a/Content.Shared/RCD/RCDEvents.cs
+++ b/Content.Shared/RCD/RCDEvents.cs
@@ -135,4 +135,30 @@ public struct RCDDeconstructTargetResolveEvent
         Target = target;
     }
 }
+
+/// <summary>
+/// Raised during <c>ConstructObject</c> validation so a sibling system can veto the placement with logic RCD
+/// does not own (e.g. RPD pipe-layer conflict). Setting <c>Cancelled = true</c> blocks the placement; the handler
+/// owns any user-facing popup. Plain RCD has no handler, so the placement proceeds untouched.
+/// </summary>
+[ByRefEvent]
+public struct RCDConstructionAttemptEvent
+{
+    public readonly MapGridData MapGridData;
+    public readonly RCDPrototype Recipe;
+    public readonly Direction Direction;
+    public readonly EntityUid User;
+    public readonly bool ShowPopups;
+    public bool Cancelled;
+
+    public RCDConstructionAttemptEvent(MapGridData mapGridData, RCDPrototype recipe, Direction direction, EntityUid user, bool showPopups)
+    {
+        MapGridData = mapGridData;
+        Recipe = recipe;
+        Direction = direction;
+        User = user;
+        ShowPopups = showPopups;
+        Cancelled = false;
+    }
+}
 // End Triad

--- a/Content.Shared/RCD/Systems/RCDSystem.cs
+++ b/Content.Shared/RCD/Systems/RCDSystem.cs
@@ -498,6 +498,9 @@ public class RCDSystem : EntitySystem
         // Triad: layer-capable pipe recipes coexist across layers, so the base-proto identity guard must not reject
         // them. The layer-aware verdict comes from RCDConstructionAttemptEvent below (RPD) and the PipeRestrictOverlap
         // backstop. Knowable from the recipe + base proto alone, with no reference to RPDComponent.
+        // NB: today only the RPD has layer-capable (pipe) recipes, so the RCDConstructionAttemptEvent veto always
+        // fires for these. If a non-RPD tool ever gets a layer-capable recipe it loses that veto and leans solely on
+        // the PipeRestrictOverlap anchor-time backstop, which only catches same-(direction, layer) overlap.
         var layerCapable = !prototype.NoLayers
             && prototype.Prototype != null
             && _protoManager.TryIndex<EntityPrototype>(prototype.Prototype, out var baseProto)

--- a/Content.Shared/RCD/Systems/RCDSystem.cs
+++ b/Content.Shared/RCD/Systems/RCDSystem.cs
@@ -191,11 +191,14 @@ public class RCDSystem : EntitySystem
             return;
         }
 
-        // Triad: a pipe under a floor tile is invisible and blocks interactions (SubFloorHideComponent), so the click
-        // lands on the bare tile with no target. Resolve an RPD-deconstructable entity anchored on that tile so the
-        // RPD can chew covered pipes. Scoped to the RPD in Deconstruct mode; the RCD is unaffected.
-        if (target == null && prototype.Mode == RcdMode.Deconstruct && HasComp<RPDComponent>(uid))
-            target = FindSubfloorRpdDeconstructable(mapGridData.Value);
+        // Triad: a pipe under a floor tile is invisible and non-interactable (SubFloorHideComponent), so the click
+        // resolves either no target (bare tile) or a visible non-pipe entity sharing the tile, e.g. a firelock or
+        // window. In RPD Deconstruct mode, whenever the resolved target isn't itself RPD-deconstructable, look past
+        // it for an RPD-deconstructable entity anchored on the tile so the RPD can chew covered pipes. Falls back to
+        // the original target (null = tile deconstruct, or a no-op on a non-pipe) when the tile has no such pipe.
+        // Scoped to the RPD in Deconstruct mode; the RCD is unaffected.
+        if (prototype.Mode == RcdMode.Deconstruct && HasComp<RPDComponent>(uid) && !IsRpdDeconstructable(target))
+            target = FindSubfloorRpdDeconstructable(mapGridData.Value) ?? target;
         // End Triad
 
         if (!IsRCDOperationStillValid(uid, component, mapGridData.Value, target, args.User,
@@ -768,6 +771,11 @@ public class RCDSystem : EntitySystem
         return boundingPolygon.ComputeAABB(boundingTransform, 0).Intersects(fixture.Shape.ComputeAABB(entXform, 0));
     }
 
+    // Triad: true only when the entity opts into RPD deconstruction (RCDDeconstructableComponent.RpdDeconstructable).
+    // Null-safe so the OnAfterInteract gate can test the raw click target directly.
+    private bool IsRpdDeconstructable(EntityUid? target)
+        => TryComp<RCDDeconstructableComponent>(target, out var decon) && decon.RpdDeconstructable;
+
     // Triad: returns the RPD-deconstructable entity anchored on the tile, chosen deterministically by NetEntity so
     // client prediction and the server agree. Lets the RPD target pipes hidden beneath floor tiles, which are
     // invisible and non-interactable through the normal click path.
@@ -778,7 +786,7 @@ public class RCDSystem : EntitySystem
 
         foreach (var ent in _mapSystem.GetAnchoredEntities(mapGridData.GridUid, mapGridData.Component, mapGridData.Position))
         {
-            if (!TryComp<RCDDeconstructableComponent>(ent, out var decon) || !decon.RpdDeconstructable)
+            if (!IsRpdDeconstructable(ent))
                 continue;
 
             var netId = GetNetEntity(ent).Id;

--- a/Content.Shared/RCD/Systems/RCDSystem.cs
+++ b/Content.Shared/RCD/Systems/RCDSystem.cs
@@ -193,12 +193,16 @@ public class RCDSystem : EntitySystem
 
         // Triad: a pipe under a floor tile is invisible and non-interactable (SubFloorHideComponent), so the click
         // resolves either no target (bare tile) or a visible non-pipe entity sharing the tile, e.g. a firelock or
-        // window. In RPD Deconstruct mode, whenever the resolved target isn't itself RPD-deconstructable, look past
-        // it for an RPD-deconstructable entity anchored on the tile so the RPD can chew covered pipes. Falls back to
-        // the original target (null = tile deconstruct, or a no-op on a non-pipe) when the tile has no such pipe.
-        // Scoped to the RPD in Deconstruct mode; the RCD is unaffected.
+        // window. In RPD Deconstruct mode, whenever the resolved target isn't itself RPD-deconstructable, hand off
+        // to RPDSystem via the resolve event to look past it for an RPD-deconstructable entity anchored on the tile,
+        // the one on the operator's aimed pipe layer, so the RPD can chew covered pipes. A plain RCD has no handler so
+        // its target is left untouched; a null result falls back to the original click target.
         if (prototype.Mode == RcdMode.Deconstruct && HasComp<RPDComponent>(uid) && !IsRpdDeconstructable(target))
-            target = FindSubfloorRpdDeconstructable(mapGridData.Value) ?? target;
+        {
+            var resolve = new RCDDeconstructTargetResolveEvent(mapGridData.Value, target);
+            RaiseLocalEvent(uid, ref resolve);
+            target = resolve.Target;
+        }
         // End Triad
 
         if (!IsRCDOperationStillValid(uid, component, mapGridData.Value, target, args.User,
@@ -775,30 +779,6 @@ public class RCDSystem : EntitySystem
     // Null-safe so the OnAfterInteract gate can test the raw click target directly.
     private bool IsRpdDeconstructable(EntityUid? target)
         => TryComp<RCDDeconstructableComponent>(target, out var decon) && decon.RpdDeconstructable;
-
-    // Triad: returns the RPD-deconstructable entity anchored on the tile, chosen deterministically by NetEntity so
-    // client prediction and the server agree. Lets the RPD target pipes hidden beneath floor tiles, which are
-    // invisible and non-interactable through the normal click path.
-    private EntityUid? FindSubfloorRpdDeconstructable(MapGridData mapGridData)
-    {
-        EntityUid? best = null;
-        var bestId = int.MaxValue;
-
-        foreach (var ent in _mapSystem.GetAnchoredEntities(mapGridData.GridUid, mapGridData.Component, mapGridData.Position))
-        {
-            if (!IsRpdDeconstructable(ent))
-                continue;
-
-            var netId = GetNetEntity(ent).Id;
-            if (netId < bestId)
-            {
-                bestId = netId;
-                best = ent;
-            }
-        }
-
-        return best;
-    }
     // End Triad
 
     #endregion

--- a/Content.Shared/RCD/Systems/RCDSystem.cs
+++ b/Content.Shared/RCD/Systems/RCDSystem.cs
@@ -13,7 +13,6 @@ using Content.Shared.Maps;
 using Content.Shared.Physics;
 using Content.Shared.Popups;
 using Content.Shared.RCD.Components;
-using Content.Shared.RPD.Components; // Triad
 using Content.Shared._NF.Shipyard.Components; // Frontier
 using Content.Shared.Tag;
 using Content.Shared.Tiles;
@@ -192,13 +191,10 @@ public class RCDSystem : EntitySystem
             return;
         }
 
-        // Triad: a pipe under a floor tile is invisible and non-interactable (SubFloorHideComponent), so the click
-        // resolves either no target (bare tile) or a visible non-pipe entity sharing the tile, e.g. a firelock or
-        // window. In RPD Deconstruct mode, whenever the resolved target isn't itself RPD-deconstructable, hand off
-        // to RPDSystem via the resolve event to look past it for an RPD-deconstructable entity anchored on the tile,
-        // the one on the operator's aimed pipe layer, so the RPD can chew covered pipes. A plain RCD has no handler so
-        // its target is left untouched; a null result falls back to the original click target.
-        if (prototype.Mode == RcdMode.Deconstruct && HasComp<RPDComponent>(uid) && !IsRpdDeconstructable(target))
+        // Triad: in Deconstruct mode, hand off to a sibling (RPDSystem) to optionally redirect the target, e.g. to
+        // a covered pipe under a floor tile on the operator's aimed layer. Plain RCD has no handler, so its target
+        // is left untouched. RPDSystem owns the "already deconstructable, don't redirect" decision.
+        if (prototype.Mode == RcdMode.Deconstruct)
         {
             var resolve = new RCDDeconstructTargetResolveEvent(mapGridData.Value, target);
             RaiseLocalEvent(uid, ref resolve);
@@ -621,12 +617,10 @@ public class RCDSystem : EntitySystem
         // Attempt to deconstruct an object
         else
         {
-            // Triad: RPD tools share this gate; admit a target if either the generic Deconstructable flag is on,
-            // or the tool is an RPD and the target opted into RpdDeconstructable. RPDSystem's earlier
-            // RCDDeconstructAttemptEvent handler has already enforced the RPD-only whitelist semantics.
-            var hasRpd = HasComp<RPDComponent>(uid);
+            // Triad: admit a target if the generic Deconstructable flag is on, or a sibling handler admitted it
+            // earlier via RCDDeconstructAttemptEvent (the RPD admits its own whitelist). RCD stays RPD-agnostic.
             if (!TryComp<RCDDeconstructableComponent>(target, out var deconstructible)
-                || !(deconstructible.Deconstructable || (hasRpd && deconstructible.RpdDeconstructable)))
+                || !(deconstructible.Deconstructable || attempt.Admitted))
             // End Triad
             {
                 if (popMsgs)
@@ -792,12 +786,6 @@ public class RCDSystem : EntitySystem
 
         return boundingPolygon.ComputeAABB(boundingTransform, 0).Intersects(fixture.Shape.ComputeAABB(entXform, 0));
     }
-
-    // Triad: true only when the entity opts into RPD deconstruction (RCDDeconstructableComponent.RpdDeconstructable).
-    // Null-safe so the OnAfterInteract gate can test the raw click target directly.
-    private bool IsRpdDeconstructable(EntityUid? target)
-        => TryComp<RCDDeconstructableComponent>(target, out var decon) && decon.RpdDeconstructable;
-    // End Triad
 
     #endregion
 }

--- a/Content.Shared/RCD/Systems/RCDSystem.cs
+++ b/Content.Shared/RCD/Systems/RCDSystem.cs
@@ -675,24 +675,38 @@ public class RCDSystem : EntitySystem
                 if (string.IsNullOrEmpty(spawnProto))
                     return;
 
-                var ent = Spawn(spawnProto, _mapSystem.GridTileToLocal(mapGridData.GridUid, mapGridData.Component, mapGridData.Position));
+                // Triad: the recipe rotation must ride into the spawn call. Pipe-bearing prototypes anchor during
+                // entity startup and PipeRestrictOverlap judges their node directions right there; rotating after
+                // Spawn() meant that check always ran south-facing, falsely unanchoring legal rotated placements
+                // (e.g. crossing two same-layer straight pipes).
+                var rotation = prototype.Rotation switch
+                {
+                    RcdRotation.Fixed => Angle.Zero,
+                    RcdRotation.Camera => Transform(uid).LocalRotation,
+                    RcdRotation.User => direction.ToAngle(),
+                    _ => Angle.Zero,
+                };
+
+                var ent = SpawnAttachedTo(spawnProto, _mapSystem.GridTileToLocal(mapGridData.GridUid, mapGridData.Component, mapGridData.Position), rotation: rotation);
 
                 var spawned = new RCDObjectSpawnedEvent(ent, prototype);
                 RaiseLocalEvent(uid, ref spawned);
-                // End Triad
 
-                switch (prototype.Rotation)
-                {
-                    case RcdRotation.Fixed:
-                        Transform(ent).LocalRotation = Angle.Zero;
-                        break;
-                    case RcdRotation.Camera:
-                        Transform(ent).LocalRotation = Transform(uid).LocalRotation;
-                        break;
-                    case RcdRotation.User:
-                        Transform(ent).LocalRotation = direction.ToAngle();
-                        break;
-                }
+                // Triad: rotation now applied at spawn (see above); this post-spawn switch ran after the
+                // anchor-time overlap check had already judged the entity facing south.
+                // switch (prototype.Rotation)
+                // {
+                //     case RcdRotation.Fixed:
+                //         Transform(ent).LocalRotation = Angle.Zero;
+                //         break;
+                //     case RcdRotation.Camera:
+                //         Transform(ent).LocalRotation = Transform(uid).LocalRotation;
+                //         break;
+                //     case RcdRotation.User:
+                //         Transform(ent).LocalRotation = direction.ToAngle();
+                //         break;
+                // }
+                // End Triad
 
                 _adminLogger.Add(LogType.RCD, LogImpact.High, $"{ToPrettyString(user):user} used RCD to spawn {ToPrettyString(ent)} at {mapGridData.Position} on grid {mapGridData.GridUid}");
                 break;

--- a/Content.Shared/RCD/Systems/RCDSystem.cs
+++ b/Content.Shared/RCD/Systems/RCDSystem.cs
@@ -1,5 +1,6 @@
 using Content.Shared.Access.Components;
 using Content.Shared.Administration.Logs;
+using Content.Shared.Atmos.Components; // Triad
 using Content.Shared.Charges.Components;
 using Content.Shared.Charges.Systems;
 using Content.Shared.Construction;
@@ -431,7 +432,7 @@ public class RCDSystem : EntitySystem
         return false;
     }
 
-    private bool IsConstructionLocationValid(EntityUid uid, RCDComponent component, MapGridData mapGridData, EntityUid user, bool popMsgs = true,
+    public bool IsConstructionLocationValid(EntityUid uid, RCDComponent component, MapGridData mapGridData, EntityUid user, bool popMsgs = true,
         Direction? tilePlacementDirection = null)
     {
         var prototype = _protoManager.Index(component.ProtoId);
@@ -498,11 +499,20 @@ public class RCDSystem : EntitySystem
         _intersectingEntities.Clear();
         _lookup.GetLocalEntitiesIntersecting(mapGridData.GridUid, mapGridData.Position, _intersectingEntities, -0.05f, LookupFlags.Uncontained);
 
+        // Triad: layer-capable pipe recipes coexist across layers, so the base-proto identity guard must not reject
+        // them. The layer-aware verdict comes from RCDConstructionAttemptEvent below (RPD) and the PipeRestrictOverlap
+        // backstop. Knowable from the recipe + base proto alone, with no reference to RPDComponent.
+        var layerCapable = !prototype.NoLayers
+            && prototype.Prototype != null
+            && _protoManager.TryIndex<EntityPrototype>(prototype.Prototype, out var baseProto)
+            && baseProto.TryGetComponent<AtmosPipeLayersComponent>(out _, EntityManager.ComponentFactory);
+        // End Triad
+
         foreach (var ent in _intersectingEntities)
         {
             // space-wizards/space-station-14#42556 — block spamming the same entity on one tile (e.g. lights);
             // AllowMultiDirection permits one per cardinal direction (directional windows, diagonals, etc.).
-            if (prototype.Prototype != null && MetaData(ent).EntityPrototype?.ID == prototype.Prototype)
+            if (!layerCapable && prototype.Prototype != null && MetaData(ent).EntityPrototype?.ID == prototype.Prototype) // Triad: skip identity guard for layer-capable pipes
             {
                 var isIdentical = true;
                 if (prototype.AllowMultiDirection)
@@ -553,6 +563,14 @@ public class RCDSystem : EntitySystem
                 }
             }
         }
+
+        // Triad: let a sibling system (RPD) apply layer-aware conflict rules RCD does not own. Plain RCD has no
+        // handler, so this is a no-op for non-RPD tools.
+        var constructAttempt = new RCDConstructionAttemptEvent(mapGridData, prototype, tilePlacementDirection ?? component.ConstructionDirection, user, popMsgs);
+        RaiseLocalEvent(uid, ref constructAttempt);
+        if (constructAttempt.Cancelled)
+            return false;
+        // End Triad
 
         return true;
     }

--- a/Content.Shared/RCD/Systems/RCDSystem.cs
+++ b/Content.Shared/RCD/Systems/RCDSystem.cs
@@ -191,18 +191,11 @@ public class RCDSystem : EntitySystem
             return;
         }
 
-        // Triad: a pipe under a floor tile is invisible and non-interactable (SubFloorHideComponent), so the click
-        // resolves either no target (bare tile) or a visible non-pipe entity sharing the tile, e.g. a firelock or
-        // window. In RPD Deconstruct mode, whenever the resolved target isn't itself RPD-deconstructable, hand off
-        // to RPDSystem via the resolve event to look past it for an RPD-deconstructable entity anchored on the tile,
-        // the one on the operator's aimed pipe layer, so the RPD can chew covered pipes. A plain RCD has no handler so
-        // its target is left untouched; a null result falls back to the original click target.
-        if (prototype.Mode == RcdMode.Deconstruct && HasComp<RPDComponent>(uid) && !IsRpdDeconstructable(target))
-        {
-            var resolve = new RCDDeconstructTargetResolveEvent(mapGridData.Value, target);
-            RaiseLocalEvent(uid, ref resolve);
-            target = resolve.Target;
-        }
+        // Triad: a pipe under a floor tile is invisible and blocks interactions (SubFloorHideComponent), so the click
+        // lands on the bare tile with no target. Resolve an RPD-deconstructable entity anchored on that tile so the
+        // RPD can chew covered pipes. Scoped to the RPD in Deconstruct mode; the RCD is unaffected.
+        if (target == null && prototype.Mode == RcdMode.Deconstruct && HasComp<RPDComponent>(uid))
+            target = FindSubfloorRpdDeconstructable(mapGridData.Value);
         // End Triad
 
         if (!IsRCDOperationStillValid(uid, component, mapGridData.Value, target, args.User,
@@ -775,10 +768,29 @@ public class RCDSystem : EntitySystem
         return boundingPolygon.ComputeAABB(boundingTransform, 0).Intersects(fixture.Shape.ComputeAABB(entXform, 0));
     }
 
-    // Triad: true only when the entity opts into RPD deconstruction (RCDDeconstructableComponent.RpdDeconstructable).
-    // Null-safe so the OnAfterInteract gate can test the raw click target directly.
-    private bool IsRpdDeconstructable(EntityUid? target)
-        => TryComp<RCDDeconstructableComponent>(target, out var decon) && decon.RpdDeconstructable;
+    // Triad: returns the RPD-deconstructable entity anchored on the tile, chosen deterministically by NetEntity so
+    // client prediction and the server agree. Lets the RPD target pipes hidden beneath floor tiles, which are
+    // invisible and non-interactable through the normal click path.
+    private EntityUid? FindSubfloorRpdDeconstructable(MapGridData mapGridData)
+    {
+        EntityUid? best = null;
+        var bestId = int.MaxValue;
+
+        foreach (var ent in _mapSystem.GetAnchoredEntities(mapGridData.GridUid, mapGridData.Component, mapGridData.Position))
+        {
+            if (!TryComp<RCDDeconstructableComponent>(ent, out var decon) || !decon.RpdDeconstructable)
+                continue;
+
+            var netId = GetNetEntity(ent).Id;
+            if (netId < bestId)
+            {
+                bestId = netId;
+                best = ent;
+            }
+        }
+
+        return best;
+    }
     // End Triad
 
     #endregion

--- a/Content.Shared/RPD/Components/RPDComponent.cs
+++ b/Content.Shared/RPD/Components/RPDComponent.cs
@@ -23,12 +23,6 @@ public sealed partial class RPDComponent : Component
     public string PipeColor { get; set; } = RPDPalette.DefaultKey;
 
     /// <summary>
-    /// Player eye rotation as of the last <c>RPDEyeRotationEvent</c>. Server-only ephemeral state — clients send
-    /// it up but the server doesn't echo it back. Not networked.
-    /// </summary>
-    public float? LastKnownEyeRotation { get; set; } = null;
-
-    /// <summary>
     /// Pipe layer chosen at the last <see cref="Robust.Shared.GameObjects.AfterInteractEvent"/>. Per-entity so
     /// concurrent users with their own RPDs don't trample each other's selection between click and do-after
     /// completion. Server-only state.

--- a/Content.Shared/RPD/RPDEvents.cs
+++ b/Content.Shared/RPD/RPDEvents.cs
@@ -1,3 +1,4 @@
+using Content.Shared.Atmos.Components;
 using Robust.Shared.Serialization;
 
 namespace Content.Shared.RPD;
@@ -17,6 +18,24 @@ public sealed class RPDEyeRotationEvent : EntityEventArgs
     {
         NetEntity = netEntity;
         EyeRotation = eyeRotation;
+    }
+}
+
+/// <summary>
+/// Client pushes the operator's cursor-aimed pipe layer to the server (on change). Replaces streaming raw eye
+/// rotation: the client already computes this layer for its ghost/guide, so sending it directly removes the
+/// duplicate server-side <see cref="RPDLayerMath"/> computation and the click-time desync.
+/// </summary>
+[Serializable, NetSerializable]
+public sealed class RPDLayerSelectEvent : EntityEventArgs
+{
+    public readonly NetEntity NetEntity;
+    public readonly AtmosPipeLayer Layer;
+
+    public RPDLayerSelectEvent(NetEntity netEntity, AtmosPipeLayer layer)
+    {
+        NetEntity = netEntity;
+        Layer = layer;
     }
 }
 

--- a/Content.Shared/RPD/RPDEvents.cs
+++ b/Content.Shared/RPD/RPDEvents.cs
@@ -4,24 +4,6 @@ using Robust.Shared.Serialization;
 namespace Content.Shared.RPD;
 
 /// <summary>
-/// Networks the local player's eye rotation to the server so the RPD can compute pipe-layer placement.
-/// Eye rotation isn't networked by Robust natively; funky-station's note "Not intended as a permanent
-/// solution" still applies.
-/// </summary>
-[Serializable, NetSerializable]
-public sealed class RPDEyeRotationEvent : EntityEventArgs
-{
-    public readonly NetEntity NetEntity;
-    public readonly float? EyeRotation;
-
-    public RPDEyeRotationEvent(NetEntity netEntity, float? eyeRotation)
-    {
-        NetEntity = netEntity;
-        EyeRotation = eyeRotation;
-    }
-}
-
-/// <summary>
 /// Client pushes the operator's cursor-aimed pipe layer to the server (on change). Replaces streaming raw eye
 /// rotation: the client already computes this layer for its ghost/guide, so sending it directly removes the
 /// duplicate server-side <see cref="RPDLayerMath"/> computation and the click-time desync.

--- a/Content.Shared/RPD/Systems/RPDSystem.cs
+++ b/Content.Shared/RPD/Systems/RPDSystem.cs
@@ -56,8 +56,14 @@ public sealed class RPDSystem : EntitySystem
             return;
         }
 
-        // RCDSystem already handles the "target lacks RCDDeconstructable" case; we only add the RPD-specific opt-in gate.
-        if (TryComp<RCDDeconstructableComponent>(target, out var decon) && !decon.RpdDeconstructable)
+        // No RCDDeconstructable at all -> leave it to RCD's own whitelist rejection.
+        if (!TryComp<RCDDeconstructableComponent>(target, out var decon))
+            return;
+
+        // The RPD admits its own whitelist; RCD doesn't need to know what an RPD is.
+        if (decon.RpdDeconstructable)
+            args.Admitted = true;
+        else
         {
             if (args.ShowPopups)
                 _popup.PopupClient(Loc.GetString("rpd-component-deconstruct-target-invalid"), ent, args.User);
@@ -149,13 +155,18 @@ public sealed class RPDSystem : EntitySystem
     /// <summary>
     /// Resolves the covered-pipe deconstruct target the direct click couldn't reach (the pipe sits under a floor tile,
     /// hidden and non-interactable). Picks the RPD-deconstructable entity anchored on the tile whose pipe layer matches
-    /// the operator's cursor-aimed layer (<see cref="RPDComponent.CurrentLayer"/>, set in <see cref="OnAfterInteract"/>
-    /// from the streamed eye rotation), so deconstruct mirrors construct: aim at a quadrant, pull that layer.
+    /// the operator's cursor-aimed layer (<see cref="RPDComponent.CurrentLayer"/>, pushed by the client), so
+    /// deconstruct mirrors construct: aim at a quadrant, pull that layer.
     /// Server-authoritative — CurrentLayer is server-only state and the do-after that does the work only starts
     /// server-side, so the client's placeholder pick (default Primary) is cosmetic and never desyncs the result.
     /// </summary>
     private void OnDeconstructTargetResolve(Entity<RPDComponent> ent, ref RCDDeconstructTargetResolveEvent args)
     {
+        // The direct click already hit an RPD-deconstructable target (a visible, uncovered pipe) -> use it; only
+        // look past the target when the click landed on a tile or a non-pipe (firelock, window) covering the pipe.
+        if (args.Target is { } t && IsRpdDeconstructable(t))
+            return;
+
         args.Target = FindSubfloorRpdDeconstructable(args.MapGridData, ent.Comp.CurrentLayer) ?? args.Target;
     }
 

--- a/Content.Shared/RPD/Systems/RPDSystem.cs
+++ b/Content.Shared/RPD/Systems/RPDSystem.cs
@@ -48,6 +48,7 @@ public sealed class RPDSystem : EntitySystem
         SubscribeLocalEvent<RPDComponent, RPDColorChangeMessage>(OnColorChange);
 
         SubscribeNetworkEvent<RPDEyeRotationEvent>(OnEyeRotation);
+        SubscribeNetworkEvent<RPDLayerSelectEvent>(OnLayerSelect);
     }
 
     /// <summary>
@@ -185,6 +186,39 @@ public sealed class RPDSystem : EntitySystem
             return;
 
         rpd.LastKnownEyeRotation = ev.EyeRotation;
+    }
+
+    /// <summary>
+    /// Client streams its cursor-aimed pipe layer; stored per-RPD for spawn and deconstruct targeting. Validated
+    /// to the sender's active-hand RPD so a client can't set the layer on a tool it isn't holding.
+    /// </summary>
+    private void OnLayerSelect(RPDLayerSelectEvent ev, EntitySessionEventArgs session)
+    {
+        var uid = GetEntity(ev.NetEntity);
+
+        if (session.SenderSession.AttachedEntity is not { } player)
+            return;
+
+        if (!TryComp<HandsComponent>(player, out var hands) || uid != hands.ActiveHand?.HeldEntity)
+            return;
+
+        if (!TryComp<RPDComponent>(uid, out var rpd))
+            return;
+
+        SetLayer((uid, rpd), ev.Layer);
+    }
+
+    /// <summary>
+    /// Sets the RPD's selected pipe layer. Clamps to a defined enum value so a malicious client can't store
+    /// garbage; an unsupported-but-valid layer (target has fewer layers) simply no-ops the alternative-prototype
+    /// lookup at spawn. Server-only ephemeral state, not networked.
+    /// </summary>
+    public void SetLayer(Entity<RPDComponent> ent, AtmosPipeLayer layer)
+    {
+        if (!Enum.IsDefined(layer))
+            return;
+
+        ent.Comp.CurrentLayer = layer;
     }
 
     /// <summary>

--- a/Content.Shared/RPD/Systems/RPDSystem.cs
+++ b/Content.Shared/RPD/Systems/RPDSystem.cs
@@ -10,7 +10,6 @@ using Content.Shared.RCD.Systems;
 using Content.Shared.RPD.Components;
 using Robust.Shared.Map;
 using Robust.Shared.Map.Components;
-using Robust.Shared.Network;
 using Robust.Shared.Prototypes;
 
 namespace Content.Shared.RPD.Systems;
@@ -24,77 +23,23 @@ namespace Content.Shared.RPD.Systems;
 /// </summary>
 public sealed class RPDSystem : EntitySystem
 {
-    [Dependency] private readonly INetManager _net = default!;
     [Dependency] private readonly IPrototypeManager _protoManager = default!;
     [Dependency] private readonly SharedAppearanceSystem _appearance = default!;
     [Dependency] private readonly SharedAtmosPipeLayersSystem _pipeLayers = default!;
     [Dependency] private readonly SharedMapSystem _mapSystem = default!;
     [Dependency] private readonly SharedPopupSystem _popup = default!;
-    [Dependency] private readonly SharedTransformSystem _transform = default!;
 
     public override void Initialize()
     {
         base.Initialize();
 
-        // Must run before RCDSystem so CurrentLayer is committed to the component before RCDSystem captures
-        // the click into a DoAfter and (a few ticks later) raises RCDObjectSpawnAttemptEvent. Without this
-        // ordering RCDSystem sets args.Handled first and we bail at the Handled gate, leaving CurrentLayer
-        // at its default (Primary) regardless of cursor position.
-        SubscribeLocalEvent<RPDComponent, AfterInteractEvent>(OnAfterInteract, before: new[] { typeof(RCDSystem) });
         SubscribeLocalEvent<RPDComponent, RCDDeconstructAttemptEvent>(OnDeconstructAttempt);
         SubscribeLocalEvent<RPDComponent, RCDObjectSpawnAttemptEvent>(OnObjectSpawnAttempt);
         SubscribeLocalEvent<RPDComponent, RCDObjectSpawnedEvent>(OnObjectSpawned);
         SubscribeLocalEvent<RPDComponent, RCDDeconstructTargetResolveEvent>(OnDeconstructTargetResolve);
         SubscribeLocalEvent<RPDComponent, RPDColorChangeMessage>(OnColorChange);
 
-        SubscribeNetworkEvent<RPDEyeRotationEvent>(OnEyeRotation);
         SubscribeNetworkEvent<RPDLayerSelectEvent>(OnLayerSelect);
-    }
-
-    /// <summary>
-    /// Computes the target <see cref="AtmosPipeLayer"/> from the cursor's position inside the clicked tile. The
-    /// chosen layer is stored on the RPDComponent so the spawn event (which fires after the do-after delay) reads
-    /// the layer that was chosen at click time, not whatever the cursor is hovering by then.
-    /// </summary>
-    private void OnAfterInteract(Entity<RPDComponent> ent, ref AfterInteractEvent args)
-    {
-        // Layer is consumed at server-side spawn time. Client prediction doesn't need to mutate the component.
-        if (!_net.IsServer)
-            return;
-
-        if (args.Handled || !args.CanReach)
-            return;
-
-        if (!TryComp<RCDComponent>(ent, out var rcd))
-            return;
-
-        if (!_protoManager.TryIndex(rcd.ProtoId, out var recipe) || recipe.NoLayers)
-        {
-            ent.Comp.CurrentLayer = AtmosPipeLayer.Primary;
-            return;
-        }
-
-        var location = args.ClickLocation;
-        if (!location.IsValid(EntityManager))
-            return;
-
-        var gridUid = _transform.GetGrid(location);
-        if (!TryComp<MapGridComponent>(gridUid, out var grid))
-            return;
-
-        var tileRef = _mapSystem.GetTileRef(gridUid.Value, grid, location);
-        var tileSize = grid.TileSize;
-        // Both terms are in the grid's local frame (tile units); cursor minus tile center yields an offset
-        // in [-tileSize/2, tileSize/2] which is what RPDLayerMath.PickLayer expects. Mirror the client-side
-        // computation in AlignRPDAtmosPipeLayers.AlignPlacementMode so the ghost and the commit agree.
-        var tileCenter = new System.Numerics.Vector2(tileRef.X + tileSize / 2f, tileRef.Y + tileSize / 2f);
-        var mouseDiff = location.Position - tileCenter;
-
-        var eye = ent.Comp.LastKnownEyeRotation is { } theta ? new Angle(theta) : Angle.Zero;
-        var gridRotation = _transform.GetWorldRotation(gridUid.Value);
-        ent.Comp.CurrentLayer = ent.Comp.LastKnownEyeRotation.HasValue
-            ? RPDLayerMath.PickLayer(mouseDiff, eye, gridRotation)
-            : AtmosPipeLayer.Primary;
     }
 
     /// <summary>
@@ -166,26 +111,6 @@ public sealed class RPDSystem : EntitySystem
 
         ent.Comp.PipeColor = args.PipeColor;
         Dirty(ent);
-    }
-
-    /// <summary>
-    /// Client streams local eye rotation; stored per-RPD so the server-side layer math can reproduce the
-    /// client's cursor-quadrant pick when the placement commits.
-    /// </summary>
-    private void OnEyeRotation(RPDEyeRotationEvent ev, EntitySessionEventArgs session)
-    {
-        var uid = GetEntity(ev.NetEntity);
-
-        if (session.SenderSession.AttachedEntity is not { } player)
-            return;
-
-        if (!TryComp<HandsComponent>(player, out var hands) || uid != hands.ActiveHand?.HeldEntity)
-            return;
-
-        if (!TryComp<RPDComponent>(uid, out var rpd))
-            return;
-
-        rpd.LastKnownEyeRotation = ev.EyeRotation;
     }
 
     /// <summary>

--- a/Content.Shared/RPD/Systems/RPDSystem.cs
+++ b/Content.Shared/RPD/Systems/RPDSystem.cs
@@ -162,9 +162,10 @@ public sealed class RPDSystem : EntitySystem
     /// </summary>
     private void OnDeconstructTargetResolve(Entity<RPDComponent> ent, ref RCDDeconstructTargetResolveEvent args)
     {
-        // The direct click already hit an RPD-deconstructable target (a visible, uncovered pipe) -> use it; only
-        // look past the target when the click landed on a tile or a non-pipe (firelock, window) covering the pipe.
-        if (args.Target is { } t && IsRpdDeconstructable(t))
+        // A directly-clicked non-layered RPD-deconstructable device (air sensor/alarm) is taken as-is. For layered
+        // pipes the operator's aimed quadrant wins, so stacked layers on one tile resolve to the pipe under the aim,
+        // not whichever one the cursor grabbed.
+        if (args.Target is { } t && IsRpdDeconstructable(t) && !HasComp<AtmosPipeLayersComponent>(t))
             return;
 
         args.Target = FindSubfloorRpdDeconstructable(args.MapGridData, ent.Comp.CurrentLayer) ?? args.Target;

--- a/Content.Shared/RPD/Systems/RPDSystem.cs
+++ b/Content.Shared/RPD/Systems/RPDSystem.cs
@@ -16,15 +16,13 @@ namespace Content.Shared.RPD.Systems;
 
 /// <summary>
 /// Adds RPD-specific behavior on top of the generic RCD pipeline. Subscribes to <c>RCDSystem</c>'s extensibility
-/// events to (a) gate deconstruction to RPD-whitelisted atmos hardware only, (b) swap the spawn prototype to the
-/// pipe-layer alternative chosen by cursor quadrant, and (c) stain spawned pipes/atmos hardware with the
-/// operator's selected color. The stain is an unconditional <c>PipeColorVisuals.Color</c> appearance write —
-/// entities without a <c>PipeColorVisuals</c> visualizer (air alarms, air sensors) absorb it harmlessly.
+/// events to (a) gate deconstruction to RPD-whitelisted atmos hardware only and (b) swap the spawn prototype to the
+/// pipe-layer alternative chosen by cursor quadrant. The operator's pipe-color stain lives server-side in
+/// <c>RPDPipeColorSystem</c>, which owns the canonical <c>AtmosPipeColorComponent</c>.
 /// </summary>
 public sealed class RPDSystem : EntitySystem
 {
     [Dependency] private readonly IPrototypeManager _protoManager = default!;
-    [Dependency] private readonly SharedAppearanceSystem _appearance = default!;
     [Dependency] private readonly SharedAtmosPipeLayersSystem _pipeLayers = default!;
     [Dependency] private readonly SharedMapSystem _mapSystem = default!;
     [Dependency] private readonly SharedPopupSystem _popup = default!;
@@ -35,7 +33,6 @@ public sealed class RPDSystem : EntitySystem
 
         SubscribeLocalEvent<RPDComponent, RCDDeconstructAttemptEvent>(OnDeconstructAttempt);
         SubscribeLocalEvent<RPDComponent, RCDObjectSpawnAttemptEvent>(OnObjectSpawnAttempt);
-        SubscribeLocalEvent<RPDComponent, RCDObjectSpawnedEvent>(OnObjectSpawned);
         SubscribeLocalEvent<RPDComponent, RCDDeconstructTargetResolveEvent>(OnDeconstructTargetResolve);
         SubscribeLocalEvent<RPDComponent, RPDColorChangeMessage>(OnColorChange);
 
@@ -88,22 +85,6 @@ public sealed class RPDSystem : EntitySystem
 
         if (_pipeLayers.TryGetAlternativePrototype(atmosPipeLayers, ent.Comp.CurrentLayer, out var layerProto))
             args.SpawnProto = layerProto.Id;
-    }
-
-    /// <summary>
-    /// Applies the operator's selected pipe-color stain to the freshly spawned entity. The default key skips the
-    /// write entirely; otherwise the appearance data is set unconditionally and the <c>PipeColorVisuals</c>
-    /// visualizer (on every pipe/pump/vent/valve/mixer/heat-exchanger prototype) picks it up. Entities without
-    /// the visualizer (air alarms, air sensors) absorb the appearance bytes harmlessly — cheaper than a per-spawn
-    /// component check.
-    /// </summary>
-    private void OnObjectSpawned(Entity<RPDComponent> ent, ref RCDObjectSpawnedEvent args)
-    {
-        if (ent.Comp.PipeColor == RPDPalette.DefaultKey)
-            return;
-
-        if (RPDPalette.Colors.TryGetValue(ent.Comp.PipeColor, out var pipeColor) && pipeColor is { } color)
-            _appearance.SetData(args.Spawned, PipeColorVisuals.Color, color);
     }
 
     /// <summary>

--- a/Content.Shared/SubFloor/SharedSubFloorHideSystem.cs
+++ b/Content.Shared/SubFloor/SharedSubFloorHideSystem.cs
@@ -2,6 +2,7 @@ using Content.Shared.Audio;
 using Content.Shared.Construction.Components;
 using Content.Shared.Explosion;
 using Content.Shared.Eye;
+using Content.Shared.Hands.EntitySystems;
 using Content.Shared.Interaction.Events;
 using Content.Shared.Maps;
 using Content.Shared.Popups;
@@ -24,14 +25,17 @@ namespace Content.Shared.SubFloor
         [Dependency] protected readonly SharedAppearanceSystem Appearance = default!;
         [Dependency] private readonly SharedVisibilitySystem _visibility = default!;
         [Dependency] protected readonly SharedPopupSystem _popup = default!;
+        [Dependency] private readonly SharedHandsSystem _hands = default!; // Triad
 
         private EntityQuery<SubFloorHideComponent> _hideQuery;
+        private EntityQuery<SubfloorReachComponent> _reachQuery; // Triad
 
         public override void Initialize()
         {
             base.Initialize();
 
             _hideQuery = GetEntityQuery<SubFloorHideComponent>();
+            _reachQuery = GetEntityQuery<SubfloorReachComponent>(); // Triad
 
             SubscribeLocalEvent<TileChangedEvent>(OnTileChanged);
             SubscribeLocalEvent<SubFloorHideComponent, ComponentStartup>(OnSubFloorStarted);
@@ -83,9 +87,27 @@ namespace Content.Shared.SubFloor
 
         private void OnInteractionAttempt(EntityUid uid, SubFloorHideComponent component, ref GettingInteractedWithAttemptEvent args)
         {
-            // No interactions with entities hidden under floor tiles.
-            if (component.BlockInteractions && component.IsUnderCover)
+            // No interactions with entities hidden under floor tiles...
+            // Triad: ...unless the user holds a tool flagged SubfloorReach (the RPD), so it can deconstruct the
+            // pipes its own t-ray reveals. Explosion/attack protection is unaffected (those gate on
+            // BlockInteractions directly).
+            if (component.BlockInteractions && component.IsUnderCover && !HolderCanReachSubfloor(args.Uid))
                 args.Cancelled = true;
+        }
+
+        // Triad: true when the user holds an item flagged SubfloorReach (e.g. the RPD).
+        private bool HolderCanReachSubfloor(EntityUid? user)
+        {
+            if (user == null)
+                return false;
+
+            foreach (var held in _hands.EnumerateHeld(user.Value))
+            {
+                if (_reachQuery.HasComp(held))
+                    return true;
+            }
+
+            return false;
         }
 
         private void OnSubFloorStarted(EntityUid uid, SubFloorHideComponent component, ComponentStartup _)

--- a/Content.Shared/SubFloor/SharedSubFloorHideSystem.cs
+++ b/Content.Shared/SubFloor/SharedSubFloorHideSystem.cs
@@ -88,9 +88,11 @@ namespace Content.Shared.SubFloor
         private void OnInteractionAttempt(EntityUid uid, SubFloorHideComponent component, ref GettingInteractedWithAttemptEvent args)
         {
             // No interactions with entities hidden under floor tiles...
-            // Triad: ...unless the user holds a tool flagged SubfloorReach (the RPD), so it can deconstruct the
-            // pipes its own t-ray reveals. Explosion/attack protection is unaffected (those gate on
-            // BlockInteractions directly).
+            // Triad: ...unless the user holds a tool flagged SubfloorReach (the RPD). This lifts the interaction
+            // block entirely while the tool is held: the motivating case is letting the RPD deconstruct the pipes
+            // its own t-ray reveals, but it also permits any other interaction with the covered entity (e.g. opening
+            // a buried filter's UI). Acceptable, the tool is in hand. Explosion/attack protection is unaffected
+            // (those gate on BlockInteractions directly, not through this attempt event).
             if (component.BlockInteractions && component.IsUnderCover && !HolderCanReachSubfloor(args.Uid))
                 args.Cancelled = true;
         }

--- a/Content.Shared/SubFloor/SubfloorReachComponent.cs
+++ b/Content.Shared/SubFloor/SubfloorReachComponent.cs
@@ -1,0 +1,16 @@
+// SPDX-FileCopyrightText: 2026 Triad Sector
+//
+// SPDX-License-Identifier: AGPL-3.0-or-later
+
+using Robust.Shared.GameStates;
+
+namespace Content.Shared.SubFloor;
+
+/// <summary>
+/// Triad: marks an item whose holder may interact with subfloor entities that are under floor cover (which
+/// normally cancel all interaction via <see cref="SubFloorHideComponent.BlockInteractions"/>). The RPD carries
+/// this so its built-in t-ray reveal is matched by the ability to actually deconstruct the revealed pipe.
+/// Scoped to the held tool on purpose, so it does not broaden subfloor access for every t-ray user.
+/// </summary>
+[RegisterComponent, NetworkedComponent]
+public sealed partial class SubfloorReachComponent : Component;

--- a/Resources/Prototypes/Entities/Objects/Tools/tools.yml
+++ b/Resources/Prototypes/Entities/Objects/Tools/tools.yml
@@ -516,6 +516,8 @@
     revealWhitelist:
       components:
       - AtmosPipeLayers
+  # Triad: lets the operator deconstruct the pipes the built-in t-ray reveals under floor tiles.
+  - type: SubfloorReach
   - type: LimitedCharges
     maxCharges: 45
   - type: Sprite

--- a/Resources/Prototypes/Entities/Structures/Piping/Atmospherics/alt_layers.yml
+++ b/Resources/Prototypes/Entities/Structures/Piping/Atmospherics/alt_layers.yml
@@ -724,3 +724,210 @@
       map: [ "enabled", "enum.SubfloorLayers.FirstLayer" ]
   - type: Construction
     node: dualportventpumpAlt2
+
+# Triad: cursor-quadrant layer placement for the RPD's AtmosphericUtility category (filter, mixer,
+# pneumatic valve, canister port), same body-keeps-base-RSI approach as the Vents block above. The
+# filter/mixer alts re-point Flippable at the SAME layer's mirror so an in-world flip doesn't quietly
+# drop the device back to the Primary layer.
+
+# GasFilter
+- type: entity
+  parent: [GasPipeLayerAlt1, GasFilter]
+  id: GasFilterAlt1
+  categories: [ HideSpawnMenu ]
+  components:
+  - type: Sprite
+    layers:
+    - sprite: Structures/Piping/Atmospherics/pipe_alt1.rsi
+      state: pipeTrinaryConnectors
+      map: [ "enum.PipeVisualLayers.Pipe" ]
+    - state: gasFilter
+      map: [ "enum.SubfloorLayers.FirstLayer", "enabled" ]
+  - type: Flippable
+    mirrorEntity: GasFilterFlippedAlt1
+  - type: Construction
+    node: filterAlt1
+
+- type: entity
+  parent: [GasPipeLayerAlt2, GasFilter]
+  id: GasFilterAlt2
+  categories: [ HideSpawnMenu ]
+  components:
+  - type: Sprite
+    layers:
+    - sprite: Structures/Piping/Atmospherics/pipe_alt2.rsi
+      state: pipeTrinaryConnectors
+      map: [ "enum.PipeVisualLayers.Pipe" ]
+    - state: gasFilter
+      map: [ "enum.SubfloorLayers.FirstLayer", "enabled" ]
+  - type: Flippable
+    mirrorEntity: GasFilterFlippedAlt2
+  - type: Construction
+    node: filterAlt2
+
+# GasFilterFlipped
+- type: entity
+  parent: [GasPipeLayerAlt1, GasFilterFlipped]
+  id: GasFilterFlippedAlt1
+  categories: [ HideSpawnMenu ]
+  components:
+  - type: Sprite
+    layers:
+    - sprite: Structures/Piping/Atmospherics/pipe_alt1.rsi
+      state: pipeTrinaryConnectors
+      map: [ "enum.PipeVisualLayers.Pipe" ]
+    - state: gasFilterF
+      map: [ "enum.SubfloorLayers.FirstLayer", "enabled" ]
+  - type: Flippable
+    mirrorEntity: GasFilterAlt1
+  - type: Construction
+    node: filterflippedAlt1
+
+- type: entity
+  parent: [GasPipeLayerAlt2, GasFilterFlipped]
+  id: GasFilterFlippedAlt2
+  categories: [ HideSpawnMenu ]
+  components:
+  - type: Sprite
+    layers:
+    - sprite: Structures/Piping/Atmospherics/pipe_alt2.rsi
+      state: pipeTrinaryConnectors
+      map: [ "enum.PipeVisualLayers.Pipe" ]
+    - state: gasFilterF
+      map: [ "enum.SubfloorLayers.FirstLayer", "enabled" ]
+  - type: Flippable
+    mirrorEntity: GasFilterAlt2
+  - type: Construction
+    node: filterflippedAlt2
+
+# GasMixer
+- type: entity
+  parent: [GasPipeLayerAlt1, GasMixer]
+  id: GasMixerAlt1
+  categories: [ HideSpawnMenu ]
+  components:
+  - type: Sprite
+    layers:
+    - sprite: Structures/Piping/Atmospherics/pipe_alt1.rsi
+      state: pipeTrinaryConnectors
+      map: [ "enum.PipeVisualLayers.Pipe" ]
+    - state: gasMixer
+      map: [ "enum.SubfloorLayers.FirstLayer", "enabled" ]
+  - type: Flippable
+    mirrorEntity: GasMixerFlippedAlt1
+  - type: Construction
+    node: mixerAlt1
+
+- type: entity
+  parent: [GasPipeLayerAlt2, GasMixer]
+  id: GasMixerAlt2
+  categories: [ HideSpawnMenu ]
+  components:
+  - type: Sprite
+    layers:
+    - sprite: Structures/Piping/Atmospherics/pipe_alt2.rsi
+      state: pipeTrinaryConnectors
+      map: [ "enum.PipeVisualLayers.Pipe" ]
+    - state: gasMixer
+      map: [ "enum.SubfloorLayers.FirstLayer", "enabled" ]
+  - type: Flippable
+    mirrorEntity: GasMixerFlippedAlt2
+  - type: Construction
+    node: mixerAlt2
+
+# GasMixerFlipped
+- type: entity
+  parent: [GasPipeLayerAlt1, GasMixerFlipped]
+  id: GasMixerFlippedAlt1
+  categories: [ HideSpawnMenu ]
+  components:
+  - type: Sprite
+    layers:
+    - sprite: Structures/Piping/Atmospherics/pipe_alt1.rsi
+      state: pipeTrinaryConnectors
+      map: [ "enum.PipeVisualLayers.Pipe" ]
+    - state: gasMixerF
+      map: [ "enum.SubfloorLayers.FirstLayer", "enabled" ]
+  - type: Flippable
+    mirrorEntity: GasMixerAlt1
+  - type: Construction
+    node: mixerflippedAlt1
+
+- type: entity
+  parent: [GasPipeLayerAlt2, GasMixerFlipped]
+  id: GasMixerFlippedAlt2
+  categories: [ HideSpawnMenu ]
+  components:
+  - type: Sprite
+    layers:
+    - sprite: Structures/Piping/Atmospherics/pipe_alt2.rsi
+      state: pipeTrinaryConnectors
+      map: [ "enum.PipeVisualLayers.Pipe" ]
+    - state: gasMixerF
+      map: [ "enum.SubfloorLayers.FirstLayer", "enabled" ]
+  - type: Flippable
+    mirrorEntity: GasMixerAlt2
+  - type: Construction
+    node: mixerflippedAlt2
+
+# PressureControlledValve
+- type: entity
+  parent: [GasPipeLayerAlt1, PressureControlledValve]
+  id: PressureControlledValveAlt1
+  categories: [ HideSpawnMenu ]
+  components:
+  - type: Sprite
+    layers:
+    - sprite: Structures/Piping/Atmospherics/pipe_alt1.rsi
+      state: pipeTrinaryConnectors
+      map: [ "enum.PipeVisualLayers.Pipe" ]
+    - state: "off"
+      map: [ "enum.SubfloorLayers.FirstLayer", "enabled" ]
+  - type: Construction
+    node: pneumaticvalveAlt1
+
+- type: entity
+  parent: [GasPipeLayerAlt2, PressureControlledValve]
+  id: PressureControlledValveAlt2
+  categories: [ HideSpawnMenu ]
+  components:
+  - type: Sprite
+    layers:
+    - sprite: Structures/Piping/Atmospherics/pipe_alt2.rsi
+      state: pipeTrinaryConnectors
+      map: [ "enum.PipeVisualLayers.Pipe" ]
+    - state: "off"
+      map: [ "enum.SubfloorLayers.FirstLayer", "enabled" ]
+  - type: Construction
+    node: pneumaticvalveAlt2
+
+# GasPort
+- type: entity
+  parent: [GasPipeLayerAlt1, GasPort]
+  id: GasPortAlt1
+  categories: [ HideSpawnMenu ]
+  components:
+  - type: Sprite
+    layers:
+    - sprite: Structures/Piping/Atmospherics/pipe_alt1.rsi
+      state: pipeUnaryConnectors
+      map: [ "enum.PipeVisualLayers.Pipe" ]
+    - state: gasCanisterPort
+      map: [ "enum.SubfloorLayers.FirstLayer" ]
+  - type: Construction
+    node: portAlt1
+
+- type: entity
+  parent: [GasPipeLayerAlt2, GasPort]
+  id: GasPortAlt2
+  categories: [ HideSpawnMenu ]
+  components:
+  - type: Sprite
+    layers:
+    - sprite: Structures/Piping/Atmospherics/pipe_alt2.rsi
+      state: pipeUnaryConnectors
+      map: [ "enum.PipeVisualLayers.Pipe" ]
+    - state: gasCanisterPort
+      map: [ "enum.SubfloorLayers.FirstLayer" ]
+  - type: Construction
+    node: portAlt2

--- a/Resources/Prototypes/Entities/Structures/Piping/Atmospherics/alt_layers.yml
+++ b/Resources/Prototypes/Entities/Structures/Piping/Atmospherics/alt_layers.yml
@@ -555,3 +555,172 @@
       map: [ "enum.SubfloorLayers.FirstLayer", "enabled" ]
   - type: Construction
     node: pressureregulatorAlt2
+
+# Triad: cursor-quadrant layer placement for the RPD's Vents category (air vent, passive vent, scrubber,
+# injector, dual-port vent), completing the upstream pump/valve/sensor set above. Unlike the pumps, the
+# device body keeps the base prototype's RSI (there is no offset alt art for vents and none is needed at
+# FloorObjects draw depth); only the pipe-connector sprite layer swaps to the alt RSI. The root sprite path
+# is deliberately inherited so a body-RSI change on the base propagates here.
+
+# GasVentPump
+- type: entity
+  parent: [GasPipeLayerAlt1, GasVentPump]
+  id: GasVentPumpAlt1
+  categories: [ HideSpawnMenu ]
+  components:
+  - type: Sprite
+    layers:
+    - sprite: Structures/Piping/Atmospherics/pipe_alt1.rsi
+      state: pipeUnaryConnectors
+      map: [ "enum.PipeVisualLayers.Pipe" ]
+    - state: vent_off
+      map: [ "enabled", "enum.SubfloorLayers.FirstLayer" ]
+  - type: Construction
+    node: ventpumpAlt1
+
+- type: entity
+  parent: [GasPipeLayerAlt2, GasVentPump]
+  id: GasVentPumpAlt2
+  categories: [ HideSpawnMenu ]
+  components:
+  - type: Sprite
+    layers:
+    - sprite: Structures/Piping/Atmospherics/pipe_alt2.rsi
+      state: pipeUnaryConnectors
+      map: [ "enum.PipeVisualLayers.Pipe" ]
+    - state: vent_off
+      map: [ "enabled", "enum.SubfloorLayers.FirstLayer" ]
+  - type: Construction
+    node: ventpumpAlt2
+
+# GasPassiveVent
+- type: entity
+  parent: [GasPipeLayerAlt1, GasPassiveVent]
+  id: GasPassiveVentAlt1
+  categories: [ HideSpawnMenu ]
+  components:
+  - type: Sprite
+    layers:
+    - sprite: Structures/Piping/Atmospherics/pipe_alt1.rsi
+      state: pipeUnaryConnectors
+      map: [ "enum.PipeVisualLayers.Pipe" ]
+    - state: vent_passive
+      map: [ "enum.SubfloorLayers.FirstLayer" ]
+  - type: Construction
+    node: passiveventAlt1
+
+- type: entity
+  parent: [GasPipeLayerAlt2, GasPassiveVent]
+  id: GasPassiveVentAlt2
+  categories: [ HideSpawnMenu ]
+  components:
+  - type: Sprite
+    layers:
+    - sprite: Structures/Piping/Atmospherics/pipe_alt2.rsi
+      state: pipeUnaryConnectors
+      map: [ "enum.PipeVisualLayers.Pipe" ]
+    - state: vent_passive
+      map: [ "enum.SubfloorLayers.FirstLayer" ]
+  - type: Construction
+    node: passiveventAlt2
+
+# GasVentScrubber
+- type: entity
+  parent: [GasPipeLayerAlt1, GasVentScrubber]
+  id: GasVentScrubberAlt1
+  categories: [ HideSpawnMenu ]
+  components:
+  - type: Sprite
+    layers:
+    - sprite: Structures/Piping/Atmospherics/pipe_alt1.rsi
+      state: pipeUnaryConnectors
+      map: [ "enum.PipeVisualLayers.Pipe" ]
+    - state: scrub_off
+      map: [ "enabled", "enum.SubfloorLayers.FirstLayer" ]
+  - type: Construction
+    node: ventscrubberAlt1
+
+- type: entity
+  parent: [GasPipeLayerAlt2, GasVentScrubber]
+  id: GasVentScrubberAlt2
+  categories: [ HideSpawnMenu ]
+  components:
+  - type: Sprite
+    layers:
+    - sprite: Structures/Piping/Atmospherics/pipe_alt2.rsi
+      state: pipeUnaryConnectors
+      map: [ "enum.PipeVisualLayers.Pipe" ]
+    - state: scrub_off
+      map: [ "enabled", "enum.SubfloorLayers.FirstLayer" ]
+  - type: Construction
+    node: ventscrubberAlt2
+
+# GasOutletInjector
+- type: entity
+  parent: [GasPipeLayerAlt1, GasOutletInjector]
+  id: GasOutletInjectorAlt1
+  categories: [ HideSpawnMenu ]
+  components:
+  - type: Sprite
+    layers:
+    - sprite: Structures/Piping/Atmospherics/pipe_alt1.rsi
+      state: pipeUnaryConnectors
+      map: [ "enum.PipeVisualLayers.Pipe" ]
+    - state: injector
+      map: [ "enum.SubfloorLayers.FirstLayer" ]
+    - state: injector-unshaded
+      shader: unshaded
+      map: [ "enum.LightLayers.Unshaded" ]
+      color: "#990000"
+  - type: Construction
+    node: outletinjectorAlt1
+
+- type: entity
+  parent: [GasPipeLayerAlt2, GasOutletInjector]
+  id: GasOutletInjectorAlt2
+  categories: [ HideSpawnMenu ]
+  components:
+  - type: Sprite
+    layers:
+    - sprite: Structures/Piping/Atmospherics/pipe_alt2.rsi
+      state: pipeUnaryConnectors
+      map: [ "enum.PipeVisualLayers.Pipe" ]
+    - state: injector
+      map: [ "enum.SubfloorLayers.FirstLayer" ]
+    - state: injector-unshaded
+      shader: unshaded
+      map: [ "enum.LightLayers.Unshaded" ]
+      color: "#990000"
+  - type: Construction
+    node: outletinjectorAlt2
+
+# GasDualPortVentPump
+- type: entity
+  parent: [GasPipeLayerAlt1, GasDualPortVentPump]
+  id: GasDualPortVentPumpAlt1
+  categories: [ HideSpawnMenu ]
+  components:
+  - type: Sprite
+    layers:
+    - sprite: Structures/Piping/Atmospherics/pipe_alt1.rsi
+      state: pipeBinaryConnectors
+      map: [ "enum.PipeVisualLayers.Pipe" ]
+    - state: vent_off
+      map: [ "enabled", "enum.SubfloorLayers.FirstLayer" ]
+  - type: Construction
+    node: dualportventpumpAlt1
+
+- type: entity
+  parent: [GasPipeLayerAlt2, GasDualPortVentPump]
+  id: GasDualPortVentPumpAlt2
+  categories: [ HideSpawnMenu ]
+  components:
+  - type: Sprite
+    layers:
+    - sprite: Structures/Piping/Atmospherics/pipe_alt2.rsi
+      state: pipeBinaryConnectors
+      map: [ "enum.PipeVisualLayers.Pipe" ]
+    - state: vent_off
+      map: [ "enabled", "enum.SubfloorLayers.FirstLayer" ]
+  - type: Construction
+    node: dualportventpumpAlt2

--- a/Resources/Prototypes/Entities/Structures/Piping/Atmospherics/binary.yml
+++ b/Resources/Prototypes/Entities/Structures/Piping/Atmospherics/binary.yml
@@ -466,6 +466,14 @@
           map: [ "enabled", "enum.SubfloorLayers.FirstLayer" ]
     - type: AtmosPipeLayers
       spriteRsiPaths: {}
+      # Triad: cursor-quadrant layer placement via the RPD (alt prototypes live in alt_layers.yml). Must be
+      # declared here even though GasVentPump has its own map: inheritance merges the parent's in otherwise,
+      # and an RPD-built dual-port vent aimed off-Primary would spawn a single-port GasVentPumpAlt1.
+      alternativePrototypes:
+        Primary: GasDualPortVentPump
+        Secondary: GasDualPortVentPumpAlt1
+        Tertiary: GasDualPortVentPumpAlt2
+      # End Triad
     - type: GenericVisualizer
       visuals:
         enum.VentPumpVisuals.State:

--- a/Resources/Prototypes/Entities/Structures/Piping/Atmospherics/binary.yml
+++ b/Resources/Prototypes/Entities/Structures/Piping/Atmospherics/binary.yml
@@ -426,6 +426,12 @@
           map: [ "enum.SubfloorLayers.FirstLayer" ]
     - type: AtmosPipeLayers
       spriteRsiPaths: {}
+      # Triad: cursor-quadrant layer placement via the RPD (alt prototypes live in alt_layers.yml).
+      alternativePrototypes:
+        Primary: GasPort
+        Secondary: GasPortAlt1
+        Tertiary: GasPortAlt2
+      # End Triad
     - type: Appearance
     - type: PipeColorVisuals
     - type: GasPort

--- a/Resources/Prototypes/Entities/Structures/Piping/Atmospherics/trinary.yml
+++ b/Resources/Prototypes/Entities/Structures/Piping/Atmospherics/trinary.yml
@@ -86,6 +86,14 @@
   components:
   - type: Flippable
     mirrorEntity: GasFilterFlipped
+  # Triad: cursor-quadrant layer placement via the RPD (alt prototypes live in alt_layers.yml). The
+  # component itself is inherited from GasPipeBase; this only adds the per-layer prototype map.
+  - type: AtmosPipeLayers
+    alternativePrototypes:
+      Primary: GasFilter
+      Secondary: GasFilterAlt1
+      Tertiary: GasFilterAlt2
+  # End Triad
 
 - type: entity
   parent: GasFilter
@@ -109,6 +117,15 @@
       map: [ "enum.SubfloorLayers.FirstLayer", "enabled" ]
   - type: Flippable
     mirrorEntity: GasFilter
+  # Triad: cursor-quadrant layer placement via the RPD. Declared on the flipped variant too: inheritance
+  # field-merges GasFilter's map in otherwise, and an RPD-built flipped filter aimed off-Primary would
+  # spawn an unflipped GasFilterAlt1.
+  - type: AtmosPipeLayers
+    alternativePrototypes:
+      Primary: GasFilterFlipped
+      Secondary: GasFilterFlippedAlt1
+      Tertiary: GasFilterFlippedAlt2
+  # End Triad
   - type: Appearance
   - type: GenericVisualizer
     visuals:
@@ -174,6 +191,14 @@
       inletTwo: filter
     - type: Flippable
       mirrorEntity: GasMixerFlipped
+    # Triad: cursor-quadrant layer placement via the RPD (alt prototypes live in alt_layers.yml). The
+    # component itself is inherited from GasPipeBase; this only adds the per-layer prototype map.
+    - type: AtmosPipeLayers
+      alternativePrototypes:
+        Primary: GasMixer
+        Secondary: GasMixerAlt1
+        Tertiary: GasMixerAlt2
+    # End Triad
     - type: Construction
       graph: GasTrinary
       node: mixer
@@ -216,6 +241,15 @@
   - type: PipeColorVisuals
   - type: Flippable
     mirrorEntity: GasMixer
+  # Triad: cursor-quadrant layer placement via the RPD. Declared on the flipped variant too: inheritance
+  # field-merges GasMixer's map in otherwise, and an RPD-built flipped mixer aimed off-Primary would
+  # spawn an unflipped GasMixerAlt1.
+  - type: AtmosPipeLayers
+    alternativePrototypes:
+      Primary: GasMixerFlipped
+      Secondary: GasMixerFlippedAlt1
+      Tertiary: GasMixerFlippedAlt2
+  # End Triad
   - type: NodeContainer
     nodes:
       inlet:
@@ -282,6 +316,14 @@
             False: { state: off }
     - type: PipeColorVisuals
     - type: PressureControlledValve
+    # Triad: cursor-quadrant layer placement via the RPD (alt prototypes live in alt_layers.yml). The
+    # component itself is inherited from GasPipeBase; this only adds the per-layer prototype map.
+    - type: AtmosPipeLayers
+      alternativePrototypes:
+        Primary: PressureControlledValve
+        Secondary: PressureControlledValveAlt1
+        Tertiary: PressureControlledValveAlt2
+    # End Triad
     - type: AmbientSound
       enabled: false
       volume: -9

--- a/Resources/Prototypes/Entities/Structures/Piping/Atmospherics/unary.yml
+++ b/Resources/Prototypes/Entities/Structures/Piping/Atmospherics/unary.yml
@@ -61,6 +61,14 @@
             Welded: { state: vent_welded }
             Lockout: { state: vent_lockout }
     - type: GasVentPump
+    # Triad: cursor-quadrant layer placement via the RPD (alt prototypes live in alt_layers.yml). The
+    # component itself is inherited from GasPipeBase; this only adds the per-layer prototype map.
+    - type: AtmosPipeLayers
+      alternativePrototypes:
+        Primary: GasVentPump
+        Secondary: GasVentPumpAlt1
+        Tertiary: GasVentPumpAlt2
+    # End Triad
     - type: Construction
       graph: GasUnary
       node: ventpump
@@ -103,6 +111,13 @@
     - type: Appearance
     - type: PipeColorVisuals
     - type: GasPassiveVent
+    # Triad: cursor-quadrant layer placement via the RPD (alt prototypes live in alt_layers.yml).
+    - type: AtmosPipeLayers
+      alternativePrototypes:
+        Primary: GasPassiveVent
+        Secondary: GasPassiveVentAlt1
+        Tertiary: GasPassiveVentAlt2
+    # End Triad
     - type: Construction
       graph: GasUnary
       node: passivevent
@@ -154,6 +169,13 @@
             Welded: { state: scrub_welded }
     - type: AtmosDevice
     - type: GasVentScrubber
+    # Triad: cursor-quadrant layer placement via the RPD (alt prototypes live in alt_layers.yml).
+    - type: AtmosPipeLayers
+      alternativePrototypes:
+        Primary: GasVentScrubber
+        Secondary: GasVentScrubberAlt1
+        Tertiary: GasVentScrubberAlt2
+    # End Triad
     - type: Construction
       graph: GasUnary
       node: ventscrubber
@@ -202,6 +224,13 @@
            False: { color: "#990000" }
     - type: PipeColorVisuals
     - type: GasOutletInjector
+    # Triad: cursor-quadrant layer placement via the RPD (alt prototypes live in alt_layers.yml).
+    - type: AtmosPipeLayers
+      alternativePrototypes:
+        Primary: GasOutletInjector
+        Secondary: GasOutletInjectorAlt1
+        Tertiary: GasOutletInjectorAlt2
+    # End Triad
     - type: Construction
       graph: GasUnary
       node: outletinjector

--- a/Resources/Prototypes/Recipes/Construction/Graphs/utilities/atmos_binary.yml
+++ b/Resources/Prototypes/Recipes/Construction/Graphs/utilities/atmos_binary.yml
@@ -136,6 +136,18 @@
       - material: Steel
         amount: 2
         doAfter: 1
+
+    - to: portAlt1
+      steps:
+      - material: Steel
+        amount: 2
+        doAfter: 1
+
+    - to: portAlt2
+      steps:
+      - material: Steel
+        amount: 2
+        doAfter: 1
     # End Triad
 
     - to: radiator
@@ -467,6 +479,40 @@
       steps:
       - tool: Welding
         doAfter: 1
+
+  # Triad: alt-layer node pair for the canister port (see alt_layers.yml).
+  - node: portAlt1
+    entity: GasPortAlt1
+    edges:
+    - to: start
+      conditions:
+      - !type:EntityAnchored
+        anchored: false
+      completed:
+      - !type:SpawnPrototype
+        prototype: SheetSteel1
+        amount: 2
+      - !type:DeleteEntity
+      steps:
+      - tool: Welding
+        doAfter: 1
+
+  - node: portAlt2
+    entity: GasPortAlt2
+    edges:
+    - to: start
+      conditions:
+      - !type:EntityAnchored
+        anchored: false
+      completed:
+      - !type:SpawnPrototype
+        prototype: SheetSteel1
+        amount: 2
+      - !type:DeleteEntity
+      steps:
+      - tool: Welding
+        doAfter: 1
+  # End Triad
 
   - node: dualportventpump
     entity: GasDualPortVentPump

--- a/Resources/Prototypes/Recipes/Construction/Graphs/utilities/atmos_binary.yml
+++ b/Resources/Prototypes/Recipes/Construction/Graphs/utilities/atmos_binary.yml
@@ -124,6 +124,20 @@
         amount: 2
         doAfter: 1
 
+    # Triad: alt-layer variants for RPD cursor-quadrant placement (see alt_layers.yml).
+    - to: dualportventpumpAlt1
+      steps:
+      - material: Steel
+        amount: 2
+        doAfter: 1
+
+    - to: dualportventpumpAlt2
+      steps:
+      - material: Steel
+        amount: 2
+        doAfter: 1
+    # End Triad
+
     - to: radiator
       steps:
       - material: Steel
@@ -471,6 +485,44 @@
         doAfter: 1
       - tool: Welding
         doAfter: 1
+
+  # Triad
+  - node: dualportventpumpAlt1
+    entity: GasDualPortVentPumpAlt1
+    edges:
+    - to: start
+      conditions:
+      - !type:EntityAnchored
+        anchored: false
+      completed:
+      - !type:SpawnPrototype
+        prototype: SheetSteel1
+        amount: 2
+      - !type:DeleteEntity
+      steps:
+      - tool: Screwing
+        doAfter: 1
+      - tool: Welding
+        doAfter: 1
+
+  - node: dualportventpumpAlt2
+    entity: GasDualPortVentPumpAlt2
+    edges:
+    - to: start
+      conditions:
+      - !type:EntityAnchored
+        anchored: false
+      completed:
+      - !type:SpawnPrototype
+        prototype: SheetSteel1
+        amount: 2
+      - !type:DeleteEntity
+      steps:
+      - tool: Screwing
+        doAfter: 1
+      - tool: Welding
+        doAfter: 1
+  # End Triad
 
   - node: radiator
     entity: HeatExchanger

--- a/Resources/Prototypes/Recipes/Construction/Graphs/utilities/atmos_trinary.yml
+++ b/Resources/Prototypes/Recipes/Construction/Graphs/utilities/atmos_trinary.yml
@@ -43,6 +43,68 @@
         amount: 2
         doAfter: 1
 
+    # Triad: alt-layer variants for RPD cursor-quadrant placement (see alt_layers.yml).
+    - to: filterAlt1
+      steps:
+      - material: Steel
+        amount: 2
+        doAfter: 1
+
+    - to: filterAlt2
+      steps:
+      - material: Steel
+        amount: 2
+        doAfter: 1
+
+    - to: filterflippedAlt1
+      steps:
+      - material: Steel
+        amount: 2
+        doAfter: 1
+
+    - to: filterflippedAlt2
+      steps:
+      - material: Steel
+        amount: 2
+        doAfter: 1
+
+    - to: mixerAlt1
+      steps:
+      - material: Steel
+        amount: 2
+        doAfter: 1
+
+    - to: mixerAlt2
+      steps:
+      - material: Steel
+        amount: 2
+        doAfter: 1
+
+    - to: mixerflippedAlt1
+      steps:
+      - material: Steel
+        amount: 2
+        doAfter: 1
+
+    - to: mixerflippedAlt2
+      steps:
+      - material: Steel
+        amount: 2
+        doAfter: 1
+
+    - to: pneumaticvalveAlt1
+      steps:
+      - material: Steel
+        amount: 2
+        doAfter: 1
+
+    - to: pneumaticvalveAlt2
+      steps:
+      - material: Steel
+        amount: 2
+        doAfter: 1
+    # End Triad
+
   # Filter
   - node: filter
     entity: GasFilter
@@ -141,3 +203,165 @@
       steps:
       - tool: Welding
         doAfter: 1
+
+  # Triad: alt-layer node pairs for each trinary device (see alt_layers.yml).
+  - node: filterAlt1
+    entity: GasFilterAlt1
+    edges:
+    - to: start
+      conditions:
+      - !type:EntityAnchored
+        anchored: false
+      completed:
+      - !type:SpawnPrototype
+        prototype: SheetSteel1
+        amount: 2
+      - !type:DeleteEntity
+      steps:
+      - tool: Welding
+        doAfter: 1
+
+  - node: filterAlt2
+    entity: GasFilterAlt2
+    edges:
+    - to: start
+      conditions:
+      - !type:EntityAnchored
+        anchored: false
+      completed:
+      - !type:SpawnPrototype
+        prototype: SheetSteel1
+        amount: 2
+      - !type:DeleteEntity
+      steps:
+      - tool: Welding
+        doAfter: 1
+
+  - node: filterflippedAlt1
+    entity: GasFilterFlippedAlt1
+    edges:
+    - to: start
+      conditions:
+      - !type:EntityAnchored
+        anchored: false
+      completed:
+      - !type:SpawnPrototype
+        prototype: SheetSteel1
+        amount: 2
+      - !type:DeleteEntity
+      steps:
+      - tool: Welding
+        doAfter: 1
+
+  - node: filterflippedAlt2
+    entity: GasFilterFlippedAlt2
+    edges:
+    - to: start
+      conditions:
+      - !type:EntityAnchored
+        anchored: false
+      completed:
+      - !type:SpawnPrototype
+        prototype: SheetSteel1
+        amount: 2
+      - !type:DeleteEntity
+      steps:
+      - tool: Welding
+        doAfter: 1
+
+  - node: mixerAlt1
+    entity: GasMixerAlt1
+    edges:
+    - to: start
+      conditions:
+      - !type:EntityAnchored
+        anchored: false
+      completed:
+      - !type:SpawnPrototype
+        prototype: SheetSteel1
+        amount: 2
+      - !type:DeleteEntity
+      steps:
+      - tool: Welding
+        doAfter: 1
+
+  - node: mixerAlt2
+    entity: GasMixerAlt2
+    edges:
+    - to: start
+      conditions:
+      - !type:EntityAnchored
+        anchored: false
+      completed:
+      - !type:SpawnPrototype
+        prototype: SheetSteel1
+        amount: 2
+      - !type:DeleteEntity
+      steps:
+      - tool: Welding
+        doAfter: 1
+
+  - node: mixerflippedAlt1
+    entity: GasMixerFlippedAlt1
+    edges:
+    - to: start
+      conditions:
+      - !type:EntityAnchored
+        anchored: false
+      completed:
+      - !type:SpawnPrototype
+        prototype: SheetSteel1
+        amount: 2
+      - !type:DeleteEntity
+      steps:
+      - tool: Welding
+        doAfter: 1
+
+  - node: mixerflippedAlt2
+    entity: GasMixerFlippedAlt2
+    edges:
+    - to: start
+      conditions:
+      - !type:EntityAnchored
+        anchored: false
+      completed:
+      - !type:SpawnPrototype
+        prototype: SheetSteel1
+        amount: 2
+      - !type:DeleteEntity
+      steps:
+      - tool: Welding
+        doAfter: 1
+
+  - node: pneumaticvalveAlt1
+    entity: PressureControlledValveAlt1
+    edges:
+    - to: start
+      conditions:
+      - !type:EntityAnchored
+        anchored: false
+      completed:
+      - !type:SpawnPrototype
+        prototype: SheetSteel1
+        amount: 2
+      - !type:DeleteEntity
+      steps:
+      - tool: Welding
+        doAfter: 1
+
+  - node: pneumaticvalveAlt2
+    entity: PressureControlledValveAlt2
+    edges:
+    - to: start
+      conditions:
+      - !type:EntityAnchored
+        anchored: false
+      completed:
+      - !type:SpawnPrototype
+        prototype: SheetSteel1
+        amount: 2
+      - !type:DeleteEntity
+      steps:
+      - tool: Welding
+        doAfter: 1
+  # End Triad

--- a/Resources/Prototypes/Recipes/Construction/Graphs/utilities/atmos_unary.yml
+++ b/Resources/Prototypes/Recipes/Construction/Graphs/utilities/atmos_unary.yml
@@ -10,11 +10,39 @@
         amount: 2
         doAfter: 1
 
+    # Triad: alt-layer variants for RPD cursor-quadrant placement, mirroring the pump/valve alts in GasBinary.
+    - to: ventpumpAlt1
+      steps:
+      - material: Steel
+        amount: 2
+        doAfter: 1
+
+    - to: ventpumpAlt2
+      steps:
+      - material: Steel
+        amount: 2
+        doAfter: 1
+    # End Triad
+
     - to: passivevent
       steps:
       - material: Steel
         amount: 2
         doAfter: 1
+
+    # Triad
+    - to: passiveventAlt1
+      steps:
+      - material: Steel
+        amount: 2
+        doAfter: 1
+
+    - to: passiveventAlt2
+      steps:
+      - material: Steel
+        amount: 2
+        doAfter: 1
+    # End Triad
 
     - to: ventscrubber
       steps:
@@ -22,11 +50,39 @@
         amount: 2
         doAfter: 1
 
+    # Triad
+    - to: ventscrubberAlt1
+      steps:
+      - material: Steel
+        amount: 2
+        doAfter: 1
+
+    - to: ventscrubberAlt2
+      steps:
+      - material: Steel
+        amount: 2
+        doAfter: 1
+    # End Triad
+
     - to: outletinjector
       steps:
       - material: Steel
         amount: 2
         doAfter: 1
+
+    # Triad
+    - to: outletinjectorAlt1
+      steps:
+      - material: Steel
+        amount: 2
+        doAfter: 1
+
+    - to: outletinjectorAlt2
+      steps:
+      - material: Steel
+        amount: 2
+        doAfter: 1
+    # End Triad
 
   - node: ventpump
     entity: GasVentPump
@@ -46,6 +102,44 @@
       - tool: Welding
         doAfter: 1
 
+  # Triad: alt-layer node pairs for each unary device (see alt_layers.yml).
+  - node: ventpumpAlt1
+    entity: GasVentPumpAlt1
+    edges:
+    - to: start
+      conditions:
+      - !type:EntityAnchored
+        anchored: false
+      completed:
+      - !type:SpawnPrototype
+        prototype: SheetSteel1
+        amount: 2
+      - !type:DeleteEntity
+      steps:
+      - tool: Screwing
+        doAfter: 1
+      - tool: Welding
+        doAfter: 1
+
+  - node: ventpumpAlt2
+    entity: GasVentPumpAlt2
+    edges:
+    - to: start
+      conditions:
+      - !type:EntityAnchored
+        anchored: false
+      completed:
+      - !type:SpawnPrototype
+        prototype: SheetSteel1
+        amount: 2
+      - !type:DeleteEntity
+      steps:
+      - tool: Screwing
+        doAfter: 1
+      - tool: Welding
+        doAfter: 1
+  # End Triad
+
   - node: passivevent
     entity: GasPassiveVent
     edges:
@@ -63,6 +157,44 @@
         doAfter: 1
       - tool: Welding
         doAfter: 1
+
+  # Triad
+  - node: passiveventAlt1
+    entity: GasPassiveVentAlt1
+    edges:
+    - to: start
+      conditions:
+      - !type:EntityAnchored
+        anchored: false
+      completed:
+      - !type:SpawnPrototype
+        prototype: SheetSteel1
+        amount: 2
+      - !type:DeleteEntity
+      steps:
+      - tool: Screwing
+        doAfter: 1
+      - tool: Welding
+        doAfter: 1
+
+  - node: passiveventAlt2
+    entity: GasPassiveVentAlt2
+    edges:
+    - to: start
+      conditions:
+      - !type:EntityAnchored
+        anchored: false
+      completed:
+      - !type:SpawnPrototype
+        prototype: SheetSteel1
+        amount: 2
+      - !type:DeleteEntity
+      steps:
+      - tool: Screwing
+        doAfter: 1
+      - tool: Welding
+        doAfter: 1
+  # End Triad
 
   - node: ventscrubber
     entity: GasVentScrubber
@@ -82,6 +214,44 @@
       - tool: Welding
         doAfter: 1
 
+  # Triad
+  - node: ventscrubberAlt1
+    entity: GasVentScrubberAlt1
+    edges:
+    - to: start
+      conditions:
+      - !type:EntityAnchored
+        anchored: false
+      completed:
+      - !type:SpawnPrototype
+        prototype: SheetSteel1
+        amount: 2
+      - !type:DeleteEntity
+      steps:
+      - tool: Screwing
+        doAfter: 1
+      - tool: Welding
+        doAfter: 1
+
+  - node: ventscrubberAlt2
+    entity: GasVentScrubberAlt2
+    edges:
+    - to: start
+      conditions:
+      - !type:EntityAnchored
+        anchored: false
+      completed:
+      - !type:SpawnPrototype
+        prototype: SheetSteel1
+        amount: 2
+      - !type:DeleteEntity
+      steps:
+      - tool: Screwing
+        doAfter: 1
+      - tool: Welding
+        doAfter: 1
+  # End Triad
+
   - node: outletinjector
     entity: GasOutletInjector
     edges:
@@ -97,3 +267,37 @@
       steps:
       - tool: Welding
         doAfter: 1
+
+  # Triad
+  - node: outletinjectorAlt1
+    entity: GasOutletInjectorAlt1
+    edges:
+    - to: start
+      conditions:
+      - !type:EntityAnchored
+        anchored: false
+      completed:
+      - !type:SpawnPrototype
+        prototype: SheetSteel1
+        amount: 2
+      - !type:DeleteEntity
+      steps:
+      - tool: Welding
+        doAfter: 1
+
+  - node: outletinjectorAlt2
+    entity: GasOutletInjectorAlt2
+    edges:
+    - to: start
+      conditions:
+      - !type:EntityAnchored
+        anchored: false
+      completed:
+      - !type:SpawnPrototype
+        prototype: SheetSteel1
+        amount: 2
+      - !type:DeleteEntity
+      steps:
+      - tool: Welding
+        doAfter: 1
+  # End Triad

--- a/Resources/Prototypes/_Triad/RPD/rpd.yml
+++ b/Resources/Prototypes/_Triad/RPD/rpd.yml
@@ -256,6 +256,9 @@
   collisionMask: Impassable
   rotation: User
   fx: EffectRCDConstruct0
+  # Radiators are numberOfPipeLayers: 1 by design (they exchange with the environment, not a layer),
+  # so the layer guide dots would promise a choice the entity can't honor.
+  noLayers: true
 
 - type: rcd
   id: RadiatorBend
@@ -270,6 +273,7 @@
   collisionMask: Impassable
   rotation: User
   fx: EffectRCDConstruct0
+  noLayers: true # single-layer by design, same as Radiator above
 
 - type: rcd
   id: MixerGas


### PR DESCRIPTION
## About the PR

The RPD now commits builds and deconstructs to the pipe layer you're aiming at, across the whole catalog. Pipes already worked this way; this extends the cursor-quadrant aim to vents, scrubbers, injectors, the dual-port vent, filters, mixers, the pneumatic valve, and the canister port, and makes deconstruct respect the same aim, including pipes buried under floor tiles or shadowed by firelocks.

Under the hood the client pushes the chosen layer to the server (replacing the old eye-rotation streaming), RCDSystem stops knowing what an RPD is (sibling admission via event seams instead), and recipe rotation is applied at spawn so the anchor-time overlap check sees the real facing.

For anyone cherry-picking, this sits on top of:
- #124 — Rapid Piping Device 2: Atmosia's Revenge (the RPD port itself)
- #187 — RPD Polish Pass (subfloor deconstruct, RPD sizing; superseded in part by this PR)
- Monolith-Station/Monolith#1922 — Layering for Atmospherics Pipes and Certain Devices (the pipe-layer foundation and alt_layers.yml)
- Original RPD lineage is funky-station (PRs #62/#1244/#1338/#1458/#1289 there); see the header in `Resources/Prototypes/_Triad/RPD/rpd.yml`

## Why / Balance

Quality of life for atmos work. No balance impact: same costs, same materials, same recipes. The only thing that changes is that the layer you aim at is the layer you get. Radiators are deliberately excluded since they're single-layer by design; their recipes now say so instead of showing layer dots that don't do anything.

## Media

u when you use this. trust me. i'm too tired to add footage.

<img width="402" height="613" alt="image" src="https://github.com/user-attachments/assets/fc42f2de-3968-4ffd-87ae-105e7d9d3d88" />


## Requirements

- [x] I have read relevant guidelines/documentation to this PR found on [our devwiki](https://monolith-station.github.io/mono-docs/).
- [x] I have added media to this PR or it does not require an ingame showcase.
- [x] I can confirm this PR contains either no AI-generated content, or AI-generated content that meets our guidelines.

## How to test

1. Spawn an RPD, pick any pipe or device recipe, and hover a tile: the three guide dots show the layer your cursor quadrant selects. Build on each layer and check the device lands on it (examine, or t-ray the connectors).
2. Stack pipes on different layers on one tile, switch to Deconstruct, and aim at a quadrant: the pipe on the aimed layer is the one that gets chewed, including under a floor tile or a firelock.
3. Build a flipped filter/mixer off-Primary and confirm it spawns flipped on the aimed layer; flip it in-world and confirm it stays on its layer.
4. Radiators show no layer dots and always build normally.
5. `dotnet test --filter FullyQualifiedName~RPD` covers the alt-prototype wiring, layer coexistence, overlap, and spawn rotation.

## Breaking changes

- `RPDEyeRotationEvent` and `RPDComponent.LastKnownEyeRotation` are removed; the client now sends `RPDLayerSelectEvent` and the server stores the pick via `RPDSystem.SetLayer`.
- `RCDDeconstructAttemptEvent` gains an `Admitted` flag (sibling systems admit targets RCD would reject).
- New `RCDConstructionAttemptEvent` raised during construct validation so a sibling can veto placement.

**Changelog**
:cl:
- tweak: The RPD builds vents, scrubbers, injectors, filters, mixers, valves, and canister ports on the pipe layer you're aiming at, just like pipes.
- fix: The RPD can deconstruct pipes hidden under floor tiles or sitting beneath firelocks, and it targets the layer you aim at.
- fix: RPD-built devices respect their facing at placement time, so rotated builds no longer collide with devices they don't actually overlap.