### PR TITLE
Rebalance Gas Deposits

### DIFF
--- a/Resources/Prototypes/_NF/Entities/World/Debris/asteroids.yml
+++ b/Resources/Prototypes/_NF/Entities/World/Debris/asteroids.yml
@@ -32,37 +32,24 @@
     - type: RandomEntityPopulator
       entries:
       - params:
-          prob: 0.5
-          min: 1
-          max: 2
+          prob: 0.4
+          min: 2
+          max: 6
           canBeAirSealed: true
         entries:
-        - id: GasDepositOxygen
+        #Triad Change start
+        - id: GasDepositBaseAsteroidVeryLarge
           orGroup: deposit
-        - id: GasDepositNitrogen
+        - id: GasDepositBaseAsteroidLarge
           orGroup: deposit
-        - id: GasDepositCarbonDioxide
+        - id: GasDepositBaseAsteroid
           orGroup: deposit
-          # Mono Changes Start
-        - id: GasDepositPlasmaVerySmall
+        - id: GasDepositBaseAsteroidSmall
           orGroup: deposit
-        - id: GasDepositPlasmaSmall
+        - id: GasDepositBaseAsteroidVerySmall
           orGroup: deposit
-        - id: GasDepositPlasma
-          orGroup: deposit
-        - id: GasDepositPlasmaLarge
-          orGroup: deposit
-        - id: GasDepositPlasmaVeryLarge
-          orGroup: deposit
-        - id: GasDepositMuddlePlasma
-          orGroup: deposit
-          # Mono Changes End
-        - id: GasDepositAir
-          orGroup: deposit
-        - id: GasDepositMuddleEven
-          orGroup: deposit
-        - id: GasDepositMuddlePlasma
-          orGroup: deposit
+        #Triad change stop
+
 # endregion Rock Table
 
 # region Snow Table
@@ -97,41 +84,23 @@
     - type: RandomEntityPopulator
       entries:
       - params:
-          prob: 0.66
-          min: 1
-          max: 4
+          prob: 0.4
+          min: 2
+          max: 6
           canBeAirSealed: true
         entries:
-        - id: GasDepositOxygen
+        #Triad Change start
+        - id: GasDepositIceAsteroidVeryLarge
           orGroup: deposit
-        - id: GasDepositOxygenLarge
+        - id: GasDepositIceAsteroidLarge
           orGroup: deposit
-        - id: GasDepositNitrogen
+        - id: GasDepositIceAsteroid
           orGroup: deposit
-        - id: GasDepositNitrogenLarge
+        - id: GasDepositIceAsteroidSmall
           orGroup: deposit
-        - id: GasDepositAir
+        - id: GasDepositIceAsteroidVerySmall
           orGroup: deposit
-        - id: GasDepositAirLarge
-          orGroup: deposit
-        - id: GasDepositWaterVaporVeryLarge
-          orGroup: deposit
-        - id: GasDepositWaterVaporLarge
-          orGroup: deposit
-          # Mono Changes Start
-        - id: GasDepositPlasmaVerySmall
-          orGroup: deposit
-        - id: GasDepositPlasmaSmall
-          orGroup: deposit
-        - id: GasDepositPlasma
-          orGroup: deposit
-        - id: GasDepositPlasmaLarge
-          orGroup: deposit
-        - id: GasDepositPlasmaVeryLarge
-          orGroup: deposit
-        - id: GasDepositMuddlePlasma
-          orGroup: deposit
-          # Mono Changes End
+        #Triad change stop
 # endregion Snow Table
 
 # region Andesite Table
@@ -166,31 +135,23 @@
     - type: RandomEntityPopulator
       entries:
       - params:
-          prob: 0.33
-          min: 1
-          max: 1
+          prob: 0.4
+          min: 2
+          max: 6
           canBeAirSealed: true
         entries:
-        - id: GasDepositNitrousOxide
+        #Triad Change start
+        - id: GasDepositAndesiteAsteroidVeryLarge
           orGroup: deposit
-        - id: GasDepositCarbonDioxide
+        - id: GasDepositAndesiteAsteroidLarge
           orGroup: deposit
-        - id: GasDepositAmmonia
+        - id: GasDepositAndesiteAsteroid
           orGroup: deposit
