### PR TITLE
Cryoxadone Revertion

### DIFF
--- a/Resources/Prototypes/Reagents/medicine.yml
+++ b/Resources/Prototypes/Reagents/medicine.yml
@@ -204,10 +204,7 @@
             max: 213.0
           damage:
           # todo scale with temp like SS13
-            Airloss: -3
-            Brute: -2
-            Burn: -2
-            Toxin: -2
+            Airloss: -8 # Triad
         - !type:GenericStatusEffect # Mono edit
           conditions:
           - !type:OrganType #

--- a/Resources/Prototypes/Reagents/medicine.yml
+++ b/Resources/Prototypes/Reagents/medicine.yml
@@ -204,7 +204,10 @@
             max: 213.0
           damage:
           # todo scale with temp like SS13
-            Airloss: -8 # Triad, 8 Airloss instead of 10
+            Airloss: -3
+            Brute: -2
+            Burn: -2
+            Toxin: -2
         - !type:GenericStatusEffect # Mono edit
           conditions:
           - !type:OrganType #

--- a/Resources/Prototypes/Reagents/medicine.yml
+++ b/Resources/Prototypes/Reagents/medicine.yml
@@ -204,10 +204,7 @@
             max: 213.0
           damage:
           # todo scale with temp like SS13
-            Airloss: -3
-            Brute: -2
-            Burn: -2
-            Toxin: -2
+            Airloss: -8 # Triad, 8 Airloss instead of 10
         - !type:GenericStatusEffect # Mono edit
           conditions:
           - !type:OrganType #


### PR DESCRIPTION
## About the PR
<!-- What did you change? -->
<!-- If this is a code change, summarize at high level how your new code works. This makes it easier to review. -->
in Mono, Cryoxadene is a one med for all, obsoleting every other type of cryogenic medicines, such as Doxa, Stellox, and etc

This PR removes all non airloss type of healing from cryoxadone, and now it heals -8 Airloss instead
## Why / Balance
<!-- Discuss how this would affect game balance or explain why it was changed. Link any relevant discussions or issues. -->
Cryox should not have been a one med for all, also this was talked about in discord
## Media
<!-- Attach media if the PR makes ingame changes (clothing, items, features, etc). 
Small fixes/refactors are exempt. Media may be used in SS14 progress reports with credit. -->

## Requirements
<!-- Confirm the following by placing an X in the brackets [X]: -->
- [x] I have read relevant guidelines/documentation to this PR found on [our devwiki](https://monolith-station.github.io/mono-docs/).
- [x] I have added media to this PR or it does not require an ingame showcase.
- [x] I can confirm this PR contains either no AI-generated content, or AI-generated content that meets our guidelines.
<!-- You should understand that not following the above may get your PR closed at maintainer’s discretion -->
<!-- When using AI, make sure you are already proficient in creating whatever content you are attempting to generate and that you already have experience contributing to SS14. This means using AI to enhance your preexisting workflow, not vibecoding. -->

## How to test
<!-- Describe the way it can be tested -->
Check Reagent Guidebook of Cryoaxdone
Test out Cryox in a tube, with burn/brute/poison and airloss, should only reduce the airloss now
## Breaking changes
<!-- List any breaking changes, including namespaces, public class/method/field changes, prototype renames; and provide instructions for fixing them. -->
should be none
**Changelog**
<!-- Add a Changelog entry to make players aware of new features or changes that could affect gameplay.
Make sure to read the guidelines and take this Changelog template out of the comment block in order for it to show up.
Changelog must have a :cl: symbol, so the bot recognizes the changes and adds them to the game's changelog.
Remove this symbol for non-player facing PRs.-->
🆑 
- tweak: Cryoxadone has been reverted to Airloss only Cryogenic medicine
