### PR TITLE
Accents: Disable Affixes

### DIFF
--- a/Content.Server/Speech/EntitySystems/FrenchAccentSystem.cs
+++ b/Content.Server/Speech/EntitySystems/FrenchAccentSystem.cs
@@ -56,10 +56,10 @@ public sealed class FrenchAccentSystem : EntitySystem
         {
             msg = AccentHelpers.FixArticles(msg);
 
-            if (component.Prefixes.Count > 0 && _random.Prob(component.PrefixProb))
+            if (AccentHelpers.AffixesEnabled && component.Prefixes.Count > 0 && _random.Prob(component.PrefixProb))
                 msg = AccentHelpers.PrependPrefix(msg, Loc.GetString(_random.Pick(component.Prefixes)));
 
-            if (component.Suffixes.Count > 0 && _random.Prob(component.SuffixProb))
+            if (AccentHelpers.AffixesEnabled && component.Suffixes.Count > 0 && _random.Prob(component.SuffixProb))
                 msg = AccentHelpers.AppendSuffix(msg, Loc.GetString(_random.Pick(component.Suffixes)));
         }
 

--- a/Content.Server/Speech/EntitySystems/GermanAccentSystem.cs
+++ b/Content.Server/Speech/EntitySystems/GermanAccentSystem.cs
@@ -66,10 +66,10 @@ public sealed class GermanAccentSystem : EntitySystem
         {
             msg = AccentHelpers.FixArticles(msg);
 
-            if (component.Prefixes.Count > 0 && _random.Prob(component.PrefixProb))
+            if (AccentHelpers.AffixesEnabled && component.Prefixes.Count > 0 && _random.Prob(component.PrefixProb))
                 msg = AccentHelpers.PrependPrefix(msg, Loc.GetString(_random.Pick(component.Prefixes)));
 
-            if (component.Suffixes.Count > 0 && _random.Prob(component.SuffixProb))
+            if (AccentHelpers.AffixesEnabled && component.Suffixes.Count > 0 && _random.Prob(component.SuffixProb))
                 msg = AccentHelpers.AppendSuffix(msg, Loc.GetString(_random.Pick(component.Suffixes)));
         }
 

--- a/Content.Server/Speech/EntitySystems/PirateAccentSystem.cs
+++ b/Content.Server/Speech/EntitySystems/PirateAccentSystem.cs
@@ -35,10 +35,10 @@ public sealed class PirateAccentSystem : EntitySystem
 
         msg = AccentHelpers.FixArticles(msg);
 
-        if (component.Prefixes.Count > 0 && _random.Prob(component.PrefixProb))
+        if (AccentHelpers.AffixesEnabled && component.Prefixes.Count > 0 && _random.Prob(component.PrefixProb))
             msg = AccentHelpers.PrependPrefix(msg, Loc.GetString(_random.Pick(component.Prefixes)));
 
-        if (component.Suffixes.Count > 0 && _random.Prob(component.SuffixProb))
+        if (AccentHelpers.AffixesEnabled && component.Suffixes.Count > 0 && _random.Prob(component.SuffixProb))
             msg = AccentHelpers.AppendSuffix(msg, Loc.GetString(_random.Pick(component.Suffixes)));
 
         return msg;

--- a/Content.Server/Speech/EntitySystems/RussianAccentSystem.cs
+++ b/Content.Server/Speech/EntitySystems/RussianAccentSystem.cs
@@ -45,10 +45,10 @@ public sealed class RussianAccentSystem : EntitySystem
         if (string.IsNullOrWhiteSpace(msg))
             return msg;
 
-        if (component.Prefixes.Count > 0 && _random.Prob(component.PrefixProb))
+        if (AccentHelpers.AffixesEnabled && component.Prefixes.Count > 0 && _random.Prob(component.PrefixProb))
             msg = AccentHelpers.PrependPrefix(msg, Loc.GetString(_random.Pick(component.Prefixes)));
 
-        if (component.Suffixes.Count > 0 && _random.Prob(component.SuffixProb))
+        if (AccentHelpers.AffixesEnabled && component.Suffixes.Count > 0 && _random.Prob(component.SuffixProb))
             msg = AccentHelpers.AppendSuffix(msg, Loc.GetString(_random.Pick(component.Suffixes)));
 
         // Faux-Cyrillic glyph swap runs LAST in BOTH tiers (it is the Russian identity). Slight only

--- a/Content.Server/Speech/EntitySystems/SpanishAccentSystem.cs
+++ b/Content.Server/Speech/EntitySystems/SpanishAccentSystem.cs
@@ -55,10 +55,10 @@ public sealed class SpanishAccentSystem : EntitySystem
         {
             msg = AccentHelpers.FixArticles(msg);
 
-            if (component.Prefixes.Count > 0 && _random.Prob(component.PrefixProb))
+            if (AccentHelpers.AffixesEnabled && component.Prefixes.Count > 0 && _random.Prob(component.PrefixProb))
                 msg = AccentHelpers.PrependPrefix(msg, Loc.GetString(_random.Pick(component.Prefixes)));
 
-            if (component.Suffixes.Count > 0 && _random.Prob(component.SuffixProb))
+            if (AccentHelpers.AffixesEnabled && component.Suffixes.Count > 0 && _random.Prob(component.SuffixProb))
                 msg = AccentHelpers.AppendSuffix(msg, Loc.GetString(_random.Pick(component.Suffixes)));
         }
 

