### PR TITLE
Fix Directional Windows

### DIFF
--- a/Content.Shared/Construction/EntitySystems/AnchorableSystem.cs
+++ b/Content.Shared/Construction/EntitySystems/AnchorableSystem.cs
@@ -24,15 +24,15 @@ namespace Content.Shared.Construction.EntitySystems;
 
 public sealed partial class AnchorableSystem : EntitySystem
 {
-    [Dependency] private readonly IMapManager _mapManager = default!;
-    [Dependency] private readonly ISharedAdminLogManager _adminLogger = default!;
-    [Dependency] private readonly SharedPopupSystem _popup = default!;
-    [Dependency] private readonly PullingSystem _pulling = default!;
-    [Dependency] private readonly SharedToolSystem _tool = default!;
-    [Dependency] private readonly SharedTransformSystem _transformSystem = default!;
-    [Dependency] private readonly TagSystem _tagSystem = default!;
-    [Dependency] private readonly SharedAppearanceSystem _appearance = default!;
-    [Dependency] private readonly SharedMapSystem _map = default!;
+    [Dependency] private IMapManager _mapManager = default!;
+    [Dependency] private ISharedAdminLogManager _adminLogger = default!;
+    [Dependency] private SharedPopupSystem _popup = default!;
+    [Dependency] private PullingSystem _pulling = default!;
+    [Dependency] private SharedToolSystem _tool = default!;
+    [Dependency] private SharedTransformSystem _transformSystem = default!;
+    [Dependency] private TagSystem _tagSystem = default!;
+    [Dependency] private SharedAppearanceSystem _appearance = default!;
+    [Dependency] private SharedMapSystem _map = default!;
     private EntityQuery<PhysicsComponent> _physicsQuery;
 
     public readonly ProtoId<TagPrototype> Unstackable = "Unstackable";
@@ -297,6 +297,10 @@ public sealed partial class AnchorableSystem : EntitySystem
 
         while (enumerator.MoveNext(out var ent))
         {
+            // Triad - fixes not being able to anchor objects under directional windows
+            if (ent != null && ShouldIgnoreTileFreeCheck(ent.Value))
+                continue;
+
             if (!_physicsQuery.TryGetComponent(ent, out var body) ||
                 !body.CanCollide ||
                 !body.Hard)

--- a/Content.Shared/_Triad/Construction/AnchorableSystem.Triad.cs
+++ b/Content.Shared/_Triad/Construction/AnchorableSystem.Triad.cs
@@ -1,0 +1,11 @@
+using Content.Shared._Triad.Construction;
+
+namespace Content.Shared.Construction.EntitySystems;
+
+public sealed partial class AnchorableSystem : EntitySystem
+{
+    private bool ShouldIgnoreTileFreeCheck(EntityUid entity)
+    {
+        return HasComp<IgnoreAnchorableTileFreeComponent>(entity);
+    }
+}

--- a/Content.Shared/_Triad/Construction/IgnoreAnchorableTileFreeComponent.cs
+++ b/Content.Shared/_Triad/Construction/IgnoreAnchorableTileFreeComponent.cs
@@ -1,0 +1,10 @@
+using Robust.Shared.GameStates;
+
+namespace Content.Shared._Triad.Construction;
+
+/// <summary>
+///     Anchorable entities will not check entities with this component, allowing you to ignore bounding boxes.
+///     Useful for entities that only take up a half-tile, such as directional windows.
+/// </summary>
+[RegisterComponent, NetworkedComponent]
+public sealed partial class IgnoreAnchorableTileFreeComponent : Component;

--- a/Resources/Prototypes/Entities/Structures/Windows/window.yml
+++ b/Resources/Prototypes/Entities/Structures/Windows/window.yml
@@ -225,6 +225,7 @@
   - type: ShipRepairable
     repairTime: 2
     repairCost: 2
+  - type: IgnoreAnchorableTileFree # Triad
 
 - type: entity
   id: WindowDirectionalRCDResistant

--- a/Resources/Prototypes/Recipes/Construction/structures.yml
+++ b/Resources/Prototypes/Recipes/Construction/structures.yml
@@ -608,7 +608,7 @@
   canBuildInImpassable: true
   conditions:
     - !type:EmptyOrWindowValidInTile
-    - !type:NoWindowsInTile
+    #- !type:NoWindowsInTile
   icon:
     sprite: Structures/Windows/directional.rsi
     state: window
@@ -626,7 +626,7 @@
   canBuildInImpassable: true
   conditions:
     - !type:EmptyOrWindowValidInTile
-    - !type:NoWindowsInTile
+    #- !type:NoWindowsInTile
   icon:
     sprite: Structures/Windows/directional.rsi
     state: reinforced_window
@@ -644,7 +644,7 @@
   canBuildInImpassable: true
   conditions:
     - !type:EmptyOrWindowValidInTile
-    - !type:NoWindowsInTile
+    #- !type:NoWindowsInTile
   icon:
     sprite: Structures/Windows/directional.rsi
     state: clock_window
@@ -662,7 +662,7 @@
   description: Clear, with a purple tint.
   conditions:
     - !type:EmptyOrWindowValidInTile
-    - !type:NoWindowsInTile
+    #- !type:NoWindowsInTile
   icon:
     sprite: Structures/Windows/directional.rsi
     state: plasma_window
@@ -680,7 +680,7 @@
   description: Clear and even tougher, with a purple tint.
   conditions:
     - !type:EmptyOrWindowValidInTile
-    - !type:NoWindowsInTile
+    #- !type:NoWindowsInTile
   icon:
     sprite: Structures/Windows/directional.rsi
     state: plasma_reinforced_window


### PR DESCRIPTION
## About the PR
Fixes an annoying bug that prevented people from anchoring things under directional windows
They don't cover the whole tile, so things should be anchorable

https://github.com/user-attachments/assets/47cceb04-0c12-4545-8d58-569b4a4b071a

## Technical details
Added ``IgnoreAnchorableTileFreeComponent``, which just ignores the free tile check on certain entities. This component is given to directional windows.

TODO: fix directional window squares not being buildable



**Changelog**
:cl:
- fix: Fixed pipes and other machines not being anchorable under directional windows.
