### PR TITLE
Adds Whistles to Loadout

### DIFF
--- a/Resources/Prototypes/_NF/Loadouts/contractor_loadout_groups.yml
+++ b/Resources/Prototypes/_NF/Loadouts/contractor_loadout_groups.yml
@@ -784,6 +784,11 @@
   - ContractorBible
   - ContractorMonkeyCubeWrapped
   - ContractorKoboldCubeWrapped
+  # Triad changes
+  - Whistle
+  - SecurityWhistle
+  - SyndicateWhistle
+  # End Triad
 
 - type: loadoutGroup
   id: ContractorFun # Left Hand - 1 only

--- a/Resources/Prototypes/_Triad/Loadouts/Jobs/Contractor/tools.yml
+++ b/Resources/Prototypes/_Triad/Loadouts/Jobs/Contractor/tools.yml
@@ -5,4 +5,22 @@
     proto: ContractorT2
   price: 5000
   inhand:
-    - SprayPainter 
+    - SprayPainter
+
+- type: loadout
+  id: Whistle
+  price: 0
+  inhand:
+  - Whistle
+
+- type: loadout
+  id: SecurityWhistle
+  price: 0
+  inhand:
+  - SecurityWhistle
+
+- type: loadout
+  id: SyndicateWhistle
+  price: 0
+  inhand:
+  - SyndicateWhistle


### PR DESCRIPTION
## About the PR
This PR adds all non-NFSD/TSFMC whistle variants to loadout. Regular, security (just a red recolor with a minor stat tweak) and trench/Syndicate

## Why / Balance
Easier accessibility for whistles means it'll be way easier to give orders and such using them. Plus, they're cool

The Security whistle is just a recolor with no security-specific flavoring, and the trench whistle is not contraband. It does have a lingering reference to the Syndicate in its description though. There is still a NFSD/TFSMC-specific whistle that has not been added

## Media
<img width="957" height="335" alt="image" src="https://github.com/user-attachments/assets/7bedb97a-6ee4-4f3a-86ee-3c427dc5a2d2" />

<img width="316" height="145" alt="image" src="https://github.com/user-attachments/assets/32975d85-8c8c-4209-8d71-e9b1039a80e6" />

## Requirements
<!-- Confirm the following by placing an X in the brackets [X]: -->
- [X] I have read relevant guidelines/documentation to this PR found on [our devwiki](https://monolith-station.github.io/mono-docs/).
- [X] I have added media to this PR or it does not require an ingame showcase.
- [X] I can confirm this PR contains either no AI-generated content, or AI-generated content that meets our guidelines.
<!-- You should understand that not following the above may get your PR closed at maintainer’s discretion -->
<!-- When using AI, make sure you are already proficient in creating whatever content you are attempting to generate and that you already have experience contributing to SS14. This means using AI to enhance your preexisting workflow, not vibecoding. -->

## How to test
1. Open loadout. About any job. Switch to the tools category. There are whistles

**Changelog**
:cl: Minerva
- add: Whistles have been added to the Tools category of loadout. This includes: regular, security red, and trench.