### PR TITLE
Make Gas Deposit Scanner Beep From 64 Tiles

### DIFF
--- a/Resources/Prototypes/_NF/Entities/Objects/Specific/Atmospherics/deposits.yml
+++ b/Resources/Prototypes/_NF/Entities/Objects/Specific/Atmospherics/deposits.yml
@@ -488,7 +488,7 @@
   - type: ItemToggle
   - type: ProximityBeeper
   - type: ProximityDetector
-    range: 20
+    range: 64
     criteria:
       components:
       - GasDeposit


### PR DESCRIPTION
## About the PR
from frontier: https://github.com/new-frontiers-14/frontier-station-14/pull/4343

Makes it easier to find gas deposits on larger asteroids. 

Split off from the atmos changes PR

**Changelog**
:cl:
- tweak: Gas deposit scanner now has a range of 64 tiles, from 20.