### PR TITLE
Ship Load Fee Is Now Visible in the Shipyard Console UI

### DIFF
--- a/Content.Client/Shuttles/Save/ShipFileManagementSystem.cs
+++ b/Content.Client/Shuttles/Save/ShipFileManagementSystem.cs
@@ -391,6 +391,19 @@ namespace Content.Client.Shuttles.Save
             }
         }
 
+        // Useful for gathering fields inside of a ship YML file, like the stored appraisal value
+        public string GetKeyValueFromPath(string filePath, string key)
+        {
+            using var reader = _resourceManager.UserData.OpenText(new(filePath));
+            var content = reader.ReadToEnd();
+
+            // lazy loading
+            var lines = content.Split('\n');
+            var val = lines.FirstOrDefault(l => l.Trim().StartsWith($"{key}:"))?.Split(':')[1].Trim() ?? "Unknown";
+
+            return val;
+        }
+
         // Update ship index periodically instead of on every change
         public void FlushPendingIndexUpdates()
         {

--- a/Content.Client/_NF/Shipyard/BUI/ShipyardConsoleBoundUserInterface.cs
+++ b/Content.Client/_NF/Shipyard/BUI/ShipyardConsoleBoundUserInterface.cs
@@ -6,10 +6,14 @@ using static Robust.Client.UserInterface.Controls.BaseButton;
 using Robust.Client.UserInterface;
 using Content.Client.Shuttles.Save;
 using Robust.Client.UserInterface.Controls;
-using Robust.Client.UserInterface.XAML;
+using System.Text.RegularExpressions;
 using Robust.Shared.IoC;
 using Robust.Shared.Log;
 using System.Linq;
+using Robust.Shared.Serialization.Markdown;
+using System.IO;
+using Robust.Shared.Serialization.Markdown.Mapping;
+using Robust.Shared.Serialization.Markdown.Value;
 
 namespace Content.Client._NF.Shipyard.BUI;
 
@@ -27,9 +31,11 @@ public sealed class ShipyardConsoleBoundUserInterface : BoundUserInterface
     private Button? _loadShipButton;
     private Button? _saveShipButton;
     private ItemList? _savedShipsList;
+    private Label? _selectedShipPriceLabel;
     private int _selectedShipIndex = -1;
 
-
+    // This should be the same as Content.Server/_Triad/Shipyard/AuthenticatedShipFile/AppraisalKey
+    private const string AppraisalKey = "appraisal";
 
     public ShipyardConsoleBoundUserInterface(EntityUid owner, Enum uiKey) : base(owner, uiKey)
     {
@@ -79,13 +85,16 @@ public sealed class ShipyardConsoleBoundUserInterface : BoundUserInterface
         _loadShipButton = _menu.FindControl<Button>("LoadShipButton");
         _saveShipButton = _menu.FindControl<Button>("SaveShipButton");
         _savedShipsList = _menu.FindControl<ItemList>("SavedShipsList");
+        _selectedShipPriceLabel = _menu.FindControl<Label>("SelectedShipPriceLabel");
 
-        if (_loadShipButton != null)
-            _loadShipButton.OnPressed += OnLoadShipButtonPressed;
+        _loadShipButton?.OnPressed += OnLoadShipButtonPressed;
         // Save button already wired via ShipyardConsoleMenu to raise OnSaveShip, which we handle in SaveShip()
         // Avoid wiring a second handler that would incorrectly send a direct save request.
         if (_savedShipsList != null)
+        {
             _savedShipsList.OnItemSelected += OnSavedShipSelected;
+            _savedShipsList.OnItemDeselected += OnSavedShipDeselected;
+        }
 
         // Subscribe to ship updates
         _shipFileManagementSystem.OnShipsUpdated += RefreshSavedShipList;
@@ -130,12 +139,29 @@ public sealed class ShipyardConsoleBoundUserInterface : BoundUserInterface
         }
     }
 
