### PR TITLE
Venmar Station and Biome Fixes

### DIFF
--- a/Resources/Maps/_Triad/Outpost/venmar_station.yml
+++ b/Resources/Maps/_Triad/Outpost/venmar_station.yml
@@ -4,8 +4,8 @@ meta:
   engineVersion: 277.2.1
   forkId: ""
   forkVersion: ""
-  time: 07/09/2026 00:13:06
-  entityCount: 14185
+  time: 07/09/2026 15:42:56
+  entityCount: 14209
 maps:
 - 1
 grids:
@@ -408,9 +408,9 @@ entities:
     - type: ThermalSignature
     - type: SpreaderGrid
       spreadQueues:
+        Smoke: []
         Kudzu: []
         MetalFoam: []
-        Smoke: []
         Puddle: []
     - type: Shuttle
       dampingModifier: 0.25
@@ -25206,6 +25206,62 @@ entities:
     - type: Transform
       pos: -57.5,-2.5
       parent: 2
+- proto: BiomeSourceFallback
+  entities:
+  - uid: 5517
+    components:
+    - type: Transform
+      pos: -7.394554,10.682073
+      parent: 2
+- proto: BiomeSourceFarReachesI
+  entities:
+  - uid: 14186
+    components:
+    - type: Transform
+      pos: -6.436221,10.606885
+      parent: 2
+- proto: BiomeSourceFarReachesII
+  entities:
+  - uid: 14187
+    components:
+    - type: Transform
+      pos: -5.373721,10.565218
+      parent: 2
+- proto: BiomeSourceFarReachesIII
+  entities:
+  - uid: 14188
+    components:
+    - type: Transform
+      pos: -4.540387,10.481885
+      parent: 2
+- proto: BiomeSourceFarReachesIV
+  entities:
+  - uid: 14189
+    components:
+    - type: Transform
+      pos: -7.519554,9.461052
+      parent: 2
+- proto: BiomeSourceInnerRing
+  entities:
+  - uid: 14190
+    components:
+    - type: Transform
+      pos: -4.457054,9.586052
+      parent: 2
+- proto: BiomeSourceMiddleRing
+  entities:
+  - uid: 14191
+    components:
+    - type: Transform
+      pos: -4.561221,8.461052
+      parent: 2
+- proto: BiomeSourceOuterRing
+  entities:
+  - uid: 14192
+    components:
+    - type: Transform
+      pos: -7.540387,8.502718
+      parent: 2
 - proto: BlastDoor
   entities:
   - uid: 1607
@@ -31550,6 +31606,21 @@ entities:
     components:
     - type: Transform
       pos: 52.5,13.5
+      parent: 2
+  - uid: 14201
+    components:
+    - type: Transform
+      pos: -20.5,-10.5
+      parent: 2
+  - uid: 14202
+    components:
+    - type: Transform
+      pos: -21.5,-10.5
+      parent: 2
+  - uid: 14203
+    components:
+    - type: Transform
+      pos: -21.5,-11.5
       parent: 2
 - proto: CableHV
   entities:
@@ -44649,11 +44720,6 @@ entities:
       parent: 2
 - proto: DefaultStationBeaconBar
   entities:
-  - uid: 5214
-    components:
-    - type: Transform
-      pos: -29.5,-8.5
-      parent: 2
   - uid: 5215
     components:
     - type: Transform
@@ -44727,13 +44793,6 @@ entities:
     - type: Transform
       pos: 32.5,-5.5
       parent: 2
-- proto: DefaultStationBeaconFrontierCafe
-  entities:
-  - uid: 5226
-    components:
-    - type: Transform
-      pos: -30.5,-1.5
-      parent: 2
 - proto: DefaultStationBeaconFrontierCargobayOne
   entities:
   - uid: 5227
@@ -44802,12 +44861,33 @@ entities:
     - type: Transform
       pos: 36.5,29.5
       parent: 2
+- proto: DefaultStationBeaconOverseer
+  entities:
+  - uid: 14208
+    components:
+    - type: Transform
+      pos: -0.5,6.5
+      parent: 2
+- proto: DefaultStationBeaconRestaurant
+  entities:
+  - uid: 14209
+    components:
+    - type: Transform
+      pos: -22.5,-7.5
+      parent: 2
 - proto: DefaultStationBeaconSecurity
   entities:
   - uid: 5237
     components:
     - type: Transform
       pos: -11.5,14.5
+      parent: 2
+- proto: DefaultStationBeaconSecurityCheckpoint
+  entities:
+  - uid: 5214
+    components:
+    - type: Transform
+      pos: 36.5,12.5
       parent: 2
 - proto: DefaultStationBeaconSurgery
   entities:
@@ -44984,6 +45064,18 @@ entities:
       rot: 3.141592653589793 rad
       pos: 25.5,7.5
       parent: 2
+  - uid: 5513
+    components:
+    - type: Transform
+      rot: 1.5707963267948966 rad
+      pos: 36.5,14.5
+      parent: 2
+  - uid: 14196
+    components:
+    - type: Transform
+      rot: 3.141592653589793 rad
+      pos: 36.5,10.5
+      parent: 2
 - proto: DisposalJunction
   entities:
   - uid: 5267
