### PR TITLE
Drone Engagement Range Adjustment

### DIFF
--- a/Content.Server/NPC/Queries/Queries/NearbyHostileShuttlesQuery.cs
+++ b/Content.Server/NPC/Queries/Queries/NearbyHostileShuttlesQuery.cs
@@ -11,7 +11,8 @@ namespace Content.Server.NPC.Queries.Queries;
 public sealed partial class NearbyNpcTargetsQuery : UtilityQuery
 {
     [DataField]
-    public float Range = 4000f;
+    // Triad: revert of Mono #3728 (2x targeting range), halved back for perf.
+    public float Range = 2000f;
 
     // TODO: make this use factions
     [DataField]

--- a/Resources/Prototypes/_Mono/Entities/Mobs/NPCs/ai.yml
+++ b/Resources/Prototypes/_Mono/Entities/Mobs/NPCs/ai.yml
@@ -46,7 +46,7 @@
       path: /Audio/Ambience/Objects/periodic_beep.ogg
   - type: Anchorable
   - type: HTN
-    sleepPlayerCheckRangeOverride: 4000
+    sleepPlayerCheckRangeOverride: 2000 # Triad: revert of #4075 (Mono 2x'd 2000->4000)
     # Triad: disabled. A rammer is always moving, so this kept it permanently awake, it never slept away from players and self-piloted across the sector into safe zones (CC) and over-despawned in the far reaches. Per-drone radial containment is the real fix; this stops the bleeding. (revert of #4075)
     # sleepMaxGridSpeed: 10 # don't sleep so we can still dodge grids or such if drifting far from players
     rootTask:
@@ -247,7 +247,7 @@
   suffix: AI, Drone-Quake
   components:
   - type: HTN
-    sleepPlayerCheckRangeOverride: 4000
+    sleepPlayerCheckRangeOverride: 2000 # Triad: revert of #4075 (Mono 2x'd 2000->4000)
     rootTask:
       task: DroneCompoundQuake
 

--- a/Resources/Prototypes/_Mono/Entities/Mobs/NPCs/ai.yml
+++ b/Resources/Prototypes/_Mono/Entities/Mobs/NPCs/ai.yml
@@ -47,7 +47,8 @@
   - type: Anchorable
   - type: HTN
     sleepPlayerCheckRangeOverride: 4000
-    sleepMaxGridSpeed: 10 # don't sleep so we can still dodge grids or such if drifting far from players
+    # Triad: disabled. A rammer is always moving, so this kept it permanently awake, it never slept away from players and self-piloted across the sector into safe zones (CC) and over-despawned in the far reaches. Per-drone radial containment is the real fix; this stops the bleeding. (revert of #4075)
+    # sleepMaxGridSpeed: 10 # don't sleep so we can still dodge grids or such if drifting far from players
     rootTask:
       task: RammerShuttleCompound
   - type: StaticPrice


### PR DESCRIPTION
## About the PR
Reverts three Monolith range/sleep bumps that kept the hostile ship AI cores (rammers, attackers, approachers, and drones) permanently awake and acquiring targets across the entire sector. Restores the original pre-bump tuning so cores sleep when no player is nearby and only engage at sane distances.

## Why / Balance
Two Mono PRs had doubled the activity envelope for the whole AI core family:
- `#4075` set `sleepMaxGridSpeed: 10` on `NpcStationAiRammer` and bumped `sleepPlayerCheckRangeOverride` 2000 → 4000. Because these cores are usually moving, the grid-speed gate in `NPCSystem.CheckPlayerDistancesAndPauseNPCs` meant they never slept, even with no player nearby. With no faction/IFF or zone containment, they self-piloted across the sector: ramming safe zones (CC) on one side and over-despawning in the cleanup void on the other (both confirmed in prod Loki).
- `#3728` doubled `NearbyNpcTargetsQuery.Range` 2000 → 4000, so every core's HTN target query scanned a 4000-tile radius each plan cycle and would chase targets from across the sector.

Scope: `NearbyNpcTargetsQuery.Range` is a shared default with no per-entity override, so the detection change applies to all ship AI uniformly. The sleep edits are made on `NpcStationAiRammer` (the root every core in ai.yml inherits from, via field-merge) plus `NpcDroneAiQuake` (which set its own override), so the sleep change reaches the whole family too: Attacker, Approacher, Shooter, the Smart variants, and the Drone-Medusa/Assembly/MPulsar/Lance/Quake cores.

This PR comments out `sleepMaxGridSpeed` (line preserved with a Triad marker) to restore sleep-when-unobserved, and halves both ranges back to their original `2000` (the `#2760` values, before the 2x bumps). A sleeping core runs no HTN/steering/active physics, so this trims the awake-NPC count that drives server tick cost at population. Cores with a player within ~2000 tiles still wake and engage normally; this only stops the sector-wide wandering. Per-drone radial containment is the real follow-up fix.

## Media
N/A (behavior/perf fix, no visual change).

## Requirements
- [x] I have read relevant guidelines/documentation to this PR found on [our devwiki](https://monolith-station.github.io/mono-docs/).
- [x] I have added media to this PR or it does not require an ingame showcase.
- [x] I can confirm this PR contains either no AI-generated content, or AI-generated content that meets our guidelines.

## How to test
1. Spawn any hostile core (e.g. `NpcStationAiRammer`, `NpcStationAiAttacker`, or a drone core) or use `StressFleetCommand` with no player nearby. Confirm it pauses/sleeps in place instead of self-piloting off across the sector.
2. Approach within ~2000 tiles: confirm it wakes, acquires the target, and engages as before.
3. Confirm a core does not acquire targets sitting beyond 2000 tiles (previously 4000).

## Breaking changes
None. `NearbyNpcTargetsQuery.Range` default and the HTN sleep values change behavior only; no namespace, prototype, or public API renames.

**Changelog**
:cl:
- fix: Hostile drones no longer self-pilot across the sector into safe zones when no players are nearby.
- tweak: Reduced hostile drone target-detection and wake ranges back to their pre-2x values.