-    private void OnSavedShipSelected(ItemList.ItemListSelectedEventArgs args)
+    private async void OnSavedShipSelected(ItemList.ItemListSelectedEventArgs args)
     {
         // Store selected index and update Load Ship button state
         _selectedShipIndex = args.ItemIndex;
-        if (_loadShipButton != null)
-            _loadShipButton.Disabled = false;
+        _loadShipButton?.Disabled = false;
+
+        // Set load price label
+        var selectedItem = args.ItemList[_selectedShipIndex];
+        var filePath = (string)selectedItem.Metadata!;
+        var appraisalValue = _shipFileManagementSystem.GetKeyValueFromPath(filePath, AppraisalKey);
+
+        // Round it up
+        if (double.TryParse(appraisalValue, out var finalValue))
+            finalValue = (int)Math.Round(finalValue * 100, MidpointRounding.AwayFromZero);
+
+        _selectedShipPriceLabel?.Text = "$" + finalValue;
+    }
+
+    private void OnSavedShipDeselected(ItemList.ItemListDeselectedEventArgs args)
+    {
+        // Store selected index and update Load Ship button state
+        _selectedShipPriceLabel?.Text = Loc.GetString("shipyard-console-save-appraisal-no-ship-selected-text");
+        _loadShipButton?.Disabled = true;
     }
 
     private void OnShipLoaded(string shipName)
@@ -161,13 +187,6 @@ public sealed class ShipyardConsoleBoundUserInterface : BoundUserInterface
             var item = _savedShipsList.AddItem(fileName);
             item.Metadata = filePath;
             //_sawmill.Info($"Added ship to UI list: {fileName} (path: {filePath})");
-        }
-
-        // Enable/disable load button based on available ships
-        if (_loadShipButton != null)
-        {
-            _loadShipButton.Disabled = savedShipFiles.Count == 0;
-            _sawmill.Info($"Load button disabled: {_loadShipButton.Disabled}");
         }
     }
 

--- a/Content.Client/_NF/Shipyard/BUI/ShipyardConsoleBoundUserInterface.cs
+++ b/Content.Client/_NF/Shipyard/BUI/ShipyardConsoleBoundUserInterface.cs
@@ -14,12 +14,15 @@ using Robust.Shared.Serialization.Markdown;
 using System.IO;
 using Robust.Shared.Serialization.Markdown.Mapping;
 using Robust.Shared.Serialization.Markdown.Value;
+using Robust.Shared.Configuration;
+using Content.Shared._Triad.CCVar;
 
 namespace Content.Client._NF.Shipyard.BUI;
 
 public sealed class ShipyardConsoleBoundUserInterface : BoundUserInterface
 {
     [Dependency] private readonly ShipFileManagementSystem _shipFileManagementSystem = default!;
+    [Dependency] private readonly IConfigurationManager _configManager = default!; // Triad
     private static readonly ISawmill _sawmill = Logger.GetSawmill("shipyard_console_bui"); // Triad
 
     private ShipyardConsoleMenu? _menu;
@@ -32,6 +35,8 @@ public sealed class ShipyardConsoleBoundUserInterface : BoundUserInterface
     private Button? _saveShipButton;
     private ItemList? _savedShipsList;
     private Label? _selectedShipPriceLabel;
+    private Label? _taxRateLabel;
+
     private int _selectedShipIndex = -1;
 
     // This should be the same as Content.Server/_Triad/Shipyard/AuthenticatedShipFile/AppraisalKey
@@ -86,6 +91,7 @@ public sealed class ShipyardConsoleBoundUserInterface : BoundUserInterface
         _saveShipButton = _menu.FindControl<Button>("SaveShipButton");
         _savedShipsList = _menu.FindControl<ItemList>("SavedShipsList");
         _selectedShipPriceLabel = _menu.FindControl<Label>("SelectedShipPriceLabel");
+        _taxRateLabel = _menu.FindControl<Label>("TaxRateLabel");
 
         _loadShipButton?.OnPressed += OnLoadShipButtonPressed;
         // Save button already wired via ShipyardConsoleMenu to raise OnSaveShip, which we handle in SaveShip()
@@ -101,6 +107,7 @@ public sealed class ShipyardConsoleBoundUserInterface : BoundUserInterface
         _shipFileManagementSystem.OnShipLoaded += OnShipLoaded;
 
         RefreshSavedShipList();
+        RefreshTaxRateLabel();
     }
 
     // Removed duplicate direct save path to prevent sending an incorrect deed UID.