-          # Mono Changes Start
-        - id: GasDepositPlasmaVerySmall
+        - id: GasDepositAndesiteAsteroidSmall
           orGroup: deposit
-        - id: GasDepositPlasmaSmall
+        - id: GasDepositAndesiteAsteroidVerySmall
           orGroup: deposit
-        - id: GasDepositPlasma
-          orGroup: deposit
-        - id: GasDepositPlasmaLarge
-          orGroup: deposit
-        - id: GasDepositPlasmaVeryLarge
-          orGroup: deposit
-        - id: GasDepositMuddlePlasma
-          orGroup: deposit
-          # Mono Changes End
+        #Triad change stop
 # endregion Andesite Table
 
 # region Basalt Table
@@ -225,25 +186,23 @@
     - type: RandomEntityPopulator
       entries:
       - params:
-          prob: 0.5
-          min: 4
+          prob: 0.4
+          min: 2
           max: 6
           canBeAirSealed: true
         entries:
-          # Mono Changes Start
-        - id: GasDepositPlasmaVerySmall
+        #Triad Change start
+        - id: GasDepositBasaltAsteroidVeryLarge
           orGroup: deposit
-        - id: GasDepositPlasmaSmall
+        - id: GasDepositBasaltAsteroidLarge
           orGroup: deposit
-        - id: GasDepositPlasma
+        - id: GasDepositBasaltAsteroid
           orGroup: deposit
-        - id: GasDepositPlasmaLarge
+        - id: GasDepositBasaltAsteroidSmall
           orGroup: deposit
-        - id: GasDepositPlasmaVeryLarge
+        - id: GasDepositBasaltAsteroidVerySmall
           orGroup: deposit
-        - id: GasDepositMuddlePlasma
-          orGroup: deposit
-          # Mono Changes End
+        #Triad change stop
 # endregion Basalt Table
 
 # region Sand Table
@@ -278,31 +237,23 @@
     - type: RandomEntityPopulator
       entries:
       - params:
-          prob: 0.5
+          prob: 0.4
           min: 2
-          max: 4
+          max: 6
           canBeAirSealed: true
         entries:
-        - id: GasDepositCarbonDioxideSmall
+        #Triad Change start
+        - id: GasDepositSandAsteroidVeryLarge
           orGroup: deposit
-        - id: GasDepositAmmonia
+        - id: GasDepositSandAsteroidLarge
           orGroup: deposit
-        - id: GasDepositNitrogenLarge
+        - id: GasDepositSandAsteroid
           orGroup: deposit
-          # Mono Changes Start
-        - id: GasDepositPlasmaVerySmall
+        - id: GasDepositSandAsteroidSmall
           orGroup: deposit
-        - id: GasDepositPlasmaSmall
+        - id: GasDepositSandAsteroidVerySmall
           orGroup: deposit
-        - id: GasDepositPlasma
-          orGroup: deposit
-        - id: GasDepositPlasmaLarge
-          orGroup: deposit
-        - id: GasDepositPlasmaVeryLarge
-          orGroup: deposit
-        - id: GasDepositMuddlePlasma
-          orGroup: deposit
-          # Mono Changes End
+        #Triad change stop
 # endregion Sand Table
 
 # region Chromite Table
@@ -337,33 +288,23 @@
     - type: RandomEntityPopulator
       entries:
       - params:
-          prob: 0.6
-          min: 1
-          max: 1
+          prob: 0.4
+          min: 2
+          max: 6
           canBeAirSealed: true
         entries:
-        - id: GasDepositOxygenVeryLarge
+        #Triad Change start
+        - id: GasDepositChromiteAsteroidVeryLarge
           orGroup: deposit
-        - id: GasDepositMuddleEvenVeryLarge
+        - id: GasDepositChromiteAsteroidLarge
           orGroup: deposit
-        - id: GasDepositNitrogenVeryLarge
+        - id: GasDepositChromiteAsteroid
           orGroup: deposit
-        - id: GasDepositAirVeryLarge
+        - id: GasDepositChromiteAsteroidSmall
           orGroup: deposit
-          # Mono Changes Start
-        - id: GasDepositPlasmaVerySmall
+        - id: GasDepositChromiteAsteroidVerySmall
           orGroup: deposit
