### PR TITLE
Cherrypick: Fixes Trap Avoider Giving Immunity to Lava and Chasms (#4218)

### DIFF
--- a/Content.Shared/_Mono/Traits/Physical/TrapAvoiderSystem.cs
+++ b/Content.Shared/_Mono/Traits/Physical/TrapAvoiderSystem.cs
@@ -1,13 +1,19 @@
 using Content.Shared.StepTrigger.Components;
 using Content.Shared.StepTrigger.Systems;
+using Content.Shared.Tag;
+using Robust.Shared.Prototypes;
 
 namespace Content.Shared._Mono.Traits.Physical;
 
 /// <summary>
-/// Cancels step triggers for entities that have TrapAvoiderComponent.
+/// Cancels step triggers for entities that have TrapAvoiderComponent, unless the owner of the trigger has the UnavoidableTrap tag.
 /// </summary>
 public sealed class TrapAvoiderSystem : EntitySystem
 {
+    [Dependency] private TagSystem _tag = default!;
+
+    private static readonly ProtoId<TagPrototype> UnavoidableTag = "UnavoidableTrap";
+
     public override void Initialize()
     {
         SubscribeLocalEvent<StepTriggerComponent, StepTriggerAttemptEvent>(OnStepTriggerAttempt);
@@ -15,7 +21,7 @@ public sealed class TrapAvoiderSystem : EntitySystem
 
     private void OnStepTriggerAttempt(Entity<StepTriggerComponent> ent, ref StepTriggerAttemptEvent args)
     {
-        if (HasComp<TrapAvoiderComponent>(args.Tripper))
+        if (!_tag.HasTag(ent.Owner, UnavoidableTag) && HasComp<TrapAvoiderComponent>(args.Tripper))
             args.Cancelled = true;
     }
 }

--- a/Resources/Prototypes/Entities/Tiles/chasm.yml
+++ b/Resources/Prototypes/Entities/Tiles/chasm.yml
@@ -45,6 +45,7 @@
   - type: Tag
     tags:
     - HideContextMenu
+    - UnavoidableTrap # Mono - TrapAvoider shouldn't make you immune to this.
 
 - type: entity
   parent: FloorChasmEntity

--- a/Resources/Prototypes/Entities/Tiles/lava.yml
+++ b/Resources/Prototypes/Entities/Tiles/lava.yml
@@ -54,3 +54,4 @@
   - type: Tag
     tags:
       - HideContextMenu
+      - UnavoidableTrap # Mono - TrapAvoider shouldn't make you immune to this.

--- a/Resources/Prototypes/Entities/Tiles/liquid_plasma.yml
+++ b/Resources/Prototypes/Entities/Tiles/liquid_plasma.yml
@@ -54,3 +54,4 @@
   - type: Tag
     tags:
     - HideContextMenu
+    - UnavoidableTrap # Mono - TrapAvoider shouldn't make you immune to this.

--- a/Resources/Prototypes/_Mono/tags.yml
+++ b/Resources/Prototypes/_Mono/tags.yml
@@ -46,6 +46,9 @@
 - type: Tag # Prevents a crash and makes future cherry-picks hurt less but not actually implemented
   id: TurretCompatibleWeapon # Used in the construction of sentry turrets
 
+- type: Tag
+  id: UnavoidableTrap # For "traps" (step triggers) that TrapAvoider shouldn't dodge, like lava or chasms.
+
 # Crafting for desert planet
 
 - type: Tag


### PR DESCRIPTION
## About the PR
Cherrypicks my PR at https://github.com/Monolith-Station/Monolith/pull/4218
Everything else in this PR will be copied from the original

This PR fixes `TrapAvoiderComponent` giving immunity to lava and chasms by adding a new tag named `UnavoidableTrap`, as well as adding said new tag to lava/chasms/liquid plasma pools

I'm learning C#, so please do tell me if I could have done anything better

## Why / Balance
It'd have to be, like... some ridiculous anime level of skill to be so fast on your feet you can walk on lava or over air. Bugfix

## Media
### Pre-fix
<img width="270" height="283" alt="image" src="https://github.com/user-attachments/assets/a81e93c2-d646-4ef4-a4c3-d6f7ae3ba105" />

---

<img width="277" height="249" alt="image" src="https://github.com/user-attachments/assets/cab07efc-05ed-49c9-aea3-a4c8bb8974ec" />
<img width="283" height="207" alt="image" src="https://github.com/user-attachments/assets/1f642162-0edb-4046-acd1-084a53fe2be0" />
<img width="180" height="207" alt="image" src="https://github.com/user-attachments/assets/4f4e4074-94d5-4f5a-b2d0-0fdbec0113eb" />


New screenshots taken for the cherrypick, showing the results of the testing instructions:
<img width="367" height="185" alt="image" src="https://github.com/user-attachments/assets/6f624375-8905-4c36-af11-356824dea7ab" />
<img width="367" height="185" alt="image" src="https://github.com/user-attachments/assets/8eadf4a7-adcd-4890-b19d-31c609f2c3f7" />


## Requirements
<!-- Confirm the following by placing an X in the brackets [X]: -->
- [X] I have read relevant guidelines/documentation to this PR found on [our devwiki](https://monolith-station.github.io/mono-docs/).
- [X] I have added media to this PR or it does not require an ingame showcase.
- [X] I can confirm this PR contains either no AI-generated content, or AI-generated content that meets our guidelines.
<!-- You should understand that not following the above may get your PR closed at maintainer’s discretion -->
<!-- When using AI, make sure you are already proficient in creating whatever content you are attempting to generate and that you already have experience contributing to SS14. This means using AI to enhance your preexisting workflow, not vibecoding. -->

## How to test
1. Give yourself TrapAvoiderComponent
2. Spawn in lava, liquid plasma, any explosive mine, and a chasm
3. Step into the lava. Be set on fire
4. `rejuvenate`. Step into the liquid plasma. Be set on fire
5. `rejuvenate`. Step onto the mine. It does not go off
6. Step into the chasm. Fall to your death
7. Move onto the mine without TrapAvoider. It still explodes

**Changelog**
:cl: 
Monolith:
- fix: Trap Avoider no longer allows walking on lava or over chasms.