@@ -150,9 +157,13 @@ public sealed class ShipyardConsoleBoundUserInterface : BoundUserInterface
         var filePath = (string)selectedItem.Metadata!;
         var appraisalValue = _shipFileManagementSystem.GetKeyValueFromPath(filePath, AppraisalKey);
 
-        // Round it up
-        if (double.TryParse(appraisalValue, out var finalValue))
-            finalValue = (int)Math.Round(finalValue * 100, MidpointRounding.AwayFromZero);
+        // Round it up 2 significant digits
+        if (int.TryParse(appraisalValue, out var finalValue) && finalValue != 0)
+        {
+            var digits = (int)Math.Floor(Math.Log10(Math.Abs(finalValue)));
+            var factor = Math.Pow(10, digits - 1);
+            finalValue = (int)(Math.Round(finalValue / factor) * factor);
+        }
 
         _selectedShipPriceLabel?.Text = "$" + finalValue;
     }
@@ -188,6 +199,12 @@ public sealed class ShipyardConsoleBoundUserInterface : BoundUserInterface
             item.Metadata = filePath;
             //_sawmill.Info($"Added ship to UI list: {fileName} (path: {filePath})");
         }
+    }
+
+    private void RefreshTaxRateLabel()
+    {
+        var loadShipPrice = _configManager.GetCVar(TriadCCVars.LoadShipPrice);
+        _taxRateLabel?.Text = Loc.GetString("shipyard-console-tax-rate-price-label", ("tax", loadShipPrice));
     }
 
     private static string ExtractFileNameWithoutExtension(string filePath)

--- a/Content.Client/_NF/Shipyard/BUI/ShipyardConsoleBoundUserInterface.cs
+++ b/Content.Client/_NF/Shipyard/BUI/ShipyardConsoleBoundUserInterface.cs
@@ -6,7 +6,6 @@ using static Robust.Client.UserInterface.Controls.BaseButton;
 using Robust.Client.UserInterface;
 using Content.Client.Shuttles.Save;
 using Robust.Client.UserInterface.Controls;
-using System.Text.RegularExpressions;
 using Robust.Shared.IoC;
 using Robust.Shared.Log;
 using System.Linq;

--- a/Content.Client/_NF/Shipyard/BUI/ShipyardConsoleBoundUserInterface.cs
+++ b/Content.Client/_NF/Shipyard/BUI/ShipyardConsoleBoundUserInterface.cs
@@ -146,7 +146,7 @@ public sealed class ShipyardConsoleBoundUserInterface : BoundUserInterface
         }
     }
 
