### PR TITLE
Drunk Avali Are Real

### DIFF
--- a/Resources/Prototypes/_Mono/Body/Organs/avali.yml
+++ b/Resources/Prototypes/_Mono/Body/Organs/avali.yml
@@ -49,11 +49,11 @@
   description: "The liver of an avali."
   components:
   - type: Metabolizer # The liver metabolizes certain chemicals only, like alcohol.
-    updateInterval: 1.5
     maxReagents: 1
     metabolizerTypes: [Avali]
     groups:
     - id: Alcohol
+      rateModifier: 0.1 #Triad should remove alcohol from bloodstream now
   - type: Sprite
     sprite: _Starlight/Mobs/Species/Avali/organs.rsi
     state: liver


### PR DESCRIPTION
## About the PR
Made Avali able to get drunk
Removed the "Interval Limit: 1.5" and added a rate modifier of 0.1, putting it inline with other species livers, allowing them to metabolize Ethanol

## Why / Balance
Avalis have been unable to get drunk and enjoy a brew with their friends for far too long

## Media
<img width="534" height="316" alt="image" src="https://github.com/user-attachments/assets/3544e129-67c0-4b29-9785-8daa03d36d87" />

<img width="643" height="475" alt="image" src="https://github.com/user-attachments/assets/bf3c5407-7c53-414a-9ecd-6aadcdb60df1" />

<img width="547" height="460" alt="image" src="https://github.com/user-attachments/assets/530ebe3d-f3f6-4c7f-a49e-f22853f11217" />



## Requirements
<!-- Confirm the following by placing an X in the brackets [X]: -->
- [X] I have read relevant guidelines/documentation to this PR found on [our devwiki](https://monolith-station.github.io/mono-docs/).
- [X] I have added media to this PR or it does not require an ingame showcase.
- [X] I can confirm this PR contains either no AI-generated content, or AI-generated content that meets our guidelines.

## How to test
Take an Avali and drink something with alcohol in it!

**Changelog**
:cl:
- fix: Avalis should be able to get drunk now!
