### PR TITLE
Bunk Bed Constuctibles

### DIFF
--- a/Resources/Prototypes/_Mono/Entities/Structures/Furniture/bunk.yml
+++ b/Resources/Prototypes/_Mono/Entities/Structures/Furniture/bunk.yml
@@ -10,7 +10,7 @@
     state: bottom_bunk
     noRot: true
   - type: Strap
-    #buckleOffset: "0,-0.2"
+    buckleOffset: "0,-0.2"
   - type: InteractionOutline
   - type: Construction
     graph: bunkbed
@@ -31,7 +31,7 @@
     - state: top_bunk_ladder
     noRot: true
   - type: Strap
-    #buckleOffset: "0,0.3"
+    buckleOffset: "0,0.3"
   - type: InteractionOutline
   - type: Construction
     graph: bunkbed

--- a/Resources/Prototypes/_Mono/Entities/Structures/Furniture/bunk.yml
+++ b/Resources/Prototypes/_Mono/Entities/Structures/Furniture/bunk.yml
@@ -9,6 +9,8 @@
     sprite: _Mono/Structures/Furniture/Beds/bunk.rsi
     state: bottom_bunk
     noRot: true
+  - type: Strap
+    #buckleOffset: "0,-0.2"
   - type: InteractionOutline
   - type: Construction
     graph: bunkbed
@@ -28,6 +30,8 @@
     - state: top_bunk_posts
     - state: top_bunk_ladder
     noRot: true
+  - type: Strap
+    #buckleOffset: "0,0.3"
   - type: InteractionOutline
   - type: Construction
     graph: bunkbed

--- a/Resources/Prototypes/_Mono/Entities/Structures/Furniture/bunk.yml
+++ b/Resources/Prototypes/_Mono/Entities/Structures/Furniture/bunk.yml
@@ -3,18 +3,23 @@
   id: BunkBottom
   suffix: Bottom
   parent: Bed
+  description: This is used to lie in, sleep in or strap on. Resting here provides extremely slow healing. Use a crowbar to adjust the position. # Triad
   components:
   - type: Sprite
     sprite: _Mono/Structures/Furniture/Beds/bunk.rsi
     state: bottom_bunk
     noRot: true
   - type: InteractionOutline
+  - type: Construction
+    graph: bunkbed
+    node: bunkbottom
 
 - type: entity
   name: bunk bed
   id: BunkTop
   suffix: Top
   parent: Bed
+  description: This is used to lie in, sleep in or strap on. Resting here provides extremely slow healing. Use a crowbar to adjust the position. # Triad
   components:
   - type: Sprite
     sprite: _Mono/Structures/Furniture/Beds/bunk.rsi
@@ -24,3 +29,6 @@
     - state: top_bunk_ladder
     noRot: true
   - type: InteractionOutline
+  - type: Construction
+    graph: bunkbed
+    node: bunktop

--- a/Resources/Prototypes/_Triad/Recipes/Construction/Graphs/furniture/bunkbed.yml
+++ b/Resources/Prototypes/_Triad/Recipes/Construction/Graphs/furniture/bunkbed.yml
@@ -1,0 +1,64 @@
+- type: constructionGraph
+  id: bunkbed
+  start: start
+  graph:
+    - node: start
+      actions:
+        - !type:DestroyEntity {}
+      edges:
+        - to: bunktop
+          completed:
+            - !type:SnapToGrid { }
+          steps:
+            - material: Steel
+              amount: 2
+              doAfter: 1
+            - material: Cloth
+              amount: 2
+              doAfter: 1
+        - to: bunkbottom
+          completed:
+            - !type:SnapToGrid { }
+          steps:
+            - material: Steel
+              amount: 2
+              doAfter: 1
+            - material: Cloth
+              amount: 2
+              doAfter: 1
+    - node: bunktop
+      entity: BunkTop
+      edges:
+        - to: start
+          completed:
+            - !type:SpawnPrototype
+              prototype: SheetSteel1
+              amount: 2
+            - !type:SpawnPrototype
+              prototype: MaterialCloth1
+              amount: 2
+          steps:
+            - tool: Screwing
+              doAfter: 1
+        - to: bunkbottom
+          steps:
+            - tool: Prying
+              doAfter: 1
+    - node: bunkbottom
+      entity: BunkBottom
+      edges:
+        - to: start
+          completed:
+            - !type:SpawnPrototype
+              prototype: SheetSteel1
+              amount: 2
+            - !type:SpawnPrototype
+              prototype: MaterialCloth1
+              amount: 2
+          steps:
+            - tool: Screwing
+              doAfter: 1
+        - to: bunktop
+          steps:
+            - tool: Prying
+              doAfter: 1

--- a/Resources/Prototypes/_Triad/Recipes/Construction/furniture.yml
+++ b/Resources/Prototypes/_Triad/Recipes/Construction/furniture.yml
@@ -19,9 +19,9 @@
   id: BunkBed
   name: bunk bed
   description: This is used to lie in, sleep in or strap on. Use a crowbar to adjust the position.
-  graph: bed
+  graph: bunkbed
   startNode: start
-  targetNode: bed
+  targetNode: bunkbottom
   category: construction-category-furniture
   icon:
     sprite: _Mono/Structures/Furniture/Beds/bunk.rsi

--- a/Resources/Prototypes/_Triad/Recipes/Construction/furniture.yml
+++ b/Resources/Prototypes/_Triad/Recipes/Construction/furniture.yml
@@ -14,3 +14,20 @@
   canBuildInImpassable: false
   conditions:
   - !type:TileNotBlocked
+
+- type: construction
+  id: BunkBed
+  name: bunk bed
+  description: This is used to lie in, sleep in or strap on. Use a crowbar to adjust the position.
+  graph: bed
+  startNode: start
+  targetNode: bed
+  category: construction-category-furniture
+  icon:
+    sprite: _Mono/Structures/Furniture/Beds/bunk.rsi
+    state: bottom_bunk
+  objectType: Structure
+  placementMode: SnapgridCenter
+  canBuildInImpassable: false
+  conditions:
+    - !type:TileNotBlocked


### PR DESCRIPTION
## About the PR
Good feature for ship builders
Changing the orientation with the crowbar is so the construction menu doesn't become flooded

## Media

https://github.com/user-attachments/assets/ba20e28f-b8bd-4d83-969d-d7fa60b510e6



**Changelog**
<!-- Add a Changelog entry to make players aware of new features or changes that could affect gameplay.
Make sure to read the guidelines and take this Changelog template out of the comment block in order for it to show up.
Changelog must have a :cl: symbol, so the bot recognizes the changes and adds them to the game's changelog.
Remove this symbol for non-player facing PRs.-->
:cl:
- add: Added Bunk beds as constructible objects. You can use a crowbar on bunk beds to change their orientation now.
- tweak: Bunk beds offset you correctly, making it so two spacemen laying on a bunk bed do not looked stacked on top of eachother, but rather on the correct mattress.