-    private async void OnSavedShipSelected(ItemList.ItemListSelectedEventArgs args)
+    private void OnSavedShipSelected(ItemList.ItemListSelectedEventArgs args)
     {
         // Store selected index and update Load Ship button state
         _selectedShipIndex = args.ItemIndex;

--- a/Content.Client/_NF/Shipyard/BUI/ShipyardConsoleBoundUserInterface.cs
+++ b/Content.Client/_NF/Shipyard/BUI/ShipyardConsoleBoundUserInterface.cs
@@ -23,6 +23,7 @@ public sealed class ShipyardConsoleBoundUserInterface : BoundUserInterface
 {
     [Dependency] private readonly ShipFileManagementSystem _shipFileManagementSystem = default!;
     [Dependency] private readonly IConfigurationManager _configManager = default!; // Triad
+
     private static readonly ISawmill _sawmill = Logger.GetSawmill("shipyard_console_bui"); // Triad
 
     private ShipyardConsoleMenu? _menu;

--- a/Content.Client/_NF/Shipyard/UI/ShipyardConsoleMenu.xaml
+++ b/Content.Client/_NF/Shipyard/UI/ShipyardConsoleMenu.xaml
@@ -1,7 +1,7 @@
 <controls:FancyWindow xmlns="https://spacestation14.io"
                            xmlns:gfx="clr-namespace:Robust.Client.Graphics;assembly=Robust.Client"
                            xmlns:controls="clr-namespace:Content.Client.UserInterface.Controls"
-                           SetSize="900 600"
+                           SetSize="900 700"
                            MinSize="900 450">
     <PanelContainer VerticalExpand="True" HorizontalExpand="True" Margin="0 8 0 2">
         <PanelContainer.PanelOverride>
@@ -134,6 +134,29 @@
                     Disabled="True" />
         </BoxContainer>
 
+        <BoxContainer Name="SavedShipsContainer" Orientation="Vertical" HorizontalExpand="True" Margin="0 8 0 2">
+            <Label Text="Saved Ships:" />
+            <ItemList Name="SavedShipsList"
+                      MinSize="0 100"
+                      HorizontalExpand="True" />
+        <PanelContainer VerticalExpand="True" HorizontalExpand="True" Margin="0 5 0 5">
+            <PanelContainer.PanelOverride>
+                <gfx:StyleBoxFlat BorderThickness="2" BorderColor="#333333" BackgroundColor="#141414"/>
+            </PanelContainer.PanelOverride>
+            <BoxContainer Orientation="Vertical" Margin="5 0 0 0">
+                <BoxContainer Orientation="Horizontal">
+                    <Label Text="{Loc 'shipyard-console-tax-rate-label'}" StyleClasses="LabelKeyText" />
+                    <Label Text="{Loc 'shipyard-console-tax-rate-amount-label'}" />
+                </BoxContainer>
+                <BoxContainer Orientation="Horizontal">
+                    <Label Text="{Loc 'shipyard-console-save-appraisal-label'}"
+                        StyleClasses="LabelKeyText" />
+                    <Label Name="SelectedShipPriceLabel"
+                        Text="{Loc 'shipyard-console-save-appraisal-no-ship-selected-text'}" />
+                </BoxContainer>
+            </BoxContainer>
+        </PanelContainer>
+        </BoxContainer>
         <!-- Footer -->
         <BoxContainer Orientation="Vertical" Margin="0 5 0 0" >
             <PanelContainer StyleClasses="LowDivider" Margin="0 5 0 0" />
@@ -144,12 +167,6 @@
                 <TextureRect StyleClasses="NTLogoDark" Stretch="KeepAspectCentered"
                              VerticalAlignment="Center" HorizontalAlignment="Right" SetSize="19 19"/>
             </BoxContainer>
-        </BoxContainer>
-        <BoxContainer Orientation="Vertical" HorizontalExpand="True" Margin="0 8 0 2">
-            <Label Text="Saved Ships:" />
-            <ItemList Name="SavedShipsList"
-                      MinSize="0 100"
-                      HorizontalExpand="True" />
         </BoxContainer>
     </BoxContainer>
         </PanelContainer>

--- a/Content.Client/_NF/Shipyard/UI/ShipyardConsoleMenu.xaml
+++ b/Content.Client/_NF/Shipyard/UI/ShipyardConsoleMenu.xaml
@@ -146,7 +146,7 @@
             <BoxContainer Orientation="Vertical" Margin="5 0 0 0">
                 <BoxContainer Orientation="Horizontal">
                     <Label Text="{Loc 'shipyard-console-tax-rate-label'}" StyleClasses="LabelKeyText" />
-                    <Label Text="{Loc 'shipyard-console-tax-rate-amount-label'}" />
+                    <Label Name="TaxRateLabel" Text="???" />
                 </BoxContainer>
                 <BoxContainer Orientation="Horizontal">
                     <Label Text="{Loc 'shipyard-console-save-appraisal-label'}"

--- a/Content.Shared/_Triad/CCVar/CCVars.Triad.cs
+++ b/Content.Shared/_Triad/CCVar/CCVars.Triad.cs
@@ -13,7 +13,7 @@ public sealed class TriadCCVars
     ///     How much the ship cost will be. 0.3f = 30% of full appraisal
     /// </summary>
     public static readonly CVarDef<float> LoadShipPrice =
-        CVarDef.Create("triad.load_ship_price", 0.3f, CVar.SERVERONLY);
+        CVarDef.Create("triad.load_ship_price", 0.3f, CVar.SERVER | CVar.REPLICATED);
 
     // Triad: tamper protection
     /// <summary>

--- a/Resources/Locale/en-US/_Triad/shipyard/shipyard-console-component.ftl
+++ b/Resources/Locale/en-US/_Triad/shipyard/shipyard-console-component.ftl
@@ -3,4 +3,4 @@ shipyard-console-saved = {$owner} shuttle {$vessel} stored to shipyard by {$play
 shipyard-console-save-appraisal-label = Estimated deployment fee after tax:{" "}
 shipyard-console-save-appraisal-no-ship-selected-text = Select ship
 shipyard-console-tax-rate-label = Deployment tax rate:{" "}
-shipyard-console-tax-rate-amount-label = 30%
+shipyard-console-tax-rate-price-label = { TOSTRING($tax, "P0") }

--- a/Resources/Locale/en-US/_Triad/shipyard/shipyard-console-component.ftl
+++ b/Resources/Locale/en-US/_Triad/shipyard/shipyard-console-component.ftl
@@ -1,2 +1,6 @@
 ## UI
 shipyard-console-saved = {$owner} shuttle {$vessel} stored to shipyard by {$player}.
+shipyard-console-save-appraisal-label = Estimated deployment fee after tax:{" "}
+shipyard-console-save-appraisal-no-ship-selected-text = Select ship
+shipyard-console-tax-rate-label = Deployment tax rate:{" "}
+shipyard-console-tax-rate-amount-label = 30%


### PR DESCRIPTION
## About the PR
Adds a ship load fee label to the shipyard console

The number is rounded to the nearest 2 significant digits because for some reason the appraisal prices keep changing across saves.. unsure why, but this works fine for now. It's only off by a couple hundred of credits

The number is not authoritative and is simply for UI so players can see an estimate
The server will gauge the actual price and WILL put you into debt

Also fixes the bug of the load button being correctly disabled when a ship isn't selected

## Why / Balance
So people can see how much the ship fee is worth before loading it!

## Media

Tax rate label is dynamic based on the CVAR
<img width="555" height="233" alt="image" src="https://github.com/user-attachments/assets/4a265dba-78b8-4013-8afd-a64bb9ea9aac" />


<img width="500" height="196" alt="image" src="https://github.com/user-attachments/assets/548c0b1c-2b87-4598-9c2c-4a8717a81249" />


## Technical details
Makes ``TriadCCVars.LoadShipPrice`` ``SERVER` and ``REPLICATED`` so the client can see the value but not modify it
Minor XML changes

Adds the method ``GetKeyValueFromPath`` to ``ShipFileManagement`` system
This will allow you to get a certain mapping node from a ship YML file on the client  easily through a given string key

**Changelog**
:cl:
- tweak: An estimated appraisal of your ship will be displayed when you select a saved ship in the shipyard console. This value will not be visible if your ship was saved pre-tamper update. Resaving your ship will fix this, however.