### PR TITLE
Add RCD Options for Diagonal Lattice Tiles

### DIFF
--- a/Resources/Locale/en-US/rcd/components/rcd-component.ftl
+++ b/Resources/Locale/en-US/rcd/components/rcd-component.ftl
@@ -62,3 +62,11 @@ rcd-component-plating-halftilt-lower = half-tilt hull plating (lower, axis famil
 rcd-component-plating-halftilt-lower-alt = half-tilt hull plating (lower, offset family)
 rcd-component-plating-halftilt-upper = half-tilt hull plating (upper, axis family)
 rcd-component-plating-halftilt-upper-alt = half-tilt hull plating (upper, offset family)
+
+rcd-component-lattice-diagonal = diagonal lattice
+rcd-component-lattice-half = center-strip half lattice
+rcd-component-lattice-wedge = wedge lattice
+rcd-component-lattice-halftilt-lower = half-tilt lattice (lower, axis family)
+rcd-component-lattice-halftilt-lower-alt = half-tilt lattice (lower, offset family)
+rcd-component-lattice-halftilt-upper = half-tilt lattice (upper, axis family)
+rcd-component-lattice-halftilt-upper-alt = half-tilt lattice (upper, offset family)

--- a/Resources/Prototypes/Entities/Objects/Tools/tools.yml
+++ b/Resources/Prototypes/Entities/Objects/Tools/tools.yml
@@ -392,6 +392,13 @@
     - PlatingHalfTiltLowerAlt
     - PlatingHalfTiltUpper
     - PlatingHalfTiltUpperAlt
+    - LatticeDiagonal
+    - LatticeHalf
+    - LatticeWedge
+    - LatticeHalfTiltLower
+    - LatticeHalfTiltLowerAlt
+    - LatticeHalfTiltUpper
+    - LatticeHalfTiltUpperAlt
     - WindowDirectionalShuttle
     - WindowShuttle
     - WallShuttleDiagonal

--- a/Resources/Prototypes/_Mono/RCD/rcd.yml
+++ b/Resources/Prototypes/_Mono/RCD/rcd.yml
@@ -285,3 +285,150 @@
     - CanBuildOnEmptyTile
   fx: EffectRCDConstruct1
 
+# Diagonal lattice — one mode, rotate like other RCD objects
+- type: rcd
+  id: LatticeDiagonal
+  name: rcd-component-lattice-diagonal
+  category: WallsAndFlooring
+  sprite: /Textures/_Mono/Tiles/lattice/ne.png
+  mode: ConstructTile
+  prototype: LatticeCornerNE
+  rotation: User
+  constructTileByDirection:
+    North: LatticeCornerNE
+    East: LatticeCornerSE
+    South: LatticeCornerSW
+    West: LatticeCornerNW
+  cost: 1
+  delay: 1
+  collisionMask: InteractImpassable
+  rules:
+    - CanBuildOnEmptyTile
+  fx: EffectRCDConstruct1
+
+# Center-strip half lattice — N/S vertical strip, E/W horizontal (rotate like diagonal hull)
+- type: rcd
+  id: LatticeHalf
+  name: rcd-component-lattice-half
+  category: WallsAndFlooring
+  sprite: /Textures/_Mono/Tiles/lattice/script/half_v.png
+  mode: ConstructTile
+  prototype: LatticeHalfV
+  rotation: User
+  constructTileByDirection:
+    North: LatticeHalfV
+    East: LatticeHalfH
+    South: LatticeHalfV
+    West: LatticeHalfH
+  cost: 1
+  delay: 1
+  collisionMask: InteractImpassable
+  rules:
+    - CanBuildOnEmptyTile
+  fx: EffectRCDConstruct1
+
+# Wedge corners — rotate to pick N/E/S/W wedge tile
+- type: rcd
+  id: LatticeWedge
+  name: rcd-component-lattice-wedge
+  category: WallsAndFlooring
+  sprite: /Textures/_Mono/Tiles/lattice/script/wedge_n.png
+  mode: ConstructTile
+  prototype: LatticeWedgeN
+  rotation: User
+  constructTileByDirection:
+    North: LatticeWedgeN
+    East: LatticeWedgeE
+    South: LatticeWedgeS
+    West: LatticeWedgeW
+  cost: 1
+  delay: 1
+  collisionMask: InteractImpassable
+  rules:
+    - CanBuildOnEmptyTile
+  fx: EffectRCDConstruct1
+
+# Half-tilt lower (axis-aligned family) — NES / SEW / SWN / NWE cycle by rotation
+- type: rcd
+  id: LatticeHalfTiltLower
+  name: rcd-component-lattice-halftilt-lower
+  category: WallsAndFlooring
+  sprite: /Textures/_Mono/Tiles/lattice/script/halftilt_ne_s_l.png
+  mode: ConstructTile
+  prototype: LatticeHalfTiltNESLower
+  rotation: User
+  constructTileByDirection:
+    North: LatticeHalfTiltNESLower
+    East: LatticeHalfTiltSEWLower
+    South: LatticeHalfTiltSWNLower
+    West: LatticeHalfTiltNWELower
+  cost: 1
+  delay: 1
+  collisionMask: InteractImpassable
+  rules:
+    - CanBuildOnEmptyTile
+  fx: EffectRCDConstruct1
+
+# Half-tilt lower (diagonal-offset family) — NE-W / SE-N / SW-E / NW-S cycle by rotation
+- type: rcd
+  id: LatticeHalfTiltLowerAlt
+  name: rcd-component-lattice-halftilt-lower-alt
+  category: WallsAndFlooring
+  sprite: /Textures/_Mono/Tiles/lattice/script/halftilt_ne_w_l.png
+  mode: ConstructTile
+  prototype: LatticeHalfTiltNEWLower
+  rotation: User
+  constructTileByDirection:
+    North: LatticeHalfTiltNEWLower
+    East: LatticeHalfTiltSENLower
+    South: LatticeHalfTiltSWELower
+    West: LatticeHalfTiltNWSLower
+  cost: 1
+  delay: 1
+  collisionMask: InteractImpassable
+  rules:
+    - CanBuildOnEmptyTile
+  fx: EffectRCDConstruct1
+
+# Half-tilt upper (axis-aligned family)
+- type: rcd
+  id: LatticeHalfTiltUpper
+  name: rcd-component-lattice-halftilt-upper
+  category: WallsAndFlooring
+  sprite: /Textures/_Mono/Tiles/lattice/script/halftilt_ne_s_u.png
+  mode: ConstructTile
+  prototype: LatticeHalfTiltNESUpper
+  rotation: User
+  constructTileByDirection:
+    North: LatticeHalfTiltNESUpper
+    East: LatticeHalfTiltSEWUpper
+    South: LatticeHalfTiltSWNUpper
+    West: LatticeHalfTiltNWEUpper
+  cost: 1
+  delay: 1
+  collisionMask: InteractImpassable
+  rules:
+    - CanBuildOnEmptyTile
+  fx: EffectRCDConstruct1
+
+# Half-tilt upper (diagonal-offset family)
+- type: rcd
+  id: LatticeHalfTiltUpperAlt
+  name: rcd-component-lattice-halftilt-upper-alt
+  category: WallsAndFlooring
+  sprite: /Textures/_Mono/Tiles/lattice/script/halftilt_ne_w_u.png
+  mode: ConstructTile
+  prototype: LatticeHalfTiltNEWUpper
+  rotation: User
+  constructTileByDirection:
+    North: LatticeHalfTiltNEWUpper
+    East: LatticeHalfTiltSENUpper
+    South: LatticeHalfTiltSWEUpper
+    West: LatticeHalfTiltNWSUpper
+  cost: 1
+  delay: 1
+  collisionMask: InteractImpassable
+  rules:
+    - CanBuildOnEmptyTile
+  fx: EffectRCDConstruct1
+


### PR DESCRIPTION
## About the PR
Added more RCD options under "Walls and flooring" category, for diagonal lattice tiles.

## Why / Balance
Diagonal lattice tiles are not craftable, buildable or RCDable. This makes it so they are at least RCDable.

## Media
<img width="767" height="760" alt="image" src="https://github.com/user-attachments/assets/8e340d7e-d17a-4662-95f3-3ffa8a689bc0" />


## Requirements
- [X] I have read relevant guidelines/documentation to this PR found on [our devwiki](https://monolith-station.github.io/mono-docs/).
- [X] I have added media to this PR or it does not require an ingame showcase.
- [X] I can confirm this PR contains either no AI-generated content, or AI-generated content that meets our guidelines.

## How to test
Get an RCD, go to "Walls and flooring" category, pick one of the new diagonal lattice options, rotate them, and put them.

## Breaking changes
N/A

**Changelog**
:cl:
- add: Added new RCD options for diagonal lattice tiles
