### PR TITLE
Trait Fixes

### DIFF
--- a/Content.Client/_DV/Traits/UI/TraitEntry.xaml.cs
+++ b/Content.Client/_DV/Traits/UI/TraitEntry.xaml.cs
@@ -159,20 +159,7 @@ public sealed partial class TraitEntry : PanelContainer
 
         foreach (var condition in _trait.Conditions)
         {
-            var result = condition switch
-            {
-                IsSpeciesCondition speciesCond => CheckSpeciesCondition(speciesCond, speciesId),
-                HasJobCondition jobCond => CheckJobCondition(jobCond, jobId),
-                InDepartmentCondition deptCond => CheckDepartmentCondition(deptCond, jobId),
-                HasCompCondition compCond => !compCond.Invert, // can't check in lobby but screws with the inversion logic
-                IsAntagEligibleCondition antagEligibleCond => CheckAntagEligibleCondition(antagEligibleCond, antagPreferences),
-                HasTraitCondition hasTrait => CheckHasTraitCondition(hasTrait, traits),
-                HasFreeAccentSlotCondition => CheckFreeAccentSlot(speciesId, traits), // Triad - free accent slot gate
-                InCompanyCondition inCompanyCond => CheckInCompanyCondition(inCompanyCond, companyName), // Mono - Company condition
-                AnyOfCondition anyOfCond => CheckAnyOfCondition(anyOfCond, jobId, speciesId, antagPreferences, traits, companyName),
-                AllOfCondition allOfCond => CheckAllOfCondition(allOfCond, jobId, speciesId, antagPreferences, traits, companyName),
-                _ => true,
-            };
+            var result = CheckCondition(condition, jobId, speciesId, antagPreferences, traits, companyName);
 
             // Apply inversion
             result ^= condition.Invert;
@@ -191,6 +178,34 @@ public sealed partial class TraitEntry : PanelContainer
         }
 
         UpdateVisualState();
+    }
+
+    /// <summary>
+    /// Triad: Checks a given condition type into a method via a switch statement.
+    /// </summary>
+    private bool CheckCondition(
+        BaseTraitCondition condition,
+        ProtoId<JobPrototype>? jobId,
+        ProtoId<SpeciesPrototype>? speciesId,
+        IReadOnlySet<ProtoId<AntagPrototype>>? antagPreferences,
+        IReadOnlySet<ProtoId<TraitPrototype>>? traits,
+        string? companyName)
+    {
+        return condition switch
+        {
+            IsSpeciesCondition speciesCond => CheckSpeciesCondition(speciesCond, speciesId),
+            HasJobCondition jobCond => CheckJobCondition(jobCond, jobId),
+            InDepartmentCondition deptCond => CheckDepartmentCondition(deptCond, jobId),
+            HasCompCondition compCond => !compCond.Invert,
+            IsAntagEligibleCondition antagEligibleCond => CheckAntagEligibleCondition(antagEligibleCond, antagPreferences),
+            HasTraitCondition hasTrait => CheckHasTraitCondition(hasTrait, traits),
+            HasTraitInCategoryCondition hasTraitInCategory => CheckHasTraitInCategoryCondition(hasTraitInCategory, traits),
+            HasFreeAccentSlotCondition => CheckFreeAccentSlot(speciesId, traits),
+            InCompanyCondition inCompanyCond => CheckInCompanyCondition(inCompanyCond, companyName),
+            AnyOfCondition anyOfCond => CheckAnyOfCondition(anyOfCond, jobId, speciesId, antagPreferences, traits, companyName),
+            AllOfCondition allOfCond => CheckAllOfCondition(allOfCond, jobId, speciesId, antagPreferences, traits, companyName),
+            _ => true,
+        };
     }
 
     /// <summary>
@@ -254,6 +269,23 @@ public sealed partial class TraitEntry : PanelContainer
         return traits.Contains(condition.Trait);
     }
 
+    private bool CheckHasTraitInCategoryCondition(HasTraitInCategoryCondition condition, IReadOnlySet<ProtoId<TraitPrototype>>? traits)
+    {
+        if (traits is null)
+            return false;
+
+        foreach (var traitId in traits)
+        {
+            if (!_prototype.TryIndex(traitId, out var traitProto))
+                continue;
+
+            if (traitProto.Category == condition.Category)
+                return true;
+        }
+
+        return false;
+    }
+
     // Triad: lobby mirror of HasFreeAccentSlotCondition. The editor can't read entity components, but it has the
     // selected species + trait set, which is all this gate needs. Shares the species list / unlock-trait id with
     // the shared condition so client and server evaluators can't drift.