--- a/Content.Server/_Goobstation/Speech/EntitySystems/BoganAccentSystem.cs
+++ b/Content.Server/_Goobstation/Speech/EntitySystems/BoganAccentSystem.cs
@@ -38,10 +38,10 @@ public sealed class BoganAccentSystem : EntitySystem
         // caps-aware placement (replaces the old hardcoded probs + _random.Next index math).
         msg = AccentHelpers.FixArticles(msg);
 
-        if (component.Prefixes.Count > 0 && _random.Prob(component.PrefixProb))
+        if (AccentHelpers.AffixesEnabled && component.Prefixes.Count > 0 && _random.Prob(component.PrefixProb))
             msg = AccentHelpers.PrependPrefix(msg, Loc.GetString(_random.Pick(component.Prefixes)));
 
-        if (component.Suffixes.Count > 0 && _random.Prob(component.SuffixProb))
+        if (AccentHelpers.AffixesEnabled && component.Suffixes.Count > 0 && _random.Prob(component.SuffixProb))
             msg = AccentHelpers.AppendSuffix(msg, Loc.GetString(_random.Pick(component.Suffixes)));
 
         args.Message = msg;

--- a/Content.Server/_NF/Speech/EntitySystems/GoblinAccentSystem.cs
+++ b/Content.Server/_NF/Speech/EntitySystems/GoblinAccentSystem.cs
@@ -72,10 +72,10 @@ public sealed class GoblinAccentSystem : EntitySystem
         {
             message = AccentHelpers.FixArticles(message);
 
-            if (component.Prefixes.Count > 0 && _random.Prob(component.PrefixProb))
+            if (AccentHelpers.AffixesEnabled && component.Prefixes.Count > 0 && _random.Prob(component.PrefixProb))
                 message = AccentHelpers.PrependPrefix(message, Loc.GetString(_random.Pick(component.Prefixes)));
 
-            if (component.Suffixes.Count > 0 && _random.Prob(component.SuffixProb))
+            if (AccentHelpers.AffixesEnabled && component.Suffixes.Count > 0 && _random.Prob(component.SuffixProb))
                 message = AccentHelpers.AppendSuffix(message, Loc.GetString(_random.Pick(component.Suffixes)));
         }
 

--- a/Content.Server/_NF/Speech/EntitySystems/StreetpunkAccentSystem.cs
+++ b/Content.Server/_NF/Speech/EntitySystems/StreetpunkAccentSystem.cs
@@ -40,10 +40,10 @@ public sealed class StreetpunkAccentSystem : EntitySystem
         // Triad: a/an re-agreement + data-driven cyberpunk tic pools via the shared helpers.
         msg = AccentHelpers.FixArticles(msg);
 
-        if (component.Prefixes.Count > 0 && _random.Prob(component.PrefixProb))
+        if (AccentHelpers.AffixesEnabled && component.Prefixes.Count > 0 && _random.Prob(component.PrefixProb))
             msg = AccentHelpers.PrependPrefix(msg, Loc.GetString(_random.Pick(component.Prefixes)));
 
-        if (component.Suffixes.Count > 0 && _random.Prob(component.SuffixProb))
+        if (AccentHelpers.AffixesEnabled && component.Suffixes.Count > 0 && _random.Prob(component.SuffixProb))
             msg = AccentHelpers.AppendSuffix(msg, Loc.GetString(_random.Pick(component.Suffixes)));
 
         return msg;

