### PR TITLE
Removes a Syndicate Reference in Whistles, Plus a Cherrypick of Whistle Description

### DIFF
--- a/Resources/Prototypes/Entities/Objects/Fun/whistles.yml
+++ b/Resources/Prototypes/Entities/Objects/Fun/whistles.yml
@@ -3,7 +3,7 @@
   parent: BaseItem
   id: BaseWhistle
   name: whistle
-  description: Someone forgot to turn off kettle?
+  description: Someone forgot to turn off a kettle?
   components:
   - type: Item
     sprite: Objects/Fun/whistles.rsi
@@ -32,7 +32,7 @@
 - type: entity
   parent: BaseWhistle
   id: SecurityWhistle
-  description: Sound of it make you feel fear.
+  description: The sound of it brings fear.
   components:
   - type: Sprite
     state: sec

--- a/Resources/Prototypes/Entities/Objects/Fun/whistles.yml
+++ b/Resources/Prototypes/Entities/Objects/Fun/whistles.yml
@@ -45,7 +45,7 @@
   parent: BaseWhistle
   id: SyndicateWhistle
   name: trench whistle
-  description: A whistle used by Syndicate commanders to draw attention. Avanti!
+  description: A whistle used by commanders to draw attention. Avanti! # Triad - Removed Syndicate reference.
   components:
   - type: Sprite
     state: trench


### PR DESCRIPTION
## About the PR
Cherrypicks https://github.com/space-wizards/space-station-14/pull/40631 (Rephrases two Whistle descriptions)
Remove a Syndicate reference

## Why / Balance
Typos, plus one less reference to regular SS14 gameplay

## Media
<img width="358" height="207" alt="image" src="https://github.com/user-attachments/assets/915a155d-d5c3-4e39-b078-a117be9e85e0" />
<img width="358" height="207" alt="image" src="https://github.com/user-attachments/assets/9c4f1574-3a53-4681-b0ea-9f72cf286c65" />
<img width="448" height="158" alt="image" src="https://github.com/user-attachments/assets/19b97be7-65af-4e5d-b42f-fac8d0d7c51b" />

## Requirements
<!-- Confirm the following by placing an X in the brackets [X]: -->
- [X] I have read relevant guidelines/documentation to this PR found on [our devwiki](https://monolith-station.github.io/mono-docs/).
- [X] I have added media to this PR or it does not require an ingame showcase.
- [X] I can confirm this PR contains either no AI-generated content, or AI-generated content that meets our guidelines.
<!-- You should understand that not following the above may get your PR closed at maintainer’s discretion -->
<!-- When using AI, make sure you are already proficient in creating whatever content you are attempting to generate and that you already have experience contributing to SS14. This means using AI to enhance your preexisting workflow, not vibecoding. -->

## How to test
1. Open spawn entities
2. Hover over the whistles

Not worth a changelog