### PR TITLE
HZD Weapon Fixes and Changes

### DIFF
--- a/Resources/Prototypes/_Triad/Entities/Objects/Weapons/Guns/Basic/base_gun_toggleable.yml
+++ b/Resources/Prototypes/_Triad/Entities/Objects/Weapons/Guns/Basic/base_gun_toggleable.yml
@@ -6,7 +6,7 @@
     activated: false
     onUse: false
     onActivate: false
-    onAltUse: false
+    onAltUse: false # Make sure this value stays false, GunToggleableBonus adds its own alternative verb
     toggleOnWielded: false
     altPriority: 3
     verbToggleOff: unfold-verb
@@ -24,3 +24,4 @@
     maxAngle: 15
     bonusFireRate: 0
     requiresToggle: false
+    doAfterTime: 0.5

--- a/Resources/Prototypes/_Triad/Entities/Objects/Weapons/Guns/Pistols/pistols.yml
+++ b/Resources/Prototypes/_Triad/Entities/Objects/Weapons/Guns/Pistols/pistols.yml
@@ -9,6 +9,7 @@
     maxAngle: -6
     bonusFireRate: -1
     requiresToggle: false
+    doAfterTime: 1.5
   - type: GunChangeShotSoundOnToggled
     sound:
       path: /Audio/_Mono/Weapons/Guns/SmallArms/Gunshots/hawk_fire.ogg
@@ -48,9 +49,6 @@
   - type: Clothing
     sprite: _Triad/Objects/Weapons/Guns/SMGs/squire_inhands_32x.rsi
   - type: ItemToggle
-    onAltUse: true
-    verbToggleOff: fold-verb
-    verbToggleOn: unfold-verb
     altPriority: 1
     soundActivate:
       path: /Audio/_Mono/Weapons/Guns/SmallArms/MagIn/m16_magin.ogg

--- a/Resources/Prototypes/_Triad/Entities/Objects/Weapons/Guns/Smgs/smgs.yml
+++ b/Resources/Prototypes/_Triad/Entities/Objects/Weapons/Guns/Smgs/smgs.yml
@@ -9,6 +9,7 @@
     maxAngle: -16
     bonusFireRate: 0
     requiresToggle: false
+    angleDecay: 7
   - type: GunWieldBonus
     minAngle: -2
     maxAngle: -9
@@ -17,7 +18,7 @@
     maxAngle: 35
     fireRate: 7.5
     angleIncrease: 7
-    angleDecay: 17
+    angleDecay: 8
     selectedMode: FullAuto
     soundGunshot:
       path: /Audio/_Mono/Weapons/Guns/SmallArms/Gunshots/smg.ogg

--- a/Resources/Prototypes/_Triad/Entities/Objects/Weapons/Guns/Smgs/smgs.yml
+++ b/Resources/Prototypes/_Triad/Entities/Objects/Weapons/Guns/Smgs/smgs.yml
@@ -45,13 +45,7 @@
   - type: Clothing
     sprite: _Triad/Objects/Weapons/Guns/SMGs/squire_inhands_32x.rsi
   - type: ItemToggle
-    activated: false
-    onUse: false
-    onActivate: false
-    onAltUse: true
     altPriority: 1
-    verbToggleOff: fold-verb
-    verbToggleOn: unfold-verb
     soundActivate:
       path: /Audio/_Mono/Weapons/Guns/SmallArms/MagIn/m16_magin.ogg
       params:


### PR DESCRIPTION
## About the PR
- Fixed do-afters not working on the HZD guns. ``onAltUse`` was true, which bulldozed the do-after verb given by the gun bonus system
- Minor YML cleanup
- Stiletto has a 1.5 second doafter, toggling 3 attachments in a half second is quite good
- Gave the HZD Squire less angle decay when untoggled. This makes it harder to control unfolded. The HZD is quite powerful ATM and outclasses most SMGs, so this nerfs it a tiny bit.

## Requirements
<!-- Confirm the following by placing an X in the brackets [X]: -->
- [x] I have read relevant guidelines/documentation to this PR found on [our devwiki](https://monolith-station.github.io/mono-docs/).
- [x] I have added media to this PR or it does not require an ingame showcase.
- [x] I can confirm this PR contains either no AI-generated content, or AI-generated content that meets our guidelines.
<!-- You should understand that not following the above may get your PR closed at maintainer’s discretion -->
<!-- When using AI, make sure you are already proficient in creating whatever content you are attempting to generate and that you already have experience contributing to SS14. This means using AI to enhance your preexisting workflow, not vibecoding. -->

**Changelog**
:cl:
- fix: Fixed the HZD Squire and HZD Stiletto not having a do-after for toggling their attachments.
- tweak: Made the Stiletto have a 1.5 second do-after, from 0.5 seconds.
- tweak: The HZD Squire has less angle decay while the stock is folded, make it slightly harder to control unfolded.
