### PR TITLE
Perf/Skip Dead IsWeightlessEvent Raise for Inventory-Less Bodies

### DIFF
--- a/Content.Shared/Gravity/SharedGravitySystem.cs
+++ b/Content.Shared/Gravity/SharedGravitySystem.cs
@@ -1,4 +1,6 @@
+using Content.Shared._NF.Clothing.Components; // Triad
 using Content.Shared.Alert;
+using Content.Shared.Clothing; // Triad
 using Content.Shared.Inventory;
 using Content.Shared.Movement.Components;
 using Robust.Shared.GameStates;
@@ -19,6 +21,12 @@ namespace Content.Shared.Gravity
 
         private EntityQuery<GravityComponent> _gravityQuery;
 
+        // Triad: queries for the IsWeightless raw-event subscriber set (see IsWeightless guard)
+        private EntityQuery<InventoryComponent> _inventoryQuery;
+        private EntityQuery<MagbootsComponent> _magbootsQuery;
+        private EntityQuery<NFMoonBootsComponent> _moonBootsQuery;
+        // End Triad
+
         public bool IsWeightless(EntityUid uid, PhysicsComponent? body = null, TransformComponent? xform = null)
         {
             Resolve(uid, ref body, false);
@@ -28,6 +36,27 @@ namespace Content.Shared.Gravity
 
             if (TryComp<MovementIgnoreGravityComponent>(uid, out var ignoreGravityComponent))
                 return ignoreGravityComponent.Weightless;
+
+            // Triad: skip the IInventoryRelayEvent raise when no subscriber exists.
+            // The raw IsWeightlessEvent has exactly three direct subscribers: InventoryComponent
+            // (the relay), MagbootsComponent, and NFMoonBootsComponent (verified via the event
+            // index). For inventory-less mobs (carp, wildlife, projectile debris) the raise
+            // dispatches to zero handlers but still pays the directed event-bus lookup per moving
+            // body per tick (~9% of PhysicsSystem.Update under mob-heavy load). Skipping the raise
+            // here is bit-equivalent to raising it with no handler (the struct stays Handled=false,
+            // so the method falls through to the grid/map gravity check below regardless).
+            // If a future component subscribes to the RAW IsWeightlessEvent it MUST be added here,
+            // or weightlessness silently breaks for entities carrying only that component.
+            if (!_inventoryQuery.HasComp(uid)
+                && !_magbootsQuery.HasComp(uid)
+                && !_moonBootsQuery.HasComp(uid))
+            {
+                if (!Resolve(uid, ref xform))
+                    return true;
+
+                return !EntityGridOrMapHaveGravity((uid, xform));
+            }
+            // End Triad
 
             var ev = new IsWeightlessEvent(uid);
             RaiseLocalEvent(uid, ref ev);
@@ -78,6 +107,12 @@ namespace Content.Shared.Gravity
             SubscribeLocalEvent<GravityComponent, ComponentHandleState>(OnHandleState);
 
             _gravityQuery = GetEntityQuery<GravityComponent>();
+
+            // Triad: populate IsWeightless guard queries
+            _inventoryQuery = GetEntityQuery<InventoryComponent>();
+            _magbootsQuery = GetEntityQuery<MagbootsComponent>();
+            _moonBootsQuery = GetEntityQuery<NFMoonBootsComponent>();
+            // End Triad
         }
 
         public override void Update(float frameTime)


### PR DESCRIPTION
## About the PR
Guards the `IsWeightless` event raise in `SharedGravitySystem`. The method raised an `IInventoryRelayEvent` (`IsWeightlessEvent`) for every moving body every tick from the physics prestep loop, even for entities with no handler for it. The raw event has exactly three direct subscribers (`InventoryComponent` relay, `MagbootsComponent`, `NFMoonBootsComponent`); when an entity has none of those, the raise dispatches to nothing, so we skip it and fall through to the existing grid/map gravity check directly. Note for maintainers: any future component subscribing to the raw `IsWeightlessEvent` must be added to the guard, which an inline comment calls out.

## Why / Balance
For inventory-less mobs (carp, wildlife, projectile debris) the raise paid a directed event-bus lookup per body per tick for zero handlers; dotnet-trace measured it at ~9% of `PhysicsSystem.Update` under a mob-heavy load. Skipping it is bit-equivalent to raising it with no handler: the event struct stays `Handled=false` and the method falls through to the same gravity check. This is a guard, not a cache, so nothing goes stale and there is no prediction rubberbanding risk. No intended gameplay change.

## Media
N/A, backend performance change with no intended visible behavior change.

## Requirements
- [x] I have read relevant guidelines/documentation to this PR found on [our devwiki](https://monolith-station.github.io/mono-docs/).
- [x] I have added media to this PR or it does not require an ingame showcase.
- [x] I can confirm this PR contains either no AI-generated content, or AI-generated content that meets our guidelines.

## How to test
- Confirm an inventory-less mob (e.g. a carp) is weightless in space and not weightless on a gravity-enabled grid, same as before.
- Confirm a crewmember is weightless in space and not weightless under gravity.
- Confirm magboots and moonboots still keep their wearer grounded in zero-g.

## Breaking changes
None.

**Changelog**
:cl:
- tweak: Optimized weightlessness checks for better performance with many creatures.
