### PR TITLE
Autopilot Respects Player Dampening Mode

### DIFF
--- a/Content.Server/_Mono/NPC/HTN/ShipSteeringSystem.cs
+++ b/Content.Server/_Mono/NPC/HTN/ShipSteeringSystem.cs
@@ -35,6 +35,7 @@ public sealed partial class ShipSteeringSystem : EntitySystem
     [Dependency] private EntityQuery<ProjectileGridPhaseComponent> _phaseQuery;
     [Dependency] private EntityQuery<PhysicsComponent> _physQuery;
     [Dependency] private EntityQuery<ShuttleComponent> _shuttleQuery;
+    [Dependency] private EntityQuery<ShuttleConsoleComponent> _consoleQuery; // Triad
     [Dependency] private EntityQuery<ProjectileComponent> _projectileQuery;
     [Dependency] private EntityQuery<EmpOnTriggerComponent> _empQuery;
     [Dependency] private EntityQuery<ExplosiveComponent> _explosiveQuery;
@@ -152,7 +153,8 @@ public sealed partial class ShipSteeringSystem : EntitySystem
 
             RotationCompensation = ref ent.Comp.RotationCompensation,
 
-            FrameTime = args.FrameTime
+            FrameTime = args.FrameTime,
+            ManageDampening = !_consoleQuery.HasComp(ent), // Triad: leave dampening to the player on console autopilot
         };
 
         args.Input = ProcessMovement(ref context, config);
@@ -260,10 +262,14 @@ public sealed partial class ShipSteeringSystem : EntitySystem
         strafeInput = GetGoodThrustVector(strafeInput, ctx.Shuttle) * MathF.Min(1f, wishInputVec.Length());
 
         // also set us to anchor dampening if we wish to brake
-        if (brakeInput == 1f && ctx.ShipBody.LinearVelocity.Length() >= config.AnchorMaxVelocity)
-            _shuttle.SetInertiaDampening(ctx.ShipUid, ctx.ShipBody, ctx.Shuttle, ctx.ShipXform, InertiaDampeningMode.Anchor);
-        else
-            _shuttle.SetInertiaDampening(ctx.ShipUid, ctx.ShipBody, ctx.Shuttle, ctx.ShipXform, InertiaDampeningMode.Off);
+        // Triad: only NPC ships auto-manage dampening; player autopilot keeps the pilot's Drive/Cruise/Park selection (regression from #4064)
+        if (ctx.ManageDampening)
+        {
+            if (brakeInput == 1f && ctx.ShipBody.LinearVelocity.Length() >= config.AnchorMaxVelocity)
+                _shuttle.SetInertiaDampening(ctx.ShipUid, ctx.ShipBody, ctx.Shuttle, ctx.ShipXform, InertiaDampeningMode.Anchor);
+            else
+                _shuttle.SetInertiaDampening(ctx.ShipUid, ctx.ShipBody, ctx.Shuttle, ctx.ShipXform, InertiaDampeningMode.Off);
+        }
 
         return new ShuttleInput(strafeInput, rotControl.RotationInput, brakeInput);
     }
@@ -750,6 +756,7 @@ public sealed partial class ShipSteeringSystem : EntitySystem
         public ref float RotationCompensation;
         // misc
         public float FrameTime;
+        public bool ManageDampening; // Triad: false for player-console autopilot so we don't stomp the pilot's dampening mode
     }
 
     private record struct SteeringConfig


### PR DESCRIPTION
## About the PR
Player ship autopilot was overriding the pilot's selected inertia dampening mode every tick and never putting it back, so ships ended up stuck in Cruise regardless of whether the pilot had Drive, Cruise, or Park selected. This gates that override so it only runs for NPC ships, restoring the pre-`#4064` behavior where autopilot leaves the pilot's selection alone.

## Why / Balance
Mono `#4064` added a per-tick `SetInertiaDampening(Anchor/Off)` to the shared `ShipSteeringSystem.ProcessMovement` so NPC drones coast (`Off`) and hard-brake (`Anchor`) to ram. Player autopilot reuses the same steering, so that addition also clobbered the pilot's Drive/Cruise/Park choice on every tick and left the ship in `Off` (Cruise) when done. The fix adds a `ManageDampening` flag to the steering context, set false when the steerer lives on a `ShuttleConsoleComponent` (player autopilot) and true for NPC cores, and wraps the dampening override in it. NPC drone flight is unchanged; player autopilot now flies in and finishes in whatever mode the pilot selected, braking to arrive via thrust as it did before #4064.

## Media
N/A (behavior fix, no visual change).

## Requirements
- [x] I have read relevant guidelines/documentation to this PR found on [our devwiki](https://monolith-station.github.io/mono-docs/).
- [x] I have added media to this PR or it does not require an ingame showcase.
- [x] I can confirm this PR contains either no AI-generated content, or AI-generated content that meets our guidelines.

## How to test
1. At a ship console, set the dampener to Drive (or Park), then autopilot to a waypoint.
2. Confirm the ship holds the selected mode for the whole trip and stays in it on arrival, instead of snapping to Cruise.
3. Confirm NPC drones still coast and hard-brake as before (unchanged behavior).

## Breaking changes
None. Internal steering behavior only; no namespace, prototype, or public API changes.

**Changelog**
:cl:
- fix: Ship autopilot now keeps the dampener mode (Drive/Cruise/Park) you selected instead of forcing the ship into Cruise.
