### PR TITLE
Removes TSF Tracking Implanter From Dungeon Loot Pool

### DIFF
--- a/Resources/Prototypes/Entities/Markers/Spawners/Random/crates.yml
+++ b/Resources/Prototypes/Entities/Markers/Spawners/Random/crates.yml
@@ -130,7 +130,7 @@
     - CrateArmoryLaser
     - CrateArmoryPistols
     - CrateTrainingBombs
-    - CrateTrackingImplants
+    # - CrateTrackingImplants # Triad removed in case of using as spawners
     - CrateSecurityTrackingMindshieldImplants
     - CrateSecurityHelmet
     - CrateSecurityArmor

--- a/Resources/Prototypes/_NF/Entities/Markers/Spawners/Random/dungeon_items_medical.yml
+++ b/Resources/Prototypes/_NF/Entities/Markers/Spawners/Random/dungeon_items_medical.yml
@@ -368,7 +368,7 @@
     - MedicalTrackingImplanter
     - LightImplanter
     - SadTromboneImplanter
-    - TrackingImplanter
+    # - TrackingImplanter # Triad, (this is TSF's Implants in mono)
     chance: 1.0
     offset: 0.0
     rarePrototypes:

--- a/Resources/Prototypes/_NF/Entities/Markers/Spawners/Random/dungeon_items_medical.yml
+++ b/Resources/Prototypes/_NF/Entities/Markers/Spawners/Random/dungeon_items_medical.yml
@@ -368,7 +368,6 @@
     - MedicalTrackingImplanter
     - LightImplanter
     - SadTromboneImplanter
-    # - TrackingImplanter # Triad, (this is TSF's Implants in mono)
     chance: 1.0
     offset: 0.0
     rarePrototypes:


### PR DESCRIPTION
## About the PR
<!-- What did you change? -->
<!-- If this is a code change, summarize at high level how your new code works. This makes it easier to review. -->
remove a not supposed to be there implant from dungeon loot, it doesn't mention directly in the ID but Tracking Implant is TSF's implant from mono guh

## Why / Balance
<!-- Discuss how this would affect game balance or explain why it was changed. Link any relevant discussions or issues. -->
it's not supposed to be there

## Media
<!-- Attach media if the PR makes ingame changes (clothing, items, features, etc). 
Small fixes/refactors are exempt. Media may be used in SS14 progress reports with credit. -->
i don't think it needs to be there

## Requirements
<!-- Confirm the following by placing an X in the brackets [X]: -->
- [x] I have read relevant guidelines/documentation to this PR found on [our devwiki](https://monolith-station.github.io/mono-docs/).
- [x] I have added media to this PR or it does not require an ingame showcase.
- [x] I can confirm this PR contains either no AI-generated content, or AI-generated content that meets our guidelines.
<!-- You should understand that not following the above may get your PR closed at maintainer’s discretion -->
<!-- When using AI, make sure you are already proficient in creating whatever content you are attempting to generate and that you already have experience contributing to SS14. This means using AI to enhance your preexisting workflow, not vibecoding. -->

## How to test
<!-- Describe the way it can be tested -->
spawn SpawnDungeonClutterImplanter multiple times, should no longer show the TrackingImplanter (item ID did not mention TSF directly, but on examine)
## Breaking changes
<!-- List any breaking changes, including namespaces, public class/method/field changes, prototype renames; and provide instructions for fixing them. -->
it's not there
**Changelog**
<!-- Add a Changelog entry to make players aware of new features or changes that could affect gameplay.
Make sure to read the guidelines and take this Changelog template out of the comment block in order for it to show up.
Changelog must have a :cl: symbol, so the bot recognizes the changes and adds them to the game's changelog.
Remove this symbol for non-player facing PRs.-->
🆑 
- remove: Removed TSF implanter from the loot pool