### PR TITLE
Less Lethal Clake

### DIFF
--- a/Resources/Prototypes/Entities/Objects/Fun/skub.yml
+++ b/Resources/Prototypes/Entities/Objects/Fun/skub.yml
@@ -36,3 +36,4 @@
     hidden: true
   - type: UseDelay
     delay: 2.0
+  - type: HLPersistOnShipSave # Triad

--- a/Resources/Prototypes/Entities/Objects/Fun/skub.yml
+++ b/Resources/Prototypes/Entities/Objects/Fun/skub.yml
@@ -36,4 +36,3 @@
     hidden: true
   - type: UseDelay
     delay: 2.0
-  - type: HLPersistOnShipSave # Triad

--- a/Resources/Prototypes/Entities/Objects/Weapons/Guns/Launchers/launchers.yml
+++ b/Resources/Prototypes/Entities/Objects/Weapons/Guns/Launchers/launchers.yml
@@ -52,6 +52,7 @@
     whitelist:
       tags:
         - Grenade
+        - LessLethalGrenade
     capacity: 3
     proto: 40mmGrenadeFragmentation
     soundInsert:

--- a/Resources/Prototypes/Entities/Objects/Weapons/Guns/Launchers/launchers.yml
+++ b/Resources/Prototypes/Entities/Objects/Weapons/Guns/Launchers/launchers.yml
@@ -52,7 +52,7 @@
     whitelist:
       tags:
         - Grenade
-        - LessLethalGrenade
+        - LessLethalGrenade #Triad
     capacity: 3
     proto: 40mmGrenadeFragmentation
     soundInsert:


### PR DESCRIPTION
## About the PR
Added the LessLethalAmmo tag to the clake's ammo whitelist.

## Why / Balance
Just adds some nonlethal utility to the clake.

## Media
<img width="209" height="189" alt="image" src="https://github.com/user-attachments/assets/d7c1d695-a918-4ba0-92a0-9573409c12ce" />
<img width="489" height="316" alt="image" src="https://github.com/user-attachments/assets/e70b8b11-b22e-49cb-869b-47144680360c" />


## Requirements
- [ x] I have read relevant guidelines/documentation to this PR found on [our devwiki](https://monolith-station.github.io/mono-docs/).
- [ x] I have added media to this PR or it does not require an ingame showcase.
- [x ] I can confirm this PR contains either no AI-generated content, or AI-generated content that meets our guidelines.

## How to test
Spawn in CLAKE, Spawn 40MM EMP rounds and Flash rounds, fire away.


**Changelog**
:cl:
- add: Added LessLethal ammo (EMP and Flash) to the China Lake! PLOOP!
