### PR TITLE
Fix Name Regex

### DIFF
--- a/Content.Shared/Preferences/HumanoidCharacterProfile.cs
+++ b/Content.Shared/Preferences/HumanoidCharacterProfile.cs
@@ -28,7 +28,16 @@ namespace Content.Shared.Preferences
     [Serializable, NetSerializable]
     public sealed partial class HumanoidCharacterProfile : ICharacterProfile
     {
-        private static readonly Regex RestrictedNameRegex = new("[^A-Z,a-z,0-9, ,\\-,']");
+        /* DeltaV: Completely redid the regex:
+         * 0030-0039  Basic Latin: ASCII Digits
+         * 0041-005A  Basic Latin: Uppercase Latin Alphabet
+         * 0061-007A  Basic Latin: Lowercase Latin Alphabet
+         * 00C0-00D6  Latin-1 Supplement: Letters I
+         * 00D8-00F6  Latin-1 Supplement: Letters II
+         * 00F8-00FF  Latin-1 Supplement: Letters III
+         * 0100-017F  Latin Extended A: European Latin
+         */
+        private static readonly Regex RestrictedNameRegex = new("[^\\u0030-\\u0039,\\u0041-\\u005A,\\u0061-\\u007A,\\u00C0-\\u00D6,\\u00D8-\\u00F6,\\u00F8-\\u00FF,\\u0100-\\u017F, '.,-]");
         private static readonly Regex ICNameCaseRegex = new(@"^(?<word>\w)|\b(?<word>\w)(?=\w*$)");
 
         public const int MaxNameLength = 32;
@@ -580,17 +589,9 @@ namespace Content.Shared.Preferences
 
             name = name.Trim();
 
-            if (configManager.GetCVar(CCVars.RestrictedNames) && Species != "IPC")
+            if (configManager.GetCVar(CCVars.RestrictedNames))
             {
-                name = Regex.Replace(name, @"[^\u0041-\u005A,\u0061-\u007A,\u00C0-\u00D6,\u00D8-\u00F6,\u00F8-\u00FF,\u0100-\u017F, -]", string.Empty);
-                /*
-                 * 0041-005A  Basic Latin: Uppercase Latin Alphabet
-                 * 0061-007A  Basic Latin: Lowercase Latin Alphabet
-                 * 00C0-00D6  Latin-1 Supplement: Letters I
-                 * 00D8-00F6  Latin-1 Supplement: Letters II
-                 * 00F8-00FF  Latin-1 Supplement: Letters III
-                 * 0100-017F  Latin Extended A: European Latin
-                 */
+                name = RestrictedNameRegex.Replace(name, string.Empty);
             }
 
             if (configManager.GetCVar(CCVars.ICNameCase))


### PR DESCRIPTION
## About the PR
Ported Delta-V's character regex for three reasonS:
- Removing the weird hardcoding of IPCs that allowed them to have any name
- Prevented the system from remaking the regex each time instead of only once (``private static readonly Regex RestrictedNameRegex``)
- Fixed apostrophes and comas not being allowed in character names!

## Media
<img width="273" height="122" alt="image" src="https://github.com/user-attachments/assets/a038e0dc-ea62-458b-81ed-fb87abec180c" />

<img width="289" height="124" alt="image" src="https://github.com/user-attachments/assets/e50bca90-adeb-4fe9-aee9-bb75dbcc8fe6" />


**Changelog**
:cl:
- tweak: Comas and apostrophes can now be used in character names