@@ -280,20 +312,7 @@ public sealed partial class TraitEntry : PanelContainer
         // Return true if ANY child condition evaluates to true
         foreach (var childCondition in condition.Conditions)
         {
-            var result = childCondition switch
-            {
-                IsSpeciesCondition speciesCond => CheckSpeciesCondition(speciesCond, speciesId),
-                HasJobCondition jobCond => CheckJobCondition(jobCond, jobId),
-                InDepartmentCondition deptCond => CheckDepartmentCondition(deptCond, jobId),
-                HasCompCondition compCond => !compCond.Invert, // can't check in lobby
-                IsAntagEligibleCondition antagEligibleCond => CheckAntagEligibleCondition(antagEligibleCond, antagPreferences),
-                HasTraitCondition hasTrait => CheckHasTraitCondition(hasTrait, traits),
-                HasFreeAccentSlotCondition => CheckFreeAccentSlot(speciesId, traits), // Triad - free accent slot gate
-                InCompanyCondition inCompanyCond => CheckInCompanyCondition(inCompanyCond, companyName), // Mono - Company condition
-                AnyOfCondition nestedAnyOf => CheckAnyOfCondition(nestedAnyOf, jobId, speciesId, antagPreferences, traits, companyName), // Recursive!
-                AllOfCondition nestedAllOf => CheckAllOfCondition(nestedAllOf, jobId, speciesId, antagPreferences, traits, companyName),
-                _ => true,
-            };
+            var result = CheckCondition(childCondition, jobId, speciesId, antagPreferences, traits, companyName);
 
             // Apply child's inversion
             result ^= childCondition.Invert;
@@ -316,21 +335,7 @@ public sealed partial class TraitEntry : PanelContainer
 
         foreach (var childCondition in condition.Conditions)
         {
-            var result = childCondition switch
-            {
-                IsSpeciesCondition speciesCond => CheckSpeciesCondition(speciesCond, speciesId),
-                HasJobCondition jobCond => CheckJobCondition(jobCond, jobId),
-                InDepartmentCondition deptCond => CheckDepartmentCondition(deptCond, jobId),
-                HasCompCondition compCond => !compCond.Invert, // can't check in lobby
-                IsAntagEligibleCondition antagEligibleCond => CheckAntagEligibleCondition(antagEligibleCond, antagPreferences),
-                HasTraitCondition hasTrait => CheckHasTraitCondition(hasTrait, traits),
-                HasFreeAccentSlotCondition => CheckFreeAccentSlot(speciesId, traits), // Triad - free accent slot gate
-                InCompanyCondition inCompanyCond => CheckInCompanyCondition(inCompanyCond, companyName),
-                AnyOfCondition nestedAnyOf => CheckAnyOfCondition(nestedAnyOf, jobId, speciesId, antagPreferences, traits, companyName),
-                AllOfCondition nestedAllOf => CheckAllOfCondition(nestedAllOf, jobId, speciesId, antagPreferences, traits, companyName),
-                _ => true,
-            };
-
+            var result = CheckCondition(childCondition, jobId, speciesId, antagPreferences, traits, companyName);
             result ^= childCondition.Invert;
 
             // If any child fails, the AllOf fails.

--- a/Content.Server/_Mono/Traits/Physical/GlassJawSystem.cs
+++ b/Content.Server/_Mono/Traits/Physical/GlassJawSystem.cs
@@ -18,12 +18,11 @@ public sealed class GlassJawSystem : EntitySystem
         base.Initialize();
         SubscribeLocalEvent<GlassJawComponent, ComponentStartup>(OnStartup);
         SubscribeLocalEvent<GlassJawComponent, ComponentShutdown>(OnShutdown);
-        SubscribeLocalEvent<MobThresholdsComponent, ComponentInit>(OnMobThresholdsInit);
     }
 
     private void OnStartup(Entity<GlassJawComponent> ent, ref ComponentStartup args)
     {
-        AdjustCritThreshold(ent.Owner, -ent.Comp.CritDecrease);
+        AdjustCritThreshold(ent.Owner, -ent.Comp.CritDecrease, ent.Comp.CritSetValueFallback);
     }
 
     private void OnShutdown(Entity<GlassJawComponent> ent, ref ComponentShutdown args)
@@ -31,21 +30,21 @@ public sealed class GlassJawSystem : EntitySystem
         AdjustCritThreshold(ent.Owner, ent.Comp.CritDecrease);
     }
 
-    private void OnMobThresholdsInit(EntityUid uid, MobThresholdsComponent comp, ComponentInit args)
+    private void AdjustCritThreshold(EntityUid uid, int deltaPoints, int? setValue = null, MobThresholdsComponent? thresholdsComp = null)
     {
-        if (HasComp<GlassJawComponent>(uid))
-        {
-            var gj = Comp<GlassJawComponent>(uid);
-            AdjustCritThreshold(uid, -gj.CritDecrease, comp);
-        }
-    }
+        var newValue = FixedPoint2.Zero;
 
