### PR TITLE
Perf/Narrow HighPressureDelta Tile Lookup to Dynamic|Sundries

### DIFF
--- a/Content.Server/Atmos/EntitySystems/AtmosphereSystem.HighPressureDelta.cs
+++ b/Content.Server/Atmos/EntitySystems/AtmosphereSystem.HighPressureDelta.cs
@@ -4,6 +4,7 @@ using Content.Shared.Atmos.Components;
 using Content.Shared.Mobs.Components;
 using Content.Shared.Physics;
 using Robust.Shared.Audio;
+using Robust.Shared.GameObjects; // Triad: LookupFlags
 using Robust.Shared.Map;
 using Robust.Shared.Physics;
 using Robust.Shared.Physics.Components;
@@ -140,7 +141,10 @@ namespace Content.Server.Atmos.EntitySystems
             }
 
             _entSet.Clear();
-            _lookup.GetLocalEntitiesIntersecting(tile.GridIndex, tile.GridIndices, _entSet, 0f);
+            // Triad: narrow lookup flags. HPD only acts on dynamic/sundries movable bodies (the
+            // MovedByPressure filter below rejects static/contained/sensor entities anyway), so there
+            // is no need to walk the static tree or recurse into containers per tile per atmos tick.
+            _lookup.GetLocalEntitiesIntersecting(tile.GridIndex, tile.GridIndices, _entSet, 0f, LookupFlags.Dynamic | LookupFlags.Sundries);
 
             foreach (var entity in _entSet)
             {


### PR DESCRIPTION
## About the PR
Narrows the high-pressure-delta (space wind) per-tile entity lookup from the default `LookupFlags.All` to `LookupFlags.Dynamic | LookupFlags.Sundries`. This is the lookup that runs for every affected tile every atmos tick; the default walked the static physics trees and recursed into containers, all of which the downstream `MovedByPressure` filter discards anyway.

## Why / Balance
The lookup was using `All` (Contained + Dynamic + Static + Sundries + Sensors) but the pressure path only acts on movable bodies: contained entities are skipped explicitly, and static bodies only ever take a no-op linear impulse. Resting items put to sleep by `CollisionWake` move into the non-static Sundries tree, which the narrowed flags still query, so they stay covered. Measured ~9.5x faster per tile query (20.9ms to 2.2ms on a full saltern tile sweep). No intended gameplay change.

## Media
N/A, backend performance change with no intended visible behavior change.

## Requirements
- [x] I have read relevant guidelines/documentation to this PR found on [our devwiki](https://monolith-station.github.io/mono-docs/).
- [x] I have added media to this PR or it does not require an ingame showcase.
- [x] I can confirm this PR contains either no AI-generated content, or AI-generated content that meets our guidelines.

## How to test
- Settle a few loose items on a floor (let them sleep), then breach the room to vacuum and confirm they still get thrown by the space wind. This is the case the lookup change is most likely to affect.
- Confirm mobs and unanchored items are still pushed/thrown by depressurization as before.
- Confirm no change to anchored objects (they were never moved by pressure).

## Breaking changes
None.

**Changelog**
:cl:
- tweak: Optimized space wind performance during large depressurization events.