-        - id: GasDepositPlasmaSmall
-          orGroup: deposit
-        - id: GasDepositPlasma
-          orGroup: deposit
-        - id: GasDepositPlasmaLarge
-          orGroup: deposit
-        - id: GasDepositPlasmaVeryLarge
-          orGroup: deposit
-        - id: GasDepositMuddlePlasma
-          orGroup: deposit
-          # Mono Changes End
+        #Triad change stop
 # endregion Chromite Table
 
 # region AsteroidRock Table
@@ -403,28 +344,18 @@
           max: 6
           canBeAirSealed: true
         entries:
-        - id: GasDepositNitrousOxideSmall
+        #Triad Change start
+        - id: GasDepositRockAsteroidVeryLarge
           orGroup: deposit
-        - id: GasDepositMuddleEvenSmall
+        - id: GasDepositRockAsteroidLarge
           orGroup: deposit
-        - id: GasDepositCarbonDioxideSmall
+        - id: GasDepositRockAsteroid
           orGroup: deposit
-        - id: GasDepositAirSmall
+        - id: GasDepositRockAsteroidSmall
           orGroup: deposit
-          # Mono Changes Start
-        - id: GasDepositPlasmaVerySmall
+        - id: GasDepositRockAsteroidVerySmall
           orGroup: deposit
-        - id: GasDepositPlasmaSmall
-          orGroup: deposit
-        - id: GasDepositPlasma
-          orGroup: deposit
-        - id: GasDepositPlasmaLarge
-          orGroup: deposit
-        - id: GasDepositPlasmaVeryLarge
-          orGroup: deposit
-        - id: GasDepositMuddlePlasma
-          orGroup: deposit
-          # Mono Changes End
+        #Triad change stop
 # endregion AsteroidRock Table
 
 # region Scrap Table

--- a/Resources/Prototypes/_Triad/Atmos/deposits.yml
+++ b/Resources/Prototypes/_Triad/Atmos/deposits.yml
@@ -1,0 +1,119 @@
+- type: gasDeposit
+  id: BaseAsteroid
+  gases:
+  -  2000,  6000  # oxygen
+  -  4000, 12000  # nitrogen
+  -  3000,  9000  # carbon dioxide
+  -   800,  2400  # plasma
+  -    50,   150  # tritium
+  -   400,  1200  # water vapor
+  -   700,  2100  # ammonia
+  -   700,  2100  # nitrous oxide
+  -     0,     0  # frezon
+  -     0,     0  # BZ
+  -     0,     0  # Healium
+  -     0,     0  # Nitrium
+  -     0,     0  # Pluoxium
+
+- type: gasDeposit
+  id: IceAsteroid
+  gases:
+  -  3500,  10500  # oxygen
+  -  2500,   7500  # nitrogen
+  -   800,   2400  # carbon dioxide
+  -   400,   1200  # plasma
+  -    50,    150  # tritium
+  -  4000,  12000  # water vapor
+  -   400,   1200  # ammonia
+  -   400,   1200  # nitrous oxide
+  -     0,      0  # frezon
+  -     0,      0  # BZ
+  -     0,      0  # Healium
+  -     0,      0  # Nitrium
+  -     0,      0  # Pluoxium
+
+- type: gasDeposit
+  id: AndesiteAsteroid
+  gases:
+  -  1500,  4500  # oxygen
+  -   500,  1500  # nitrogen
+  -  1000,  3000  # carbon dioxide
+  -  2000,  6000  # plasma
+  -    50,   150  # tritium
+  -   500,  1500  # water vapor
+  -  4000, 12000  # ammonia
+  -  2500,  7500  # nitrous oxide
+  -     0,     0  # frezon
+  -     0,     0  # BZ
+  -     0,     0  # Healium
+  -     0,     0  # Nitrium
+  -     0,     0  # Pluoxium
+
+- type: gasDeposit
+  id: BasaltAsteroid
+  gases:
+  -  1500,  4500  # oxygen
+  -  1000,  3000  # nitrogen
+  -  1500,  4500  # carbon dioxide
+  -  3000,  9000  # plasma
+  -    50,   150  # tritium
+  -   600,  1800  # water vapor
+  -  2000,  6000  # ammonia
+  -  1000,  3000  # nitrous oxide
+  -     0,     0  # frezon
+  -     0,     0  # BZ
+  -     0,     0  # Healium
+  -     0,     0  # Nitrium
+  -     0,     0  # Pluoxium
+
+- type: gasDeposit
+  id: SandAsteroid
+  gases:
+  -  1500,  4500  # oxygen
+  -  1000,  3000  # nitrogen
+  -  2000,  6000  # carbon dioxide
+  -   600,  1800  # plasma
+  -    50,   150  # tritium
+  -   400,  1200  # water vapor
+  -  1500,  4500  # ammonia
+  -  4500, 13500  # nitrous oxide
+  -     0,     0  # frezon
+  -     0,     0  # BZ
+  -     0,     0  # Healium
+  -     0,     0  # Nitrium
+  -     0,     0  # Pluoxium
+
+- type: gasDeposit
+  id: ChromiteAsteroid
+  gases:
+  -  4000, 12000  # oxygen
+  -  3000,  9000  # nitrogen
+  -   700,  2100  # carbon dioxide
+  -   400,  1200  # plasma
+  -    50,   150  # tritium
+  -  2000,  4000  # water vapor
+  -   500,  1500  # ammonia
+  -  1000,  3000  # nitrous oxide
+  -     0,     0  # frezon
+  -     0,     0  # BZ
+  -     0,     0  # Healium
+  -     0,     0  # Nitrium
+  -     0,     0  # Pluoxium
+
+- type: gasDeposit
+  id: RockAsteroid
+  gases:
+  -  2300,  6900  # oxygen
+  -  1200,  3600  # nitrogen
+  -  4000, 12000  # carbon dioxide
+  -  1000,  3000  # plasma
+  -    50,   150  # tritium
+  -  2000,  6000  # water vapor
+  -   800,  2400  # ammonia
+  -   400,  1200  # nitrous oxide
+  -     0,     0  # frezon
+  -     0,     0  # BZ
+  -     0,     0  # Healium
+  -     0,     0  # Nitrium
+  -     0,     0  # Pluoxium
+

