### PR TITLE
Persistent Storage Stuff

### DIFF
--- a/Content.Server/_Triad/Shipyard/ShipyardGridSaveSystem.cs
+++ b/Content.Server/_Triad/Shipyard/ShipyardGridSaveSystem.cs
@@ -49,21 +49,21 @@ namespace Content.Server._Triad.Shipyard;
 /// Saves ships as complete YAML files similar to savegrid command,
 /// after cleaning them of problematic components and moving to exports folder.
 /// </summary>
-public sealed class ShipyardGridSaveSystem : EntitySystem
+public sealed partial class ShipyardGridSaveSystem : EntitySystem
 {
-    [Dependency] private readonly IEntityManager _entityManager = default!;
-    [Dependency] private readonly IEntitySystemManager _entitySystemManager = default!;
-    [Dependency] private readonly PricingSystem _pricing = default!; // Triad
-    [Dependency] private readonly IConfigurationManager _configManager = default!; // Triad
-    [Dependency] private readonly SharedContainerSystem _containerSystem = default!;
-    [Dependency] private readonly EntityLookupSystem _lookup = default!;
-    [Dependency] private readonly SharedDeviceLinkSystem _deviceLink = default!;
-    [Dependency] private readonly IPrototypeManager _prototypeManager = default!; // HardLight
-    [Dependency] private readonly SharedTransformSystem _transform = default!; // Triad
-    [Dependency] private readonly StationSystem _station = default!; // Triad
-    [Dependency] private readonly ShuttleRecordsSystem _shuttleRecords = default!; // Triad
-    [Dependency] private readonly TriadTamperPolicyService _tamperPolicy = default!; // Triad: tamper protection
-    [Dependency] private readonly GameTicker _gameTicker = default!; // Triad: stamp audit rows with the round id
+    [Dependency] private IEntityManager _entityManager = default!;
+    [Dependency] private IEntitySystemManager _entitySystemManager = default!;
+    [Dependency] private PricingSystem _pricing = default!; // Triad
+    [Dependency] private IConfigurationManager _configManager = default!; // Triad
+    [Dependency] private SharedContainerSystem _containerSystem = default!;
+    [Dependency] private EntityLookupSystem _lookup = default!;
+    [Dependency] private SharedDeviceLinkSystem _deviceLink = default!;
+    [Dependency] private IPrototypeManager _prototypeManager = default!; // HardLight
+    [Dependency] private SharedTransformSystem _transform = default!; // Triad
+    [Dependency] private StationSystem _station = default!; // Triad
+    [Dependency] private ShuttleRecordsSystem _shuttleRecords = default!; // Triad
+    [Dependency] private TriadTamperPolicyService _tamperPolicy = default!; // Triad: tamper protection
+    [Dependency] private GameTicker _gameTicker = default!; // Triad: stamp audit rows with the round id
 
     public List<ShipSaveLimitsPrototype> ShipSaveEntityLimits { get; private set; } = new();
 
@@ -124,7 +124,7 @@ public sealed class ShipyardGridSaveSystem : EntitySystem
             // Also remove any other shuttle deeds that reference this shuttle
             RemoveAllShuttleDeeds(grid);
 
-            // Destroy the station on the shuttle
+            // Destroy the station entity hooked to the shuttle
             if (_station.GetOwningStation(grid) is { Valid: true } shuttleStationUid)
                 _station.DeleteStation(shuttleStationUid);
 
@@ -269,10 +269,7 @@ public sealed class ShipyardGridSaveSystem : EntitySystem
     public bool TrySaveGridAsShip(EntityUid gridUid, string shipName, string playerUserId, ICommonSession playerSession)
     {
         if (!_gridQuery.HasComp(gridUid))
-        {
-            //_sawmill.Error($"Entity {gridUid} is not a valid grid");
             return false;
-        }
 
         try
         {
@@ -567,7 +564,7 @@ public sealed class ShipyardGridSaveSystem : EntitySystem
             if (!Exists(owner))
                 return false;
             // Also treat persistent entities as a preservation root.
-            if (_persistOnSaveQuery.HasComp(owner))
+            if (_persistOnSaveQuery.TryComp(owner, out var persist) && persist.SaveContents)
                 return true; // Found stash root above.
             if (HasComp<MachineComponent>(owner))
                 return true; // This is so machines keep their upgraded parts.

--- a/Content.Shared/_HL/Shipyard/HLPersistOnShipSaveComponent.cs
+++ b/Content.Shared/_HL/Shipyard/HLPersistOnShipSaveComponent.cs
@@ -5,5 +5,12 @@ namespace Content.Shared._HL.Shipyard;
 /// <summary>
 /// Entities with this component will persist themselves and their contents when the ship is saved.
 /// </summary>
-[RegisterComponent, NetworkedComponent]
-public sealed partial class HLPersistOnShipSaveComponent : Component;
+[RegisterComponent, NetworkedComponent, AutoGenerateComponentState]
+public sealed partial class HLPersistOnShipSaveComponent : Component
+{
+    /// <summary>
+    ///      Whether or not this entity will also persist its contents on ship save.
+    /// </summary>
+    [DataField, AutoNetworkedField]
+    public bool SaveContents = false;
+}

--- a/Content.Shared/_Triad/Shipyard/Save/PersistOnShipSaveSystem.cs
+++ b/Content.Shared/_Triad/Shipyard/Save/PersistOnShipSaveSystem.cs
@@ -18,7 +18,7 @@ public sealed class PersistOnShipSaveSystem : EntitySystem
         if (!args.IsInDetailsRange)
             return;
 
-        var examineText = HasComp<StorageComponent>(ent.Owner)
+        var examineText = ent.Comp.SaveContents
             ? "persistonshipsave-component-examine-storage" : "persistonshipsave-component-examine";
 
         args.PushMarkup(Loc.GetString(examineText), ExaminePriority);

--- a/Resources/Prototypes/Entities/Structures/Wallmounts/defib_cabinet.yml
+++ b/Resources/Prototypes/Entities/Structures/Wallmounts/defib_cabinet.yml
@@ -50,6 +50,7 @@
         sound:
           collection: MetalGlassBreak
   - type: HLPersistOnShipSave # Triad
+    saveContents: true
 
 - type: entity
   parent: DefibrillatorCabinet

--- a/Resources/Prototypes/Entities/Structures/Wallmounts/extinguisher_cabinet.yml
+++ b/Resources/Prototypes/Entities/Structures/Wallmounts/extinguisher_cabinet.yml
@@ -55,6 +55,7 @@
                 params:
                   volume: -4
     - type: HLPersistOnShipSave # Triad
+      saveContents: true
 
 - type: entity
   parent: ExtinguisherCabinet

--- a/Resources/Prototypes/Entities/Structures/Wallmounts/fireaxe_cabinet.yml
+++ b/Resources/Prototypes/Entities/Structures/Wallmounts/fireaxe_cabinet.yml
@@ -53,6 +53,8 @@
           - FireAxe
   - type: Lock
   - type: AccessReader
+  - type: HLPersistOnShipSave # Triad
+    saveContents: true
 #    access: [["Atmospherics"], ["Command"]]
 
 - type: entity

--- a/Resources/Prototypes/_NF/Entities/Structures/Wallmounts/fireaxe_cabinet.yml
+++ b/Resources/Prototypes/_NF/Entities/Structures/Wallmounts/fireaxe_cabinet.yml
@@ -4,6 +4,8 @@
   name: fire axe cabinet
   suffix: With Lock
   description: There is a small label that reads "For Emergency use only" along with details for safe use of the axe. As if.
+  placement:
+    mode: SnapgridCenter
   components:
   - type: MeleeSound
     soundGroups:
@@ -34,8 +36,8 @@
         whitelist:
           tags:
           - FireAxe
-  placement:
-    mode: SnapgridCenter
+  - type: HLPersistOnShipSave # Triad
+    saveContents: true
 
 - type: entity
   id: FireAxeCabinetOpenCommand

--- a/Resources/Prototypes/_Triad/Entities/Structures/Storage/ShipPersistent/ship_stash.yml
+++ b/Resources/Prototypes/_Triad/Entities/Structures/Storage/ShipPersistent/ship_stash.yml
@@ -1,11 +1,10 @@
 - type: entity
-  parent: BaseStorageStructure
-  id: BasePersistentShipStorageStash
+  id: BasePersistentStorage
   abstract: true
   components:
-  - type: Sprite
-    noRot: true
   - type: HLPersistOnShipSave
+    saveContents: true
+  - type: Appearance
   - type: Storage
     maxItemSize: Large
     blacklist:
@@ -25,6 +24,15 @@
     shape: square
 
 - type: entity
+  parent: [BaseStorageStructure, BasePersistentStorage]
+  id: BasePersistentShipStorageStash
+  abstract: true
+  components:
+  - type: Sprite
+    noRot: true
+
+- type: entity
+  parent: BasePersistentStorage
   id: BasePersistentShipStorageStashWallmount
   abstract: true
   placement:
@@ -53,11 +61,6 @@
     - type: PlaceableSurface
       placeCentered: true
       isPlaceable: false
-    - type: RadarBlip
-      radarColor: "#e3ffea"
-      scale: 1.5
-      requireNoGrid: true
-      shape: square
 
 - type: entity
   parent: BasePersistentShipStorageStash
@@ -205,9 +208,7 @@
       node: FuelStorageStashNode
     - type: ShipSaveLimit
       limitId: FuelStash
-    - type: Appearance
     - type: EntityStorageVisuals
       stateBaseClosed: fuel
       stateDoorOpen: fuel_open
       stateDoorClosed: fuel_door
-    - type: HLPersistOnShipSave


### PR DESCRIPTION
## About the PR
Fixes a bug with defib and fire extinguisher cabinets not having the correct examine text

Gives ``HLPersistOnShipSaveComponent`` a new ``SaveContents`` variable, in case you want to make entities that save, but their contents DO NOT save

**Changelog**
:cl:
- tweak: Fire axe cabinets now persist their contents on save
