### PR TITLE
Makes Medals and Badges Engraveable

### DIFF
--- a/Resources/Prototypes/Entities/Clothing/Neck/medals.yml
+++ b/Resources/Prototypes/Entities/Clothing/Neck/medals.yml
@@ -23,6 +23,7 @@
   - type: Tag
     tags:
       - Medal
+  - type: Engraveable # Triad - Makes medals and badges engraveable.
 
 - type: entity
   parent: ClothingNeckBase
@@ -50,6 +51,7 @@
   - type: Tag
     tags:
       - Medal
+  - type: Engraveable # Triad - Makes medals and badges engraveable.
 
 - type: entity
   parent: ClothingNeckBase
@@ -75,6 +77,7 @@
   - type: Tag
     tags:
       - Medal
+  - type: Engraveable # Triad - Makes medals and badges engraveable.
 
 - type: entity
   parent: ClothingNeckBase
@@ -100,6 +103,7 @@
   - type: Tag
     tags:
       - Medal
+  - type: Engraveable # Triad - Makes medals and badges engraveable.
 
 - type: entity
   parent: ClothingNeckBase
@@ -125,6 +129,7 @@
   - type: Tag
     tags:
       - Medal
+  - type: Engraveable # Triad - Makes medals and badges engraveable.
 
 - type: entity
   parent: ClothingNeckBase
@@ -150,6 +155,7 @@
   - type: Tag
     tags:
       - Medal
+  - type: Engraveable # Triad - Makes medals and badges engraveable.
 
 - type: entity
   parent: ClothingNeckBase
@@ -175,6 +181,7 @@
   - type: Tag
     tags:
       - Medal
+  - type: Engraveable # Triad - Makes medals and badges engraveable.
 
 - type: entity
   parent: ClothingNeckBase
@@ -202,3 +209,4 @@
   - type: Tag
     tags:
       - Medal
+  - type: Engraveable # Triad - Makes medals and badges engraveable.

--- a/Resources/Prototypes/_NF/Entities/Clothing/Neck/badges.yml
+++ b/Resources/Prototypes/_NF/Entities/Clothing/Neck/badges.yml
@@ -12,6 +12,7 @@
     layers: []
   - type: Clothing
     sprite: _NF/Clothing/Neck/Scarfs/nfsd_bronze_badge.rsi
+  - type: Engraveable # Triad - Makes medals and badges engraveable.
 
 - type: entity
   parent: ClothingNeckNfsdBadge
@@ -99,3 +100,4 @@
     sprite: _NF/Clothing/Neck/Misc/palbadge.rsi
   - type: TypingIndicatorClothing
     proto: pal
+  - type: Engraveable # Triad - Makes medals and badges engraveable.

--- a/Resources/Prototypes/_NF/Entities/Clothing/Neck/medals.yml
+++ b/Resources/Prototypes/_NF/Entities/Clothing/Neck/medals.yml
@@ -11,6 +11,7 @@
   - type: Tag
     tags:
       - Medal
+  - type: Engraveable # Triad - Makes medals and badges engraveable.
 
 - type: entity
   parent: ClothingNeckBase
@@ -25,6 +26,7 @@
   - type: Tag
     tags:
       - Medal
+  - type: Engraveable # Triad - Makes medals and badges engraveable.
 
 - type: entity
   parent: ClothingNeckBase
@@ -39,6 +41,7 @@
   - type: Tag
     tags:
       - Medal
+  - type: Engraveable # Triad - Makes medals and badges engraveable.
 
 - type: entity
   parent: ClothingNeckBase
@@ -53,6 +56,7 @@
   - type: Tag
     tags:
       - Medal
+  - type: Engraveable # Triad - Makes medals and badges engraveable.
 
 - type: entity
   parent: ClothingNeckBase
@@ -67,6 +71,7 @@
   - type: Tag
     tags:
       - Medal
+  - type: Engraveable # Triad - Makes medals and badges engraveable.
 
 - type: entity
   parent: ClothingNeckBase
@@ -81,6 +86,7 @@
   - type: Tag
     tags:
       - Medal
+  - type: Engraveable # Triad - Makes medals and badges engraveable.
 
 - type: entity
   parent: ClothingNeckBase
@@ -95,6 +101,7 @@
   - type: Tag
     tags:
       - Medal
+  - type: Engraveable # Triad - Makes medals and badges engraveable.
 
 # just a little joke :)
 - type: entity
@@ -113,3 +120,4 @@
   - type: Construction
     graph: ClothingNeckMedalGloriousOrder
     node: GloriousOrder
+  - type: Engraveable # Triad - Makes medals and badges engraveable.


### PR DESCRIPTION
## About the PR
This PR adds `Engraveable` to all medals and badges I found

## Why / Balance
This lets people actually write down *why* a medal is being given, the recipient, or the shift time and in-character date. Flavor

## Media
<img width="499" height="208" alt="image" src="https://github.com/user-attachments/assets/d701a000-09ae-46b1-b556-d534ca37066a" />


## Requirements
<!-- Confirm the following by placing an X in the brackets [X]: -->
- [X] I have read relevant guidelines/documentation to this PR found on [our devwiki](https://monolith-station.github.io/mono-docs/).
- [X] I have added media to this PR or it does not require an ingame showcase.
- [X] I can confirm this PR contains either no AI-generated content, or AI-generated content that meets our guidelines.
<!-- You should understand that not following the above may get your PR closed at maintainer’s discretion -->
<!-- When using AI, make sure you are already proficient in creating whatever content you are attempting to generate and that you already have experience contributing to SS14. This means using AI to enhance your preexisting workflow, not vibecoding. -->

## How to test
1. Spawn in a medal box
2. Right click all the contents. You can engrave them
3. Spawn in badges. You can engrave them

**Changelog**
:cl: Minerva
- add: You can now engrave medals and badges. For example, you could write down the recipient, in-character date, and reason as an engraving on medals.