### PR TITLE
Filled Chef Belt Improvements

### DIFF
--- a/Resources/Prototypes/Catalog/Fills/Items/belt.yml
+++ b/Resources/Prototypes/Catalog/Fills/Items/belt.yml
@@ -208,3 +208,6 @@
     contents:
     - id: FoodShakerSalt
     - id: FoodShakerPepper
+    - id: RollingPin #Triad
+    - id: KitchenKnife #Triad
+    - id: ServiceSelectiveDropper #Triad


### PR DESCRIPTION

## About the PR
Added the rolling pin, kitchen knife, and selective service dropper to the filled chef belt.

## Why / Balance
Convenience for people who don't already have a kitchen set up.

## Media
<img width="342" height="398" alt="chefbelt" src="https://github.com/user-attachments/assets/af784658-653a-4a95-a122-6560607b065d" />


## Requirements
- [ x] I have read relevant guidelines/documentation to this PR found on [our devwiki](https://monolith-station.github.io/mono-docs/).
- [ x] I have added media to this PR or it does not require an ingame showcase.
- [x ] I can confirm this PR contains either no AI-generated content, or AI-generated content that meets our guidelines.

## How to test
Spawn Filled Chef Belt


**Changelog**
:cl:
- tweak: Filled chef belt now contains a knife, rolling pin, and selective dropper!