--- a/Resources/Prototypes/_Triad/Entities/Objects/Specific/Atmospherics/deposits.yml
+++ b/Resources/Prototypes/_Triad/Entities/Objects/Specific/Atmospherics/deposits.yml
@@ -1,0 +1,275 @@
+# region Standard Deposits
+- type: entity
+  parent: BaseGasDeposit
+  id: GasDepositBaseAsteroid
+  suffix: BaseAsteroid
+  components:
+  - type: RandomGasDeposit
+    depositPrototype: BaseAsteroid
+  - type: Sprite
+    color: "#d67e27"
+
+- type: entity
+  parent: BaseGasDeposit
+  id: GasDepositIceAsteroid
+  suffix: IceAsteroid
+  components:
+  - type: RandomGasDeposit
+    depositPrototype: IceAsteroid
+  - type: Sprite
+    color: "#d6fffc"
+
+- type: entity
+  parent: BaseGasDeposit
+  id: GasDepositAndesiteAsteroid
+  suffix: AndesiteAsteroid
+  components:
+  - type: RandomGasDeposit
+    depositPrototype: AndesiteAsteroid
+  - type: Sprite
+    color: "#95c280"
+
+- type: entity
+  parent: BaseGasDeposit
+  id: GasDepositBasaltAsteroid
+  suffix: BasaltAsteroid
+  components:
+  - type: RandomGasDeposit
+    depositPrototype: BasaltAsteroid
+  - type: Sprite
+    color: "#b5b5b5"
+
+- type: entity
+  parent: BaseGasDeposit
+  id: GasDepositSandAsteroid
+  suffix: SandAsteroid
+  components:
+  - type: RandomGasDeposit
+    depositPrototype: SandAsteroid
+  - type: Sprite
+    color: "#cad17b"
+
+- type: entity
+  parent: BaseGasDeposit
+  id: GasDepositChromiteAsteroid
+  suffix: ChromiteAsteroid
+  components:
+  - type: RandomGasDeposit
+    depositPrototype: ChromiteAsteroid
+  - type: Sprite
+    color: "#8178cc"
+
+- type: entity
+  parent: BaseGasDeposit
+  id: GasDepositRockAsteroid
+  suffix: RockAsteroid
+  components:
+  - type: RandomGasDeposit
+    depositPrototype: RockAsteroid
+  - type: Sprite
+    color: "#BF8C5C"
+# endregion Standard Deposits
+
+# region Very Small Deposits
+- type: entity
+  parent:
+  - BaseGasDepositVerySmall
+  - GasDepositBaseAsteroid
+  id: GasDepositBaseAsteroidVerySmall
+  suffix: BaseAsteroid, Very Small
+
+- type: entity
+  parent:
+  - BaseGasDepositVerySmall
+  - GasDepositIceAsteroid
+  id: GasDepositIceAsteroidVerySmall
+  suffix: IceAsteroid, Very Small
+
+- type: entity
+  parent:
+  - BaseGasDepositVerySmall
+  - GasDepositAndesiteAsteroid
+  id: GasDepositAndesiteAsteroidVerySmall
+  suffix: AndesiteAsteroid, Very Small
+
+- type: entity
+  parent:
+  - BaseGasDepositVerySmall
+  - GasDepositBasaltAsteroid
+  id: GasDepositBasaltAsteroidVerySmall
+  suffix: BasaltAsteroid, Very Small
+
+- type: entity
+  parent:
+  - BaseGasDepositVerySmall
+  - GasDepositSandAsteroid
+  id: GasDepositSandAsteroidVerySmall
+  suffix: SandAsteroid, Very Small
+
+- type: entity
+  parent:
+  - BaseGasDepositVerySmall
+  - GasDepositChromiteAsteroid
+  id: GasDepositChromiteAsteroidVerySmall
+  suffix: ChromiteAsteroid, Very Small
+
+- type: entity
+  parent:
+  - BaseGasDepositVerySmall
+  - GasDepositRockAsteroid
+  id: GasDepositRockAsteroidVerySmall
+  suffix: RockAsteroid, Very Small
+# endregion Very Small Deposits
+
+# region Small Deposits
+- type: entity
+  parent:
+  - BaseGasDepositSmall
+  - GasDepositBaseAsteroid
+  id: GasDepositBaseAsteroidSmall
+  suffix: BaseAsteroid, Small
+
+- type: entity
+  parent:
+  - BaseGasDepositSmall
+  - GasDepositIceAsteroid
+  id: GasDepositIceAsteroidSmall
+  suffix: IceAsteroid, Small
+
+- type: entity
+  parent:
+  - BaseGasDepositSmall
+  - GasDepositAndesiteAsteroid
+  id: GasDepositAndesiteAsteroidSmall
+  suffix: AndesiteAsteroid, Small
+
+- type: entity
+  parent:
+  - BaseGasDepositSmall
+  - GasDepositBasaltAsteroid
+  id: GasDepositBasaltAsteroidSmall
+  suffix: BasaltAsteroid, Small
+
+- type: entity
+  parent:
+  - BaseGasDepositSmall
+  - GasDepositSandAsteroid
+  id: GasDepositSandAsteroidSmall
+  suffix: SandAsteroid, Small
+
+- type: entity
+  parent:
+  - BaseGasDepositSmall
+  - GasDepositChromiteAsteroid
+  id: GasDepositChromiteAsteroidSmall
+  suffix: ChromiteAsteroid, Small
+
+- type: entity
+  parent:
+  - BaseGasDepositSmall
+  - GasDepositRockAsteroid
+  id: GasDepositRockAsteroidSmall
+  suffix: RockAsteroid, Small
+# endregion Small Deposits
+
+# region Large Deposits
+- type: entity
+  parent:
+  - BaseGasDepositLarge
+  - GasDepositBaseAsteroid
+  id: GasDepositBaseAsteroidLarge
+  suffix: BaseAsteroid, Large
+
+- type: entity
+  parent:
+  - BaseGasDepositLarge
+  - GasDepositIceAsteroid
+  id: GasDepositIceAsteroidLarge
+  suffix: IceAsteroid, Large
+
+- type: entity
+  parent:
+  - BaseGasDepositLarge
+  - GasDepositAndesiteAsteroid
+  id: GasDepositAndesiteAsteroidLarge
+  suffix: AndesiteAsteroid, Large
+
+- type: entity
+  parent:
+  - BaseGasDepositLarge
+  - GasDepositBasaltAsteroid
+  id: GasDepositBasaltAsteroidLarge
+  suffix: BasaltAsteroid, Large
+
+- type: entity
+  parent:
+  - BaseGasDepositLarge
+  - GasDepositSandAsteroid
+  id: GasDepositSandAsteroidLarge
+  suffix: SandAsteroid, Large
+
+- type: entity
+  parent:
+  - BaseGasDepositLarge
+  - GasDepositChromiteAsteroid
+  id: GasDepositChromiteAsteroidLarge
+  suffix: ChromiteAsteroid, Large
+
+- type: entity
+  parent:
+  - BaseGasDepositLarge
+  - GasDepositRockAsteroid
+  id: GasDepositRockAsteroidLarge
+  suffix: RockAsteroid, Large
+# endregion Large Deposits
+
+# region Very Large Deposits
+- type: entity
+  parent:
+  - BaseGasDepositVeryLarge
+  - GasDepositBaseAsteroid
+  id: GasDepositBaseAsteroidVeryLarge
+  suffix: BaseAsteroid, Very Large
+
+- type: entity
+  parent:
+  - BaseGasDepositVeryLarge
+  - GasDepositIceAsteroid
+  id: GasDepositIceAsteroidVeryLarge
+  suffix: IceAsteroid, Very Large
+
+- type: entity
+  parent:
+  - BaseGasDepositVeryLarge
+  - GasDepositAndesiteAsteroid
+  id: GasDepositAndesiteAsteroidVeryLarge
+  suffix: AndesiteAsteroid, Very Large
+
+- type: entity
+  parent:
+  - BaseGasDepositVeryLarge
+  - GasDepositBasaltAsteroid
+  id: GasDepositBasaltAsteroidVeryLarge
+  suffix: BasaltAsteroid, Very Large
+
+- type: entity
+  parent:
+  - BaseGasDepositVeryLarge
+  - GasDepositSandAsteroid
+  id: GasDepositSandAsteroidVeryLarge
+  suffix: SandAsteroid, Very Large
+
+- type: entity
+  parent:
+  - BaseGasDepositVeryLarge
+  - GasDepositChromiteAsteroid
+  id: GasDepositChromiteAsteroidVeryLarge
+  suffix: ChromiteAsteroid, Very Large
+
+- type: entity
+  parent:
+  - BaseGasDepositVeryLarge
+  - GasDepositRockAsteroid
+  id: GasDepositRockAsteroidVeryLarge
+  suffix: RockAsteroid, Very Large
+# endregion Very Large Deposits


