### PR TITLE
Cherrypick: Adds the Ore Magnet (#3921)

### DIFF
--- a/Resources/Prototypes/Recipes/Lathes/Packs/cargo.yml
+++ b/Resources/Prototypes/Recipes/Lathes/Packs/cargo.yml
@@ -27,6 +27,7 @@
   id: CargoBoards
   recipes:
   - OreProcessorIndustrialMachineCircuitboard
+  - OreMagnetMachineCircuitboard # Mono
   # - CargoTelepadMachineCircuitboard # Frontier
   - ShuttleGunKineticCircuitboard
   - WeaponTurretM25Circuitboard # Mono

--- a/Resources/Prototypes/Research/industrial.yml
+++ b/Resources/Prototypes/Research/industrial.yml
@@ -12,6 +12,7 @@
   - WeaponGrapplingGun # Frontier
   - MineralScannerEmpty
   - OreProcessorIndustrialMachineCircuitboard
+  - OreMagnetMachineCircuitboard
   - ClothingMaskWeldingGas
   - ClothingShoesBootsJump
   - MechEquipmentDrill # Goobstation

--- a/Resources/Prototypes/_Mono/Entities/Markers/Spawners/Random/scrap_processor.yml
+++ b/Resources/Prototypes/_Mono/Entities/Markers/Spawners/Random/scrap_processor.yml
@@ -266,6 +266,7 @@
     - id: MaterialReclaimerMachineCircuitboard
     - id: OreProcessorIndustrialMachineCircuitboard
     - id: OreProcessorMachineCircuitboard
+    - id: OreMagnetMachineCircuitboard # Mono
     - id: ShredderMachineCircuitboard
     - id: ShuttleGunKineticCircuitboard
     - id: NFScrapProcessorCircuitboard

--- a/Resources/Prototypes/_Mono/Entities/Objects/Devices/Circuitboards/Machine/salvage.yml
+++ b/Resources/Prototypes/_Mono/Entities/Objects/Devices/Circuitboards/Machine/salvage.yml
@@ -1,0 +1,15 @@
+﻿- type: entity
+  id: OreMagnetMachineCircuitboard
+  parent: BaseMachineCircuitboard
+  name: ore magnet machine board
+  description: A machine printed circuit board for an ore magnet.
+  components:
+  - type: Sprite
+    state: engineering
+  - type: MachineBoard
+    prototype: MachineOreMagnet
+    requirements:
+      Capacitor: 4
+    stackRequirements:
+      Steel: 5
+      CableHV: 5

--- a/Resources/Prototypes/_Mono/Entities/Structures/Machines/ore_magnet.yml
+++ b/Resources/Prototypes/_Mono/Entities/Structures/Machines/ore_magnet.yml
@@ -1,0 +1,123 @@
+﻿- type: entity
+  parent: [BaseMachinePowered, ConstructibleMachine]
+  id: MachineOreMagnet
+  name: ore magnet
+  description: Uses a powerful magnet to suck in ore. Has an internal storage.
+  components:
+  - type: MagnetPickup
+    magnetEnabled: false
+    magnetCanBeEnabled: false
+    range: 30
+  - type: Sprite
+    sprite: Structures/Machines/salvage.rsi
+    layers:
+    - state: salvage-magnet
+    - state: salvage-magnet-o4
+      shader: unshaded
+      map: [ "enum.PowerDeviceVisualLayers.Powered" ]
+    - state: salvage-magnet-ready-blinking
+      visible: false
+      map: [ "enum.ToggleableVisuals.Layer" ]
+  - type: LitOnPowered
+  - type: PointLight
+    radius: 1.5
+    energy: 1.6
+    color: "#3db83b"
+    castShadows: false
+  - type: AmbientSound
+    volume: -10
+    range: 5
+    sound:
+      path: /Audio/Ambience/Objects/hdd_buzz.ogg
+  - type: Appearance
+  - type: ApcPowerReceiver
+    powerLoad: 7000
+  - type: ExtensionCableReceiver
+  - type: Damageable
+    damageContainer: Inorganic
+    damageModifierSet: Metallic
+  - type: Destructible
+    thresholds:
+    - trigger:
+        !type:DamageTrigger
+        damage: 300
+      behaviors:
+      - !type:DoActsBehavior
+        acts: ["Destruction"]
+      - !type:SpawnEntitiesBehavior
+        spawn:
+          SheetSteel1:
+            min: 1
+            max: 2
+  - type: Rotatable
+  - type: Physics
+    bodyType: Static
+  - type: Fixtures
+    fixtures:
+      fix1:
+        shape:
+          !type:PhysShapeAabb
+          bounds: "-0.5,-0.5,0.5,0.5"
+        density: 500
+        mask:
+        - MachineMask
+        layer:
+        - MachineLayer
+  - type: Storage
+    grid:
+    - 0,0,19,9
+    maxItemSize: Normal
+    storageOpenSound: /Audio/Effects/closetopen.ogg
+    storageCloseSound: /Audio/Effects/closetclose.ogg
+    whitelist:
+      tags:
+      - Ore
+      - ArtifactFragment
+  - type: UserInterface
+    interfaces:
+      enum.StorageUiKey.Key:
+        type: StorageBoundUserInterface
+  - type: Dumpable
+    multiplier: 0.15
+  - type: ItemToggle
+    soundActivate: &soundActivate
+      collection: sparks
+      params:
+        variation: 0.25
+    soundDeactivate: *soundActivate
+    onUse: false
+    onAltUse: true
+    onActivate: false
+  - type: GenericVisualizer
+    visuals:
+      enum.PowerDeviceVisuals.Powered:
+        enum.PowerDeviceVisualLayers.Powered:
+          True: { visible: true }
+          False: { visible: false }
+      enum.ToggleableVisuals.Enabled:
+        enum.ToggleableVisuals.Layer:
+          True: { visible: True }
+          False: { visible: False }
+  - type: ItemToggleExamine
+    on: item-toggle-examine-magnet-on
+    off: item-toggle-examine-magnet-off
+  - type: Machine
+    board: OreMagnetMachineCircuitboard
+  - type: ContainerContainer
+    containers:
+      storagebase: !type:Container
+        ents: []
+      machine_board: !type:Container
+      machine_parts: !type:Container
+
+- type: entity
+  name: ore magnet flatpack
+  id: OreMagnetFlatpack
+  parent: BaseNFFlatpack
+  description: A flatpack used for constructing an ore magnet.
+  components:
+  - type: Flatpack
+    entity: MachineOreMagnet
+  - type: StaticPrice
+    price: 6500
+    vendPrice: 10000

--- a/Resources/Prototypes/_Mono/Recipes/Lathes/electronics.yml
+++ b/Resources/Prototypes/_Mono/Recipes/Lathes/electronics.yml
@@ -102,3 +102,8 @@
   parent: BaseGoldCircuitboardRecipe
   id: CentrifugeLatheMiniCircuitboard
   result: CentrifugeLatheMiniCircuitboard
+
+- type: latheRecipe
+  parent: BaseGoldCircuitboardRecipe
+  id: OreMagnetMachineCircuitboard
+  result: OreMagnetMachineCircuitboard

--- a/Resources/Prototypes/_NF/Catalog/VendingMachines/Inventories/flatpackvend.yml
+++ b/Resources/Prototypes/_NF/Catalog/VendingMachines/Inventories/flatpackvend.yml
@@ -3,6 +3,7 @@
   startingInventory:
     #ShuttleGunKineticFlatpack: 4294967295 # Infinite
     OreProcessorFlatpack: 4294967295 # Infinite
+    OreMagnetFlatpack: 4294967295 # Infinite
     AutolatheFlatpack: 4294967295 # Infinite
     HydroponicsTrayEmptyFlatpack: 4294967295 # Get a food ship, or an atmost ship - Mono Infinite
     ExosuitFabricatorFlatpack: 4294967295 # Infinite

--- a/Resources/Prototypes/_NF/Entities/Markers/Spawners/Random/dungeon_items_general.yml
+++ b/Resources/Prototypes/_NF/Entities/Markers/Spawners/Random/dungeon_items_general.yml
@@ -699,6 +699,7 @@
     - PortableGeneratorPacmanMachineCircuitboard
     - ReagentGrinderMachineCircuitboard
     - OreProcessorMachineCircuitboard
+    - OreMagnetMachineCircuitboard
     - MicrowaveMachineCircuitboard
     - SurveillanceWirelessCameraMovableCircuitboard
     - PowerComputerCircuitboard

--- a/Resources/Prototypes/_NF/Entities/Markers/Spawners/Random/dungeon_items_supply.yml
+++ b/Resources/Prototypes/_NF/Entities/Markers/Spawners/Random/dungeon_items_supply.yml
@@ -277,6 +277,7 @@
     - SalvageTechFabCircuitboardNF
     - AutolatheMachineCircuitboard
     - OreProcessorMachineCircuitboard
+    - OreMagnetMachineCircuitboard
     # Machines
     - MaterialReclaimerMachineCircuitboard
     - SpaceHeaterMachineCircuitBoard


### PR DESCRIPTION
## About the PR
Ports https://github.com/Monolith-Station/Monolith/pull/3921, which was merged recently
- 10k spesos at a FlatpackVend
- Under "Salvage Equipment" research, which also has industrial ore processors
- Rare scrap loot I think?
- Picks up ore within 30 meters when enabled. You can get a rough gauge of the range if your shuttle console is *very* close to it as it'd be around the 32m ring

Note that this uses power but doesn't actually need it
Construction can take *any* capacitor, interestingly
This has the same sprite as the salvage magnet

- Tested to work fine with ship saving with the magnet on
- Flatpack works
- Researched recipe works
- Construction works

## Why / Balance
Massive convenience for mining and possibly a reason to actually set up and make temporary infrastructure on larger mining sites, which would be cool. Mining will be far faster for smaller asteroids

I'm not entirely sure if we **want** this given the fact we're persistent? Monolith is balanced around nonpersistence and acquiring ore quickly is probably an actual consideration?
Unsure if we want to encourage mining being ridiculously quick either? This wouldn't *fully* replace actual crew I think, but it'd be very close
You can delete ore if you deconstruct it. The ore still has to be slooowly dumped out and hauled back

I think I'd also like @rebaserHEAD's opinion on the performance implications of this as that's something I'm unfamiliar with. I kind of just want feedback in general on if this should be ported
- Should the range be debuffed at all?
- Should I try to add a power requirement?
- Should I add a radar blip? (so it's *very* obvious where your ore vanishes to)
- Should I make it unanchorable? Currently, it's just a heavy long-ranged ore box. Making it unanchorable would mean people can't haul around the huge industrial magnet like an ore box. And—because it voids ore when deconstructed—it would encourage setting up little waystations for it on large mining sites
- Should I make dumping it out slower?

## Media
<img width="418" height="444" alt="image" src="https://github.com/user-attachments/assets/b3cd6c81-bf0b-49c9-9f07-c69a13f4e9ed" />

## Requirements
<!-- Confirm the following by placing an X in the brackets [X]: -->
- [X] I have read relevant guidelines/documentation to this PR found on [our devwiki](https://monolith-station.github.io/mono-docs/).
- [X] I have added media to this PR or it does not require an ingame showcase.
- [X] I can confirm this PR contains either no AI-generated content, or AI-generated content that meets our guidelines.
<!-- You should understand that not following the above may get your PR closed at maintainer’s discretion -->
<!-- When using AI, make sure you are already proficient in creating whatever content you are attempting to generate and that you already have experience contributing to SS14. This means using AI to enhance your preexisting workflow, not vibecoding. -->

## How to test
1. Go through the list of what I tested above

**Changelog**
:cl: Monolith
- add: The ore magnet has been ported from Monolith. It can be bought for 10k credits at a FlatpackVend or found under the Salvage Equipment research. It grabs all ore within 30 meters. Deconstructing it will delete the ore it contains.