@@ -45031,6 +45123,16 @@ entities:
     - type: Transform
       pos: 41.5,32.5
       parent: 2
+  - uid: 5291
+    components:
+    - type: Transform
+      pos: -20.5,2.5
+      parent: 2
+  - uid: 5292
+    components:
+    - type: Transform
+      pos: 41.5,10.5
+      parent: 2
 - proto: DisposalJunctionFlipped
   entities:
   - uid: 5275
@@ -45057,6 +45159,11 @@ entities:
       parent: 2
 - proto: DisposalPipe
   entities:
+  - uid: 5226
+    components:
+    - type: Transform
+      pos: -20.5,3.5
+      parent: 2
   - uid: 5279
     components:
     - type: Transform
@@ -45127,18 +45234,6 @@ entities:
     - type: Transform
       rot: 3.141592653589793 rad
       pos: -20.5,4.5
-      parent: 2
-  - uid: 5291
-    components:
-    - type: Transform
-      rot: 3.141592653589793 rad
-      pos: -20.5,3.5
-      parent: 2
-  - uid: 5292
-    components:
-    - type: Transform
-      rot: 3.141592653589793 rad
-      pos: -20.5,2.5
       parent: 2
   - uid: 5293
     components:
@@ -45673,11 +45768,6 @@ entities:
     components:
     - type: Transform
       pos: 41.5,9.5
-      parent: 2
-  - uid: 5386
-    components:
-    - type: Transform
-      pos: 41.5,10.5
       parent: 2
   - uid: 5387
     components:
@@ -46300,8 +46390,59 @@ entities:
       rot: -1.5707963267948966 rad
       pos: -23.5,6.5
       parent: 2
+  - uid: 14193
+    components:
+    - type: Transform
+      pos: 36.5,13.5
+      parent: 2
+  - uid: 14194
+    components:
+    - type: Transform
+      pos: 36.5,12.5
+      parent: 2
+  - uid: 14195
+    components:
+    - type: Transform
+      pos: 36.5,11.5
+      parent: 2
+  - uid: 14197
+    components:
+    - type: Transform
+      rot: 1.5707963267948966 rad
+      pos: 37.5,10.5
+      parent: 2
+  - uid: 14198
+    components:
+    - type: Transform
+      rot: 1.5707963267948966 rad
+      pos: 38.5,10.5
+      parent: 2
+  - uid: 14199
+    components:
+    - type: Transform
+      rot: 1.5707963267948966 rad
+      pos: 39.5,10.5
+      parent: 2
+  - uid: 14200
+    components:
+    - type: Transform
+      rot: 1.5707963267948966 rad
+      pos: 40.5,10.5
+      parent: 2
+  - uid: 14204
+    components:
+    - type: Transform
+      rot: -1.5707963267948966 rad
+      pos: -21.5,2.5
+      parent: 2
 - proto: DisposalTrunk
   entities:
+  - uid: 5386
+    components:
+    - type: Transform
+      rot: -1.5707963267948966 rad
+      pos: 37.5,14.5
+      parent: 2
   - uid: 5495
     components:
     - type: Transform
@@ -46406,13 +46547,19 @@ entities:
     - type: Transform
       pos: 29.5,8.5
       parent: 2
-- proto: DisposalUnit
-  entities:
-  - uid: 5513
+  - uid: 14205
+    components:
+    - type: Transform
+      rot: 1.5707963267948966 rad
+      pos: -22.5,2.5
+      parent: 2
+  - uid: 14207
     components:
     - type: Transform
       pos: 50.5,-0.5
       parent: 2
+- proto: DisposalUnit
+  entities:
   - uid: 5514
     components:
     - type: Transform
@@ -46427,11 +46574,6 @@ entities:
     components:
     - type: Transform
       pos: 38.5,-5.5
-      parent: 2
-  - uid: 5517
-    components:
-    - type: Transform
-      pos: 32.5,42.5
       parent: 2
   - uid: 5518
     components:
@@ -46507,6 +46649,11 @@ entities:
     components:
     - type: Transform
       pos: 25.5,8.5
+      parent: 2
+  - uid: 14206
+    components:
+    - type: Transform
+      pos: 50.5,-0.5
       parent: 2
 - proto: DisposalYJunction
   entities:
@@ -49298,7 +49445,7 @@ entities:
       pos: 40.5,8.5
       parent: 2
     - type: Door
-      secondsUntilStateChange: -114051.266
+      secondsUntilStateChange: -114915.01
       state: Closing
     - type: DeviceNetwork
       deviceLists:
@@ -50085,7 +50232,7 @@ entities:
       deviceLists:
       - 62
     - type: Door
-      secondsUntilStateChange: -58767.145
+      secondsUntilStateChange: -59630.887
       state: Closing
     - type: Firelock
       emergencyCloseCooldown: 14804.3518643


### PR DESCRIPTION
## About the PR
fixes the biomes not being ingame

IDK why monolith coded it like this but you need biomes on the station map or it biomes will not work
Autopilot and drones also seem to not work as well without biomes

**Changelog**
:cl:
- fix: The Chrono-legionnaires have retrieved the space biomes from Colossus Central, Space Biomes now appear again.
- fix: Fixed drones taking the day off
- fix: Various tiny Venmar Station fixes relating to disposals mainly