-    private void AdjustCritThreshold(EntityUid uid, int deltaPoints, MobThresholdsComponent? thresholdsComp = null)
-    {
         if (!_mobThresholds.TryGetThresholdForState(uid, MobState.Critical, out var current, thresholdsComp))
-            return;
+        {
+            if (setValue == null)
+                return;
 
-        var newValue = FixedPoint2.Max(0, current.Value + (FixedPoint2)deltaPoints);
+            newValue = FixedPoint2.Max(0, (FixedPoint2)setValue);
+        }
+        else
+        {
+            newValue = FixedPoint2.Max(0, current.Value + (FixedPoint2)deltaPoints);
+        }
 
         _mobThresholds.SetMobStateThreshold(uid, newValue, MobState.Critical, thresholdsComp);
     }

--- a/Content.Shared/_Mono/Traits/Physical/GlassJawComponent.cs
+++ b/Content.Shared/_Mono/Traits/Physical/GlassJawComponent.cs
@@ -11,4 +11,10 @@ public sealed partial class GlassJawComponent : Component
     /// </summary>
     [DataField]
     public int CritDecrease = 10;
+
+    /// <summary>
+    /// Triad: Optional field for setting the critical thresholds directly, if the threshold does not exist
+    /// </summary>
+    [DataField]
+    public int? CritSetValueFallback;
 }

--- a/Resources/Prototypes/_Mono/Traits/physical.yml
+++ b/Resources/Prototypes/_Mono/Traits/physical.yml
@@ -249,6 +249,7 @@
     components:
     - type: GlassJaw
       critDecrease: 50
+      critSetValueFallback: 50 # Triad, fallback that sets crit state threshold to 50 if no critical state exists. This is done so the trait does not conflict with redshirt.
 
 - type: trait
   id: Hemophilia

--- a/Resources/Prototypes/_Triad/Traits/medical.yml
+++ b/Resources/Prototypes/_Triad/Traits/medical.yml
@@ -1,0 +1,10 @@
+- type: trait
+  id: Snoring
+  name: trait-snoring-name
+  description: trait-snoring-desc
+  category: Medical
+  cost: 0
+  effects:
+  - !type:AddCompsEffect
+    components:
+    - type: Snoring


### PR DESCRIPTION
## About the PR
- Added back the snoring trait
- Fixed the mute trait being unselectable
- Fixed osteogensis and redshirt conflicting with eachother, so now it gives you 50 HP crit and 100 HP dead as intended

## Technical details
There was no method to check for ``HasTraitInCategoryCondition`` in ``TraitEntry.xaml.cs``, so it returned true always. Inverting this condition made the trait entirely unselectable. Changed up the code a bit, making a new method ``CheckCondition`` which replaces the switch statement copy-paste that was done 4 times for checking trait condition types.

Added ``CritSetValueFallback`` to ``GlassJawComponent``, this makes it so it'll forcefully set the target's crit HP to this value even if a crit state does not exist. This is needed so that Redshirt and Osteo can co-exist, Redshirt set the '100' value in a typical mob threshold to Dead, so the crit state was entirely removed, which made ``GlassJawSystem`` unable to set the crit state.

## Media
N/A

## Requirements
<!-- Confirm the following by placing an X in the brackets [X]: -->
- [X] I have read relevant guidelines/documentation to this PR found on [our devwiki](https://monolith-station.github.io/mono-docs/).
- [X] I have added media to this PR or it does not require an ingame showcase.
- [X] I can confirm this PR contains either no AI-generated content, or AI-generated content that meets our guidelines.
<!-- You should understand that not following the above may get your PR closed at maintainer’s discretion -->
<!-- When using AI, make sure you are already proficient in creating whatever content you are attempting to generate and that you already have experience contributing to SS14. This means using AI to enhance your preexisting workflow, not vibecoding. -->

**Changelog**
<!-- Add a Changelog entry to make players aware of new features or changes that could affect gameplay.
Make sure to read the guidelines and take this Changelog template out of the comment block in order for it to show up.
Changelog must have a :cl: symbol, so the bot recognizes the changes and adds them to the game's changelog.
Remove this symbol for non-player facing PRs.-->
:cl:
- fix: Fixed snoring trait being unselectable, it is under medical
- fix: Fixed muted trait being unselectable
- fix: Fixed osteogenesis and redshirt being incompatible with eachother, it now correctly gives you 50 HP to crit and 100 HP to dead as intended.