### PR TITLE
Contraband Fixes

### DIFF
--- a/Resources/Prototypes/Entities/Objects/Tools/access_breaker.yml
+++ b/Resources/Prototypes/Entities/Objects/Tools/access_breaker.yml
@@ -1,5 +1,5 @@
 - type: entity
-  parent: [ BaseFactionGearPDVT1, BaseItem ] # Mono
+  parent: [ BaseTriadC2Contraband, BaseItem ] # Triad
   id: AccessBreakerUnlimited
   suffix: Unlimited
   name: authentication disruptor

--- a/Resources/Prototypes/Entities/Objects/Tools/emag.yml
+++ b/Resources/Prototypes/Entities/Objects/Tools/emag.yml
@@ -1,5 +1,5 @@
 - type: entity
-  parent: [BaseFactionGearPDVT1, BaseItem ]
+  parent: [BaseTriadC2Contraband, BaseItem ] # Triad
   id: EmagUnlimited
   suffix: Unlimited
   name: cryptographic sequencer

--- a/Resources/Prototypes/_Triad/Entities/Objects/base_contraband.yml
+++ b/Resources/Prototypes/_Triad/Entities/Objects/base_contraband.yml
@@ -75,3 +75,28 @@
     severity: FactionGear3
     turnInValues:
       TriadCommerceCredit: 45
+
+# Class 2 Contraband
+- type: entity
+  parent: BaseC2ContrabandUnredeemable
+  id: BaseTriadC2Contraband
+  abstract: true
+  components:
+  - type: Contraband
+    severity: Class2
+    turnInValues:
+      TriadCommerceCredit: 5
+
+# Class 3 Contraband
+- type: entity
+  parent: BaseC3ContrabandUnredeemable
+  id: BaseTriadC3Contraband
+  abstract: true
+  components:
+  - type: Contraband
+    severity: Class3General
+    turnInValues:
+      TriadCommerceCredit: 15
+  - type: ItemTax
+    taxAccounts:
+      nfsd: -0.05 # TDF account


### PR DESCRIPTION
## About the PR
Adds new base contraband entities and adds it to the hacking devices

**Changelog**
:cl:
- fix: Fixed auth disruptors and emags being marked as 'imperial coalition' contraband. They are now marked as Class 2 contra.
