### PR TITLE
Added Ability for Avali to Become Drunk

### DIFF
--- a/Resources/Prototypes/_Mono/Body/Organs/avali.yml
+++ b/Resources/Prototypes/_Mono/Body/Organs/avali.yml
@@ -49,11 +49,11 @@
   description: "The liver of an avali."
   components:
   - type: Metabolizer # The liver metabolizes certain chemicals only, like alcohol.
-    updateInterval: 1.5
     maxReagents: 1
     metabolizerTypes: [Avali]
     groups:
     - id: Alcohol
+      rateModifier: 0.1 #Triad should remove alcohol from bloodstream now
   - type: Sprite
     sprite: _Starlight/Mobs/Species/Avali/organs.rsi
     state: liver


### PR DESCRIPTION
## About the PR
Made Avali able to get drunk
Removed the "Interval Limit: 1.5" and added a rate modifier of 0.1, putting it inline with other species livers, allowing them to metabolize Ethanol

## Why / Balance
Avalis have been unable to get drunk and enjoy a brew with their friends for far too long

## Media
Before drinking
<img width="534" height="316" alt="image" src="https://github.com/user-attachments/assets/82caa90c-bbdb-43bf-822c-cce127b4646c" />

After drinking
<img width="643" height="475" alt="image" src="https://github.com/user-attachments/assets/773c5f56-94e7-46b1-a4d5-0e95ec43b514" />

And the speech
<img width="547" height="460" alt="image" src="https://github.com/user-attachments/assets/f3b6d7ce-ed6a-4b35-aa75-4d4d4fc010d8" />
 
## Requirements
- [X] I have read relevant guidelines/documentation to this PR found on [our devwiki](https://monolith-station.github.io/mono-docs/).
- [X] I have added media to this PR or it does not require an ingame showcase.
- [X] I can confirm this PR contains either no AI-generated content, or AI-generated content that meets our guidelines.

## How to test
Become Avali and drink alcohol

**Changelog**

:cl:

- fix: Avalis should be able to get drunk now!