### PR DESCRIPTION
## About the PR
Add a unique deposit type for each asteroid to be used instead of gas type deposits.
Increase amount of moles you get per asteroid to 45k Moles on average considering scanning for failed asteroids.

## Why / Balance
Asteroid mining is a pain. It takes both a ton of time trying to find the correct gas and when you do find a deposit they can sometimes just be a 10k moles or less. By also creating a deposit type for each asteroid it allows for much better fine tuning for what gasses and ratios you want for each asteroid. 

Current numbers might be also generous though considering the time it takes to scan, mine, setup, harvest and selling it shouldn't be too bad for the already crying economy of Triad. I expect this to be tweaked a few times to get this right but so far I consider this a good start in trying to make this gameplay style worthwhile.

## Media
<img width="814" height="226" alt="grafik" src="https://github.com/user-attachments/assets/68a3b6d2-9d6e-4494-9375-75d87c2f58d8" />
A quick glance at the total value, moles, average moles of each type per deposit and total moles compared to everything else.

**Changelog**
<!-- Add a Changelog entry to make players aware of new features or changes that could affect gameplay.
Make sure to read the guidelines and take this Changelog template out of the comment block in order for it to show up.
Changelog must have a :cl: symbol, so the bot recognizes the changes and adds them to the game's changelog.
Remove this symbol for non-player facing PRs.-->
:cl:
- tweak: Asteroids now have their own unique gas deposits with specific gas ratios for each type.
- tweak: Significantly increased the amount of moles per asteroid on average.
