### PR TITLE
Fix/Server Exception Sweep #2

### DIFF
--- a/Content.Server/DeviceLinking/Systems/DeviceLinkSystem.cs
+++ b/Content.Server/DeviceLinking/Systems/DeviceLinkSystem.cs
@@ -23,7 +23,11 @@ public sealed class DeviceLinkSystem : SharedDeviceLinkSystem
     #region Sending & Receiving
     public override void InvokePort(EntityUid uid, string port, NetworkPayload? data = null, DeviceLinkSourceComponent? sourceComponent = null)
     {
-        if (!Resolve(uid, ref sourceComponent) || !sourceComponent.Outputs.TryGetValue(port, out var sinks))
+        // Triad: InvokePort is a no-op when the entity isn't a wired source, so a missing
+        // DeviceLinkSourceComponent is not an error. Resolve with logMissing:false to match the
+        // already-silent missing-port case below; the loud default spammed the server log whenever
+        // an entity (e.g. a disposal unit) invoked a port without being wired as a source.
+        if (!Resolve(uid, ref sourceComponent, false) || !sourceComponent.Outputs.TryGetValue(port, out var sinks))
             return;
 
         foreach (var sinkUid in sinks)

--- a/Content.Server/Shuttles/Systems/ShuttleSystem.FasterThanLight.cs
+++ b/Content.Server/Shuttles/Systems/ShuttleSystem.FasterThanLight.cs
@@ -444,6 +444,13 @@ public sealed partial class ShuttleSystem
 
         hyperspace.StartupTime = startupTime.Value;
         hyperspace.TravelTime = hyperspaceTime.Value;
+        // Triad: FTLToDock routes through here via EnsureComp<FTLComponent> but, unlike TrySetupFTL,
+        // never set the state. A freshly-ensured component stays in its default Available state, so once
+        // StateTime elapsed UpdateHyperspace hit the default case, logged "invalid FTL state Available"
+        // and dropped the component. That broke the public transit bus (it spammed errors every route
+        // cycle and never advanced through the FTL state machine). State and StateTime define the
+        // Starting phase together, so set them together here.
+        hyperspace.State = FTLState.Starting;
         hyperspace.StateTime = StartEndTime.FromStartDuration(
             _gameTiming.CurTime,
             TimeSpan.FromSeconds(hyperspace.StartupTime));

--- a/Content.Server/_EinsteinEngines/Silicon/WeldingHealable/WeldingHealableSystem.cs
+++ b/Content.Server/_EinsteinEngines/Silicon/WeldingHealable/WeldingHealableSystem.cs
@@ -97,8 +97,11 @@ public sealed class WeldingHealableSystem : SharedWeldingHealableSystem
         if (healable.Damage.DamageDict is null)
             return false;
 
+        // Triad: the target may not track every damage type the welder can heal (e.g. a silicon
+        // whose damage container has no "Radiation" key). Indexing by key threw KeyNotFoundException;
+        // TryGetValue treats an untracked type as zero damage instead of crashing the tick.
         foreach (var type in healable.Damage.DamageDict)
-            if (damageable.Comp.Damage.DamageDict[type.Key].Value > 0)
+            if (damageable.Comp.Damage.DamageDict.TryGetValue(type.Key, out var value) && value.Value > 0)
                 return true;
 
         // In case the healer is a humanoid entity with targeting, we run the check on the targeted parts.
@@ -109,7 +112,7 @@ public sealed class WeldingHealableSystem : SharedWeldingHealableSystem
         foreach (var part in _bodySystem.GetBodyChildrenOfType(damageable, targetType, symmetry: targetSymmetry))
             if (TryComp<DamageableComponent>(part.Id, out var damageablePart))
                 foreach (var type in healable.Damage.DamageDict)
-                    if (damageablePart.Damage.DamageDict[type.Key].Value > 0)
+                    if (damageablePart.Damage.DamageDict.TryGetValue(type.Key, out var partValue) && partValue.Value > 0)
                         return true;
 
         return false;

--- a/Content.Shared/Weapons/Melee/SharedMeleeWeaponSystem.cs
+++ b/Content.Shared/Weapons/Melee/SharedMeleeWeaponSystem.cs
@@ -179,12 +179,11 @@ public abstract class SharedMeleeWeaponSystem : EntitySystem
         if (args.SenderSession.AttachedEntity is not {} user)
             return;
 
-        // Validate that the user entity is valid
+        // Triad: a stale/invalid attached entity (lagging or transitioning player sending a late
+        // attack event) is routine, not an error. Return silently. The Log.Error inherited from
+        // #1255 "Console Error Spam Fix Attempt" was itself the #1 server log offender (~2400/48h).
         if (!user.IsValid())
-        {
-            Log.Error($"OnLightAttack received invalid user entity: {user} from session {args.SenderSession}");
             return;
-        }
 
         if (!TryGetWeapon(user, out var weaponUid, out var weapon) ||
             weaponUid != GetEntity(msg.Weapon))
@@ -200,12 +199,11 @@ public abstract class SharedMeleeWeaponSystem : EntitySystem
         if (args.SenderSession.AttachedEntity is not {} user)
             return;
 
-        // Validate that the user entity is valid
+        // Triad: a stale/invalid attached entity (lagging or transitioning player sending a late
+        // attack event) is routine, not an error. Return silently. The Log.Error inherited from
+        // #1255 "Console Error Spam Fix Attempt" was itself the #1 server log offender (~2400/48h).
         if (!user.IsValid())
-        {
-            Log.Error($"OnHeavyAttack received invalid user entity: {user} from session {args.SenderSession}");
             return;
-        }
 
         if (!TryGetWeapon(user, out var weaponUid, out var weapon) ||
             weaponUid != GetEntity(msg.Weapon) ||
@@ -222,12 +220,11 @@ public abstract class SharedMeleeWeaponSystem : EntitySystem
         if (args.SenderSession.AttachedEntity is not {} user)
             return;
 
-        // Validate that the user entity is valid
+        // Triad: a stale/invalid attached entity (lagging or transitioning player sending a late
+        // attack event) is routine, not an error. Return silently. The Log.Error inherited from
+        // #1255 "Console Error Spam Fix Attempt" was itself the #1 server log offender (~2400/48h).
         if (!user.IsValid())
-        {
-            Log.Error($"OnDisarmAttack received invalid user entity: {user} from session {args.SenderSession}");
             return;
-        }
 
         if (TryGetWeapon(user, out var weaponUid, out var weapon))
             AttemptAttack(user, weaponUid, weapon, msg, args.SenderSession);
@@ -584,12 +581,10 @@ public abstract class SharedMeleeWeaponSystem : EntitySystem
     {
         // TODO: This is copy-paste as fuck with DoPreciseAttack
 
-        // Validate that the user entity is valid
+        // Triad: defensive guard kept, but a stale/invalid user (lagging player, late event) is
+        // routine, not an error. Return silently instead of the inherited #1255 Log.Error spam.
         if (!user.IsValid())
-        {
-            Log.Error($"DoHeavyAttack called with invalid user entity: {user}");
             return false;
-        }
 
         if (!TryComp(user, out TransformComponent? userXform))
             return false;

--- a/Resources/Prototypes/Entities/Structures/Piping/Disposal/units.yml
+++ b/Resources/Prototypes/Entities/Structures/Piping/Disposal/units.yml
@@ -93,6 +93,24 @@
       - DisposalEject
       sources:
       - DisposalReady
+  # Triad: AutomationSlots above declares device-link ports and DisposalSignalSystem already
+  # handles them (Flush/Eject/Toggle sinks), but the device-link components backing those ports
+  # were dropped when AutomationSlots was ported in. Without them the signals never arrived
+  # (disposal automation was dead) and the network configurator logged "Can't resolve
+  # DeviceLinkSourceComponent" on every disposal unit. Restore the wiring, mirroring the Autolathe.
+  - type: DeviceNetwork
+    deviceNetId: Wireless
+    receiveFrequencyId: BasicDevice
+  - type: WirelessNetworkConnection
+    range: 200
+  - type: DeviceLinkSink
+    ports:
+    - Toggle
+    - DisposalFlush
+    - DisposalEject
+  - type: DeviceLinkSource
+    ports:
+    - DisposalReady
   # Mono
   - type: ShipRepairable
     repairTime: 5


### PR DESCRIPTION
## About the PR

A second pass over the live server's exception log. We pulled the highest-volume errors from the last 48h in Grafana/Loki and fixed the five that traced back to content code, from the single loudest log spammer down to an actual crash.

## Why / Balance

Each change is small and either drops a bad log, hardens an unsafe lookup, or restores wiring. Breakdown of what each commit addresses and its prod volume over 48h:

| Fix | What was wrong | Volume |
|---|---|---|
| Melee invalid-user log | The inherited #1255 "Console Error Spam Fix Attempt" added `Log.Error` to the attack handlers for invalid attacking entities. A lagging player firing a late `HeavyAttackEvent` after their mob detaches is routine, not an error, so it became the single loudest server-log line. Kept the early-returns, dropped the logging. | ~2400 |
| Device-link `InvokePort` | `InvokePort` no-ops when an entity isn't a wired source, but it resolved the source component with `logMissing:true`, so every unwired invoke logged a stack. Switched to `logMissing:false` to match the already-silent missing-port branch on the same line. | ~690 |
| Disposal device-link wiring | Disposal units lost their `DeviceLinkSource` wiring, so `UpdateState` invoking the Ready port hit the case above and automation couldn't react to them. Restored the components and ports in `units.yml`. | (feeds the above) |
| Transit-bus FTL | The public transit shuttle could land in `FTLState.Available` and re-arm every cycle without ever transitioning to `Starting`, so the update loop logged an invalid-state error forever. | large share of ~3100 |
| Welding-heal `KeyNotFound` | `WeldingHealableSystem.HasDamage` indexed the target's `DamageDict` by the welder's heal-type keys. A silicon whose damage container omits a heal type (e.g. `Radiation`) threw `KeyNotFoundException` mid-tick. Now uses `TryGetValue`. | ~54 (a real crash) |

Two other top offenders were ruled out as content fixes: the "network unreachable" unobserved-task spam is HappyEyeballs' IPv6 leg failing on a box with no IPv6 route (engine/infra), and the metrics disposed-object writes are a Prometheus scrape-disconnect race in the engine listener.

## Media

Server-side stability and logging only, no ingame visual changes. Exempt.

## Requirements

- [x] I have read relevant guidelines/documentation to this PR found on our devwiki.
- [x] I have added media to this PR or it does not require an ingame showcase.
- [x] I can confirm this PR contains either no AI-generated content, or AI-generated content that meets our guidelines.

## How to test

1. With server logs visible, have a player heavy-attack while lagging or right as their mob is deleted, confirm no `OnHeavyAttack received invalid user entity` / `DoHeavyAttack called with invalid user entity` error spam.
2. Trigger a disposal unit linked to a device (e.g. a signal-driven setup), confirm the linked port fires and no `Can't resolve DeviceLinkSourceComponent` error appears.
3. Ride the public transit shuttle through a full cycle, confirm it departs normally and no `Found invalid FTL state Available` spam.
4. Weld-repair a silicon/IPC whose damage container doesn't include every type the welder heals, confirm it heals (or no-ops) without a `KeyNotFoundException`.

## Breaking changes

None.

**Changelog**

:cl:
- fix: The public transit shuttle no longer gets stuck and unable to depart.
- fix: Disposal units once again trigger their linked devices for automation.
- fix: Welding-repairing a silicon no longer errors when the target is missing a damage type the welder can heal.
