### PR TITLE
Fix\route Generator Rad-Source Writes Through RadiationSystem Cache

### DIFF
--- a/Content.Server/Power/Generator/GeneratorSystem.cs
+++ b/Content.Server/Power/Generator/GeneratorSystem.cs
@@ -10,6 +10,7 @@ using Content.Shared.Popups;
 using Content.Shared.Power.Generator;
 using Robust.Server.GameObjects;
 using Content.Shared.Radiation.Components; // Frontier
+using Content.Server.Radiation.Systems; // Triad: cache-invalidating rad-source setters
 using Content.Shared.Audio; // Frontier
 using Content.Shared.Materials; // Frontier
 using Content.Server._NF.Power.Components; // Frontier
@@ -30,6 +31,7 @@ public sealed class GeneratorSystem : SharedGeneratorSystem
     [Dependency] private readonly PuddleSystem _puddle = default!;
 
     [Dependency] private readonly PointLightSystem _pointLight = default!; // Frontier: Rads glow
+    [Dependency] private readonly RadiationSystem _radiation = default!; // Triad: route rad-source writes through the cache
     [Dependency] private readonly SharedAmbientSoundSystem _ambientSoundSystem = default!; // Frontier: Rads sound
 
     private EntityQuery<UpgradePowerSupplierComponent> _upgradeQuery; // Frontier: keeping upgradeable power supplies
@@ -199,10 +201,8 @@ public sealed class GeneratorSystem : SharedGeneratorSystem
     // Frontier: radioactive generators
     public void TryUpdateGeneratorRadiation(EntityUid uid, bool on, FuelGeneratorComponent component) // Frontier
     {
-        if (!TryComp<RadiationSourceComponent>(uid, out var radiation)) // Frontier
+        if (!HasComp<RadiationSourceComponent>(uid)) // Frontier // Triad: HasComp - we mutate via _radiation, not the local ref
             return;
-
-        radiation.Enabled = on;
 
         if (on)
         {
@@ -211,8 +211,11 @@ public sealed class GeneratorSystem : SharedGeneratorSystem
             float radiationSlope = radiationIntensity / 3;
             float visualRadius = 1f + (component.RadiationIntensity * component.TargetPower / 4);
 
-            radiation.Intensity = radiationIntensity;
-            radiation.Slope = Math.Max(0.5f, radiationSlope); // Slope should always be at least 0.5 (typical for bananium)
+            // Triad: set intensity/slope first, then enable - both go through the system so the
+            // source cache (_sourceTree/_sourceDataMap) actually picks up the change. Direct field
+            // writes here used to silently no-op because nothing called UpdateSource.
+            _radiation.SetSourceIntensity(uid, radiationIntensity, Math.Max(0.5f, radiationSlope)); // Slope >= 0.5 (typical for bananium)
+            _radiation.SetSourceEnabled(uid, true);
 
             EnsureComp<PointLightComponent>(uid, out var light);
             _pointLight.SetColor(uid, component.RadiationColor, light); // Add glow - on
@@ -224,6 +227,7 @@ public sealed class GeneratorSystem : SharedGeneratorSystem
         }
         else
         {
+            _radiation.SetSourceEnabled(uid, false); // Triad: was a direct radiation.Enabled write; route through the system to refresh the cache
             RemComp<PointLightComponent>(uid); // Remove glow - off
             _ambientSoundSystem.SetAmbience(uid, false);
         }

--- a/Content.Server/Radiation/Systems/RadiationSystem.cs
+++ b/Content.Server/Radiation/Systems/RadiationSystem.cs
@@ -166,6 +166,24 @@ public sealed partial class RadiationSystem : EntitySystem
         UpdateSource((entity.Owner, entity.Comp));
     }
 
+    // Triad: cache-invalidating intensity setter. The gridcast reads only from the cached
+    // _sourceTree/_sourceDataMap, so callers must never write Intensity/Slope directly -
+    // they have to route through here (or SetSourceEnabled) so UpdateSource refreshes the cache.
+    /// <summary>
+    ///     Sets the source's radiation intensity (and optionally its falloff slope), refreshing the source cache.
+    /// </summary>
+    public void SetSourceIntensity(Entity<RadiationSourceComponent?> entity, float intensity, float? slope = null)
+    {
+        if (!Resolve(entity, ref entity.Comp, false))
+            return;
+
+        entity.Comp.Intensity = intensity;
+        if (slope is { } s)
+            entity.Comp.Slope = s;
+
+        UpdateSource((entity.Owner, entity.Comp));
+    }
+
     /// <summary>
     ///     Marks entity to receive/ignore radiation rays.
     /// </summary>


### PR DESCRIPTION
## About the PR
Radioactive fuel generators wrote `RadiationSourceComponent.Enabled/Intensity/Slope` directly in `TryUpdateGeneratorRadiation`, but the radiation gridcast only reads from the cached `_sourceTree`/`_sourceDataMap`, which is refreshed exclusively by `UpdateSource`. The direct field writes never refreshed the cache, so a generator's emitted radiation never reflected its actual on/off or power state. Adds a cache-invalidating `SetSourceIntensity` setter to `RadiationSystem` and routes the generator's writes through it and `SetSourceEnabled`.

## Why / Balance
Radioactive generators were effectively not emitting radiation that matched their state: turning one on, off, or changing its target power had no effect on the gridcast because the underlying field writes were invisible to the cache. This restores the intended behavior. No new balance values, the intensity/slope math is unchanged.

## Media
N/A, bug fix to existing behavior.

## Requirements
- [x] I have read relevant guidelines/documentation to this PR found on [our devwiki](https://monolith-station.github.io/mono-docs/).
- [x] I have added media to this PR or it does not require an ingame showcase.
- [x] I can confirm this PR contains either no AI-generated content, or AI-generated content that meets our guidelines.

## How to test
- Place a radioactive fuel generator, fuel it, and turn it on. Confirm a dosimeter / the radiation overlay shows radiation around it.
- Change the generator's target power and confirm the radiation intensity tracks the change.
- Turn the generator off and confirm the radiation stops.

## Breaking changes
None. Adds a public `RadiationSystem.SetSourceIntensity` method; no signatures changed.

**Changelog**
:cl:
- fix: Radioactive generators now correctly emit radiation that reflects their power state.