--- a/Content.Server/_Triad/Speech/EntitySystems/AccentHelpers.cs
+++ b/Content.Server/_Triad/Speech/EntitySystems/AccentHelpers.cs
@@ -17,6 +17,14 @@ namespace Content.Server._Triad.Speech.EntitySystems;
 // them instead of copy-pasting. Pure string in/out, no DI, so it stays trivially testable.
 public static class AccentHelpers
 {
+    // Triad: master kill-switch for the prefix/suffix tic pools, parked 2026-06-19. The random
+    // interjection/affirmation affixes were shifting the meaning of sentences in ways playtesters
+    // disliked, so the feature is off wholesale. Every accent's prefix and suffix guard ANDs on this;
+    // flip to true to re-enable. The per-accent pools, probabilities, and .ftl entries are left intact
+    // so revival is just this one bool. static readonly (not const) to avoid unreachable-code warnings
+    // at the short-circuited guards.
+    public static readonly bool AffixesEnabled = false;
+
     private static readonly Regex IngWord = new(@"\b(\w+?)(ing)\b", RegexOptions.IgnoreCase);
 
     // Short words that merely END in -ing but are not gerunds; never drop their g.

--- a/Content.Server/_Triad/Speech/EntitySystems/DrawlAccentSystem.cs
+++ b/Content.Server/_Triad/Speech/EntitySystems/DrawlAccentSystem.cs
@@ -69,10 +69,10 @@ public sealed class DrawlAccentSystem : EntitySystem
         // A swap can flip a word's vowel-sound, leaving "a outlaw" / "an space critter".
         msg = AccentHelpers.FixArticles(msg);
 
-        if (accent.Prefixes.Count > 0 && _random.Prob(accent.PrefixProb))
+        if (AccentHelpers.AffixesEnabled && accent.Prefixes.Count > 0 && _random.Prob(accent.PrefixProb))
             msg = AccentHelpers.PrependPrefix(msg, Loc.GetString(_random.Pick(accent.Prefixes)));
 
-        if (accent.Suffixes.Count > 0 && _random.Prob(accent.SuffixProb))
+        if (AccentHelpers.AffixesEnabled && accent.Suffixes.Count > 0 && _random.Prob(accent.SuffixProb))
             msg = AccentHelpers.AppendSuffix(msg, Loc.GetString(_random.Pick(accent.Suffixes)));
 
         return msg;

--- a/Content.Server/_Triad/Speech/EntitySystems/DwarfAccentSystem.cs
+++ b/Content.Server/_Triad/Speech/EntitySystems/DwarfAccentSystem.cs
@@ -62,10 +62,10 @@ public sealed class DwarfAccentSystem : EntitySystem
 
         msg = AccentHelpers.FixArticles(msg);
 
-        if (component.Prefixes.Count > 0 && _random.Prob(component.PrefixProb))
+        if (AccentHelpers.AffixesEnabled && component.Prefixes.Count > 0 && _random.Prob(component.PrefixProb))
             msg = AccentHelpers.PrependPrefix(msg, Loc.GetString(_random.Pick(component.Prefixes)));
 
-        if (component.Suffixes.Count > 0 && _random.Prob(component.SuffixProb))
+        if (AccentHelpers.AffixesEnabled && component.Suffixes.Count > 0 && _random.Prob(component.SuffixProb))
             msg = AccentHelpers.AppendSuffix(msg, Loc.GetString(_random.Pick(component.Suffixes)));
 
         return msg;

--- a/Content.Server/_Triad/Speech/EntitySystems/NewBrooklynAccentSystem.cs
+++ b/Content.Server/_Triad/Speech/EntitySystems/NewBrooklynAccentSystem.cs
@@ -58,10 +58,10 @@ public sealed class NewBrooklynAccentSystem : EntitySystem
 
         msg = AccentHelpers.FixArticles(msg);
 
-        if (component.Prefixes.Count > 0 && _random.Prob(component.PrefixProb))
+        if (AccentHelpers.AffixesEnabled && component.Prefixes.Count > 0 && _random.Prob(component.PrefixProb))
             msg = AccentHelpers.PrependPrefix(msg, Loc.GetString(_random.Pick(component.Prefixes)));
 
-        if (component.Suffixes.Count > 0 && _random.Prob(component.SuffixProb))
+        if (AccentHelpers.AffixesEnabled && component.Suffixes.Count > 0 && _random.Prob(component.SuffixProb))
             msg = AccentHelpers.AppendSuffix(msg, Loc.GetString(_random.Pick(component.Suffixes)));
 
         return msg;


### PR DESCRIPTION
## About the PR
Disables the random prefix/suffix "tic" phrases across the enriched accents (e.g. "Well now,", "Mercy me,", ", I tell you what") behind a single switch. They were getting bolted onto short fragments and shifting the apparent meaning of what players said, which players disliked. This adds `AccentHelpers.AffixesEnabled` (a `static readonly bool`, defaulted off) and ANDs it into every prefix/suffix guard across the 11 accent systems. The per-accent tic pools, probabilities, and `.ftl` entries are left untouched, so re-enabling the feature is just flipping the one bool.

## Why / Balance
Speech-flavor only, no gameplay or balance impact. The affixes read as out-of-character clutter and occasionally changed what a line appeared to say; this parks the feature while keeping it trivially revivable. The accents still apply all their phonetics and word swaps.

## Media
N/A — text-only speech change.

## Requirements
- [x] I have read relevant guidelines/documentation to this PR found on [our devwiki](https://monolith-station.github.io/mono-docs/).
- [x] I have added media to this PR or it does not require an ingame showcase.
- [x] I can confirm this PR contains either no AI-generated content, or AI-generated content that meets our guidelines.

## How to test
Give a character any enriched accent (Southern, Cowboy, Goblin, Dwarf, French, German, Russian, Spanish, Pirate, Bogan, Streetpunk, New Brooklyn) and speak in IC. Confirm no random opener/closer phrases are appended to messages, and that the accent's phonetics and word swaps still apply as before.

## Breaking changes
None.

**Changelog**
:cl:
- tweak: Accents no longer tack random interjections and sign-offs onto your speech; their pronunciation and word swaps are unchanged.
