### PR TITLE
Remove Catwalk Tile Restrictions

### DIFF
--- a/Resources/Prototypes/RCD/rcd.yml
+++ b/Resources/Prototypes/RCD/rcd.yml
@@ -69,7 +69,7 @@
   delay: 1
   collisionMask: InteractImpassable
   rules:
-    - MustBuildOnSubfloor
+    #- MustBuildOnSubfloor # Triad removal - Allow building catwalks regardless of tile type.
     - IsCatwalk
   rotation: Fixed
   fx: EffectRCDConstruct1

--- a/Resources/Prototypes/Recipes/Construction/structures.yml
+++ b/Resources/Prototypes/Recipes/Construction/structures.yml
@@ -885,10 +885,12 @@
   conditions:
     - !type:TileNotBlocked
       failIfSpace: false
-    - !type:TileType
-      targets:
-        - Lattice
-        - Plating
+    # Triad removal - Allow building catwalks regardless of tile type.
+    #- !type:TileType
+    #  targets:
+    #    - Lattice
+    #    - Plating
+    # End Triad
   icon:
     sprite: Structures/catwalk.rsi
     state: catwalk_preview

--- a/Resources/Prototypes/_Mono/Entities/Structures/catwalk.yml
+++ b/Resources/Prototypes/_Mono/Entities/Structures/catwalk.yml
@@ -122,10 +122,12 @@
   conditions:
   - !type:TileNotBlocked
     failIfSpace: false
-  - !type:TileType
-    targets:
-    - Lattice
-    - Plating
+  # Triad removal - Allow building catwalks regardless of tile type.
+  #- !type:TileType
+  #  targets:
+  #  - Lattice
+  #  - Plating
+  # End Triad
   icon:
     sprite: _Mono/Structures/steel_catwalk.rsi
     state: catwalk_preview
@@ -170,10 +172,12 @@
   conditions:
   - !type:TileNotBlocked
     failIfSpace: false
-  - !type:TileType
-    targets:
-    - Lattice
-    - Plating
+  # Triad removal - Allow building catwalks regardless of tile type.
+  #- !type:TileType
+  #  targets:
+  #  - Lattice
+  #  - Plating
+  # End Triad
   icon:
     sprite: _Mono/Structures/dark_steel_catwalk.rsi
     state: catwalk_preview
@@ -218,10 +222,12 @@
   conditions:
   - !type:TileNotBlocked
     failIfSpace: false
-  - !type:TileType
-    targets:
-    - Lattice
-    - Plating
+  # Triad removal - Allow building catwalks regardless of tile type.
+  #- !type:TileType
+  #  targets:
+  #  - Lattice
+  #  - Plating
+  # End Triad
   icon:
     sprite: _Mono/Structures/white_steel_catwalk.rsi
     state: catwalk_preview


### PR DESCRIPTION
## About the PR
This PR comments out every instance of `TileType` on catwalk entities. This is for the purpose of expanding building options. This also allows the RCD to build catwalks on any tile for parity
- This incidentally allows them all to be built over lava, liquid plasma, or chasms. This allows safe travel over them, as is intended

## Why / Balance
There are balance implications, but none that are very new or I deem very worth considering

Catwalks prevent people from stepping on chasms/lava, but they already behaved like that. All this PR is make that functionality possible to see. If someone wants to carry rods for lava, I think that would be cool
Catwalks can be built on lava on Frontier (see https://github.com/new-frontiers-14/frontier-station-14/blob/master/Resources/Prototypes/Recipes/Construction/structures.yml#L666)

Other than balance, I don't see any reason removing catwalk tile restrictions entirely would go wrong!

## Media
<img width="678" height="397" alt="image" src="https://github.com/user-attachments/assets/9c1e75ef-aad3-4161-97b9-1dec8cf5b3be" />

<img width="325" height="243" alt="image" src="https://github.com/user-attachments/assets/c78015f7-de50-4181-b1fa-e51a2400c649" />

Catwalks seem to be weird visually under certain conditions apparently? Weird graphics even on plating, which was explicitly allowed before. Probably unrelated
<img width="237" height="829" alt="image" src="https://github.com/user-attachments/assets/e38798ef-c534-4621-aa73-2a33362706af" />

## Requirements
<!-- Confirm the following by placing an X in the brackets [X]: -->
- [X] I have read relevant guidelines/documentation to this PR found on [our devwiki](https://monolith-station.github.io/mono-docs/).
- [X] I have added media to this PR or it does not require an ingame showcase.
- [X] I can confirm this PR contains either no AI-generated content, or AI-generated content that meets our guidelines.
<!-- You should understand that not following the above may get your PR closed at maintainer’s discretion -->
<!-- When using AI, make sure you are already proficient in creating whatever content you are attempting to generate and that you already have experience contributing to SS14. This means using AI to enhance your preexisting workflow, not vibecoding. -->

## How to test
1. Spawn in lava, liquid plasma, and a chasm. Build catwalks (any kind) over them. Walk on them. You won't be burned/fall because catwalks are supposed to prevent that
2. Cut the catwalk out from under your feet. You start burning/falling. Lol lmao
3. Use an RCD to make catwalks. There are no restrictions, and it should place similarly to building
4. Build catwalks... anywhere. Like... it won't stop you. Probably look good too

**Changelog**
I opted not to mention the RCD thing because it working is expected behavior. It would not benefit this changelog to add it

:cl: Minerva
- tweak: Catwalks now have no tile type restrictions on placement, meaning builders now have another thing to play around with for decor.
- tweak: As a consequence of removing tile restrictions: catwalks can also now be used for their intended purpose of safely crossing lava, liquid plasma, or chasms.