### PR TITLE
Cherrypick: Added the Pride Cloaks to the Pride-O-Mat's Inventory. (#4567)

### DIFF
--- a/Resources/Prototypes/Catalog/VendingMachines/Inventories/pride.yml
+++ b/Resources/Prototypes/Catalog/VendingMachines/Inventories/pride.yml
@@ -16,6 +16,16 @@
     ClothingNeckTransPin: 3
     ClothingNeckAutismPin: 3
     ClothingNeckGoldAutismPin: 3
+    ClothingNeckCloakTrans: 2 # Frontier
+    ClothingNeckCloakAro: 2 # Frontier
+    ClothingNeckCloakAce: 2 # Frontier
+    ClothingNeckCloakAroace: 2 # Frontier
+    ClothingNeckCloakBi: 2 # Frontier
+    ClothingNeckCloakIntersex: 2 # Frontier
+    ClothingNeckCloakEnby: 2 # Frontier
+    ClothingNeckCloakPan: 2 # Frontier
+    ClothingNeckCloakGay: 2 # Frontier
+    ClothingNeckCloakLesbian: 2 # Frontier
     PlushieSharkBlue: 2
     PlushieSharkPink: 2
     PlushieSharkGrey: 2

--- a/Resources/Prototypes/Catalog/VendingMachines/Inventories/pride.yml
+++ b/Resources/Prototypes/Catalog/VendingMachines/Inventories/pride.yml
@@ -19,7 +19,7 @@
     ClothingNeckCloakTrans: 2 # Frontier
     ClothingNeckCloakAro: 2 # Frontier
     ClothingNeckCloakAce: 2 # Frontier
-    ClothingNeckCloakAroace: 2 # Frontier
+    # ClothingNeckCloakAroace: 2 # Triad - TODO
     ClothingNeckCloakBi: 2 # Frontier
     ClothingNeckCloakIntersex: 2 # Frontier
     ClothingNeckCloakEnby: 2 # Frontier


### PR DESCRIPTION
## About the PR
Cherrypicks https://github.com/new-frontiers-14/frontier-station-14/pull/4567 from Frontier, which adds pride cloaks to the Pride-O-Mat

## Why / Balance
<img width="900" height="900" alt="image" src="https://github.com/user-attachments/assets/5fb9886f-ad06-43b9-bd05-c924b7349f7b" />

## Media
<img width="388" height="651" alt="image" src="https://github.com/user-attachments/assets/11412e03-4131-4a85-9483-8fea92dc7475" />

## Requirements
<!-- Confirm the following by placing an X in the brackets [X]: -->
- [X] I have read relevant guidelines/documentation to this PR found on [our devwiki](https://monolith-station.github.io/mono-docs/).
- [X] I have added media to this PR or it does not require an ingame showcase.
- [X] I can confirm this PR contains either no AI-generated content, or AI-generated content that meets our guidelines.
<!-- You should understand that not following the above may get your PR closed at maintainer’s discretion -->
<!-- When using AI, make sure you are already proficient in creating whatever content you are attempting to generate and that you already have experience contributing to SS14. This means using AI to enhance your preexisting workflow, not vibecoding. -->

## How to test
1. Spawn a Pride-O-Mat
2. Look inside

**Changelog**
I perhaps got too silly with the changelog. Feel free to edit to something more serious

:cl: Frontier
- add: Added the loadout Pride cloaks to the Pride-o-Mat's inventory. Happy Pride, Frontier—wait, this isn't Frontier and it isn't Pride Month now...
