### PR TITLE
Makes Fax Machines Faster

### DIFF
--- a/Content.Shared/Fax/Components/FaxMachineComponent.cs
+++ b/Content.Shared/Fax/Components/FaxMachineComponent.cs
@@ -103,14 +103,14 @@ public sealed partial class FaxMachineComponent : Component
     /// </summary>
     [ViewVariables]
     [DataField]
-    public float SendTimeout = 5f;
+    public float SendTimeout = 1; // Triad - 1<5
 
     /// <summary>
     /// Message copying timeout
     /// </summary>
     [ViewVariables]
     [DataField]
-    public float CopyTimeout = 5f;
+    public float CopyTimeout = 1f; // Triad - 1<5
 
     /// <summary>
     /// Remaining time of inserting animation

--- a/Content.Shared/Fax/Components/FaxMachineComponent.cs
+++ b/Content.Shared/Fax/Components/FaxMachineComponent.cs
@@ -103,7 +103,7 @@ public sealed partial class FaxMachineComponent : Component
     /// </summary>
     [ViewVariables]
     [DataField]
-    public float SendTimeout = 1; // Triad - 1<5
+    public float SendTimeout = 1f; // Triad - 1<5
 
     /// <summary>
     /// Message copying timeout


### PR DESCRIPTION
## About the PR
This PR makes the copying and sending functionality of fax machines faster. `1` instead of `5`, whatever these numbers translate to. It's approximately 1 Mississippi from my scientific testing, but I seriously doubt it was five whole seconds before. I was able to swap fax targets just in time for Send to come off cooldown again

This kind of makes the animation look a *bit* funky if spammed on a single fax machine, but it's kind of strange anyway and speeding up the animation would probably take away more than it'd be worth

I opted to change the default in C# because I thiiiink there's no other way? I can't even edit it in VVWrite so I have doubts

## Why / Balance
QOL for fax machines making advertising (or other faxing) faster. Less annoying to send out faxes. There is *undoubtedly* a reason this was implemented but we're a whitelisted server anyway and there's far better ways to potentially lag things

## Media
<img width="471" height="509" alt="image" src="https://github.com/user-attachments/assets/a3ceb39d-5bdc-4cd5-9ebc-c9e12ed41dd7" />

## Requirements
<!-- Confirm the following by placing an X in the brackets [X]: -->
- [X] I have read relevant guidelines/documentation to this PR found on [our devwiki](https://monolith-station.github.io/mono-docs/).
- [X] I have added media to this PR or it does not require an ingame showcase.
- [X] I can confirm this PR contains either no AI-generated content, or AI-generated content that meets our guidelines.
<!-- You should understand that not following the above may get your PR closed at maintainer’s discretion -->
<!-- When using AI, make sure you are already proficient in creating whatever content you are attempting to generate and that you already have experience contributing to SS14. This means using AI to enhance your preexisting workflow, not vibecoding. -->

## How to test
1. `self spawn:on FaxMachineBase` two times on different tiles
2. Rename the new fax machines with a screwdriver if you'd like. Optional
3. Put in a piece of paper. Press copy or send repeatedly. The fax machines are far faster

**Changelog**
:cl: Minerva
- tweak: Fax machines are now far faster for sending and copying. In roughly the time it would take you to change the destination, you can send another fax.
