### PR TITLE
Let Avalis Be Drunk Again

### DIFF
--- a/Resources/Prototypes/_StarLight/Body/Organs/avali.yml
+++ b/Resources/Prototypes/_StarLight/Body/Organs/avali.yml
@@ -54,6 +54,7 @@
     metabolizerTypes: [Avali]
     groups:
     - id: Alcohol
+    rateModifier: 0.1 # Triad removes alcohol very slowly
   - type: Sprite
     sprite: _Starlight/Mobs/Species/Avali/organs.rsi
     state: liver

--- a/Resources/Prototypes/_StarLight/Body/Organs/avali.yml
+++ b/Resources/Prototypes/_StarLight/Body/Organs/avali.yml
@@ -54,7 +54,7 @@
     metabolizerTypes: [Avali]
     groups:
     - id: Alcohol
-    rateModifier: 0.1 # Triad removes alcohol very slowly
+      rateModifier: 0.1 # Triad removes alcohol very slowly
   - type: Sprite
     sprite: _Starlight/Mobs/Species/Avali/organs.rsi
     state: liver


### PR DESCRIPTION
## About the PR
<!-- What did you change? -->
<!-- If this is a code change, summarize at high level how your new code works. This makes it easier to review. -->
somehow the avali organs in the _Mono Folder, this PR moves it correctly to the _Starlight folder and also adds back rate metabolizer so it is processed slower, allowing our fellow trillers to be drunk
## Why / Balance
<!-- Discuss how this would affect game balance or explain why it was changed. Link any relevant discussions or issues. -->
a bug report in discord, also actually allowing them to be drunk, previously they have no metabolize rate, therefore defaulting to 1u/second

also for some reason the organ is in _Mono folder, a minor folder placement cleanup
## Media
<!-- Attach media if the PR makes ingame changes (clothing, items, features, etc). 
Small fixes/refactors are exempt. Media may be used in SS14 progress reports with credit. -->
i havent tested it
## Requirements
<!-- Confirm the following by placing an X in the brackets [X]: -->
- [x] I have read relevant guidelines/documentation to this PR found on [our devwiki](https://monolith-station.github.io/mono-docs/).
- [x] I have added media to this PR or it does not require an ingame showcase.
- [x] I can confirm this PR contains either no AI-generated content, or AI-generated content that meets our guidelines.
<!-- You should understand that not following the above may get your PR closed at maintainer’s discretion -->
<!-- When using AI, make sure you are already proficient in creating whatever content you are attempting to generate and that you already have experience contributing to SS14. This means using AI to enhance your preexisting workflow, not vibecoding. -->

## How to test
<!-- Describe the way it can be tested -->
chug a whole jug of any alcoholic drink, or straight up alcohol as an avali
should now be blurry as if drunk 
## Breaking changes
<!-- List any breaking changes, including namespaces, public class/method/field changes, prototype renames; and provide instructions for fixing them. -->
to be tested
**Changelog**
<!-- Add a Changelog entry to make players aware of new features or changes that could affect gameplay.
Make sure to read the guidelines and take this Changelog template out of the comment block in order for it to show up.
Changelog must have a :cl: symbol, so the bot recognizes the changes and adds them to the game's changelog.
Remove this symbol for non-player facing PRs.-->
🆑 
- fix: Fixed Avalis unable to be drunk, now they can, bottoms up 🍻