### PR TITLE
Port Showing TEG Theoretical Supply on Inspect From Wizden

### DIFF
--- a/Content.Server/Power/Generation/Teg/TegSystem.cs
+++ b/Content.Server/Power/Generation/Teg/TegSystem.cs
@@ -100,7 +100,12 @@ public sealed class TegSystem : EntitySystem
         else
         {
             var supplier = Comp<PowerSupplierComponent>(uid);
-            args.PushMarkup(Loc.GetString("teg-generator-examine-power", ("power", supplier.CurrentSupply)));
+
+            using (args.PushGroup(nameof(TegGeneratorComponent)))
+            {
+                args.PushMarkup(Loc.GetString("teg-generator-examine-power", ("power", supplier.CurrentSupply)));
+                args.PushMarkup(Loc.GetString("teg-generator-examine-power-max-output", ("power", supplier.MaxSupply)));
+            }
         }
     }
 

--- a/Resources/Locale/en-US/power/teg.ftl
+++ b/Resources/Locale/en-US/power/teg.ftl
@@ -1,2 +1,3 @@
-﻿teg-generator-examine-power = It's generating [color=yellow]{ POWERWATTS($power) }[/color].
+﻿teg-generator-examine-power = It's currently supplying [color=yellow]{ POWERWATTS($power) }[/color].
+teg-generator-examine-power-max-output = It's capable of supplying [color=yellow]{ POWERWATTS($power) }[/color].
 teg-generator-examine-connection = To function, a [color=white]circulator[/color] must be attached on both sides.


### PR DESCRIPTION
## About the PR
Cherry picks (https://github.com/space-wizards/space-station-14/pull/37957) to show the maximum power output of a TEG without having to cut wires to check for true power output.

Tested and works.
## Media
<img width="482" height="413" alt="grafik" src="https://github.com/user-attachments/assets/73e2c326-dc05-4995-a076-3f641d687199" />



**Changelog**
<!-- Add a Changelog entry to make players aware of new features or changes that could affect gameplay.
Make sure to read the guidelines and take this Changelog template out of the comment block in order for it to show up.
Changelog must have a :cl: symbol, so the bot recognizes the changes and adds them to the game's changelog.
Remove this symbol for non-player facing PRs.-->
:cl:
- add: TEG now shows max power output

