### PR TITLE
EventHealthChange Affects Limbs Now

### DIFF
--- a/Content.Server/EntityEffects/Effects/EvenHealthChange.cs
+++ b/Content.Server/EntityEffects/Effects/EvenHealthChange.cs
@@ -3,6 +3,7 @@ using Content.Shared.Damage.Prototypes;
 using Content.Shared.EntityEffects;
 using Content.Shared.FixedPoint;
 using Content.Shared.Localizations;
+using Content.Shared._Shitmed.Targeting; // Shitmed Change
 using JetBrains.Annotations;
 using Robust.Shared.Prototypes;
 using Robust.Shared.Utility;
@@ -136,6 +137,11 @@ public sealed partial class EvenHealthChange : EntityEffect
             args.TargetEntity,
             dspec * scale,
             IgnoreResistances,
-            interruptsDoAfters: false);
+            interruptsDoAfters: false,
+            // Shitmed Change Start
+            targetPart: TargetBodyPart.All,
+            partMultiplier: 1.00f,
+            canSever: false);
+        // Shitmed Change End
     }
 }


### PR DESCRIPTION
## About the PR
Some meds like cryoxadone would not affect limbs. This cs change fixes that by adding the missing medsystem changes.


**Changelog**
<!-- Add a Changelog entry to make players aware of new features or changes that could affect gameplay.
Make sure to read the guidelines and take this Changelog template out of the comment block in order for it to show up.
Changelog must have a :cl: symbol, so the bot recognizes the changes and adds them to the game's changelog.
Remove this symbol for non-player facing PRs.-->
:cl:
- fix: EventHealthChange affects limbs now. Making meds like cryoxadone heal limbs now too.
