### PR TITLE
Fix/Expedition FTL Cooldown Guarding

### DIFF
--- a/Content.Server/Salvage/SalvageSystem.ExpeditionConsole.cs
+++ b/Content.Server/Salvage/SalvageSystem.ExpeditionConsole.cs
@@ -164,6 +164,18 @@ public sealed partial class SalvageSystem
             return;
         }
 
+        // Triad: refuse the early return while the ship's FTL drive is still on cooldown from
+        // arriving. The expedition teardown auto-FTLs out shuttles that have no FTLComponent; a
+        // grid still in FTL cooldown is skipped and then deleted with the map, taking the crew
+        // with it. Block the return until the drive is ready so the ship can actually be evacuated.
+        if (xform.GridUid is { } shuttleGrid && HasComp<FTLComponent>(shuttleGrid))
+        {
+            PlayDenySound(entity, component);
+            _popupSystem.PopupEntity(Loc.GetString("salvage-expedition-ftl-cooldown"), entity, PopupType.MediumCaution);
+            UpdateConsoles(station.Value, data);
+            return;
+        }
+
         // Frontier: check if any player characters or friendly ghost roles are outside
         var query = EntityQueryEnumerator<MindContainerComponent, MobStateComponent, TransformComponent>();
         while (query.MoveNext(out var uid, out var mindContainer, out var _, out var mobXform))

--- a/Content.Server/Salvage/SalvageSystem.Runner.cs
+++ b/Content.Server/Salvage/SalvageSystem.Runner.cs
@@ -160,6 +160,20 @@ public sealed partial class SalvageSystem
         QueueDel(ev.FromMapUid.Value);
     }
 
+    // Triad: true while any player ship (ShuttleComponent grid) is still parented to the expedition
+    // map. Dungeon/asteroid terrain grids aren't shuttles, so they don't block teardown.
+    private bool ExpeditionMapHasShuttle(EntityUid map)
+    {
+        var query = AllEntityQuery<ShuttleComponent, TransformComponent>();
+        while (query.MoveNext(out _, out var xform))
+        {
+            if (xform.MapUid == map)
+                return true;
+        }
+
+        return false;
+    }
+
     // Runs the expedition
     private void UpdateRunner()
     {
@@ -269,7 +283,12 @@ public sealed partial class SalvageSystem
 
             if (remaining < TimeSpan.Zero)
             {
-                QueueDel(uid);
+                // Triad: don't tear down the expedition map while a player ship is still on it.
+                // The auto-FTL above retries every tick, so a ship stranded by its FTL-drive
+                // cooldown is evacuated once the drive is ready; deferring until the map is clear
+                // turns "ship + crew deleted" into "expedition ends a few seconds late".
+                if (!ExpeditionMapHasShuttle(uid))
+                    QueueDel(uid);
             }
         }
 

--- a/Resources/Locale/en-US/_NF/procedural/expeditions.ftl
+++ b/Resources/Locale/en-US/_NF/procedural/expeditions.ftl
@@ -2,6 +2,7 @@ salvage-expedition-window-finish = Finish expedition
 salvage-expedition-announcement-early-finish = The expedition was completed ahead of schedule. Shuttle will depart in {$departTime} seconds.
 salvage-expedition-shuttle-not-found = Cannot locate shuttle.
 salvage-expedition-not-everyone-aboard = Not all crew aboard! {CAPITALIZE(THE($target))} is still out there!
+salvage-expedition-ftl-cooldown = The FTL drive is still spooling down from the jump in. Wait for it to cool down before returning.
 
 # Salvage mods
 salvage-time-mod-standard-time = Normal Duration


### PR DESCRIPTION
## About the PR
Fixes a data-loss bug where ending a salvage expedition early, before the ship's FTL drive finished its arrival cooldown, deleted the ship and everyone aboard it. The early-return is now blocked until the drive is ready, and the expedition map can no longer be torn down while a ship is still on it.

## Why / Balance
When a ship FTLs into an expedition it stays in its arrival cooldown (mass-scaled, up to ~50s) and keeps its `FTLComponent` the whole time. The expedition cleanup auto-FTLs shuttles back out, but it skips any grid that still has an `FTLComponent`, then `QueueDel`s the map, deleting the un-evacuated ship with it. Returning early lands you right inside that window. The return lock reuses the same `HasComp<FTLComponent>` cooldown check the mission-claim path already uses, and the map-teardown guard lets the retrying auto-FTL evacuate a stranded ship instead of deleting it. This is a bug fix, not a balance change.

## Media
<img width="401" height="44" alt="{F614E74E-A0DC-49AB-A7A6-844CED5246BD}" src="https://github.com/user-attachments/assets/9a988e54-60c3-4beb-a95b-fcf654027bae" />

## Requirements
- [X] I have read relevant guidelines/documentation to this PR found on our devwiki.
- [X] I have added media to this PR or it does not require an ingame showcase.
- [X] I can confirm this PR contains either no AI-generated content, or AI-generated content that meets our guidelines.

## How to test
1. Buy/load an expedition vessel (e.g. a Duran), board it, and fuel it.
2. From the salvage expedition console, claim and FTL to an expedition.
3. The moment you arrive, hit the early-return button.
   - Before: when the timer expires, the ship and everyone aboard are deleted.
   - After: the console denies with "The FTL drive is still spooling down from the jump in. Wait for it to cool down before returning." until the drive's cooldown ends; once it's ready, returning evacuates the ship normally.
4. Let an expedition also run to completion to confirm normal end-of-expedition returns are unaffected.

## Breaking changes
None.

**Changelog**
:cl:
- fix: Returning from a salvage expedition early no longer deletes your ship if you do it right after jumping in.
