### PR TITLE
Fix: Contain HTN Planning-Job Exceptions to the Failing NPC

### DIFF
--- a/Content.Server/NPC/HTN/HTNSystem.cs
+++ b/Content.Server/NPC/HTN/HTNSystem.cs
@@ -184,11 +184,23 @@ public sealed class HTNSystem : EntitySystem
             {
                 if (comp.PlanningJob.Exception != null)
                 {
-                    Log.Fatal($"Received exception on planning job for {uid}!");
-                    _npc.SleepNPC(uid);
+                    // Triad: contain the failure to this NPC instead of rethrowing into the tick.
+                    // Upstream rethrows, which aborts every remaining NPC's update this frame and can
+                    // take the server down over one malformed domain. Quarantine: log loudly, strip
+                    // the brain, keep everyone else running. DebugTools.Assert preserves the
+                    // crash-loudly-in-dev property so bad domains still get fixed.
                     var exc = comp.PlanningJob.Exception;
+                    Log.Error($"Received exception on planning job for {ToPrettyString(uid)}, root task {comp.RootTask}, quarantining NPC:\n{exc}");
+                    _npc.SleepNPC(uid);
                     RemComp<HTNComponent>(uid);
-                    throw exc;
+                    DebugTools.Assert(false, $"HTN planning job threw for {ToPrettyString(uid)}: {exc.Message}");
+                    continue;
+                    // Triad: end of quarantine block; upstream code below was:
+                    // Log.Fatal($"Received exception on planning job for {uid}!");
+                    // _npc.SleepNPC(uid);
+                    // var exc = comp.PlanningJob.Exception;
+                    // RemComp<HTNComponent>(uid);
+                    // throw exc;
                 }
 
                 // If a new planning job has finished then handle it.


### PR DESCRIPTION
## About the PR
Contains HTN planning-job exceptions to the NPC that caused them. Upstream rethrows the exception out of `UpdateNPC`, which aborts every remaining NPC's update that frame; one malformed domain or throwing operator can take the whole server down. The failing NPC is now quarantined instead: the full exception is logged with the entity and root task, the NPC is slept and its `HTNComponent` removed, and the update loop continues to the next NPC. A `DebugTools.Assert` keeps dev builds failing loudly so broken domains still get caught during development. The original upstream block is preserved in comments so future upstream merges surface the seam.

## Why / Balance
No balance impact. This is a server-stability fix: a brain that throws during planning will throw again every cycle, so removal is the correct containment, and the rest of the fleet's AI keeps running instead of dying with it.

## Media
N/A, server-side fix with no visual component.

## Requirements
- [x] I have read relevant guidelines/documentation to this PR found on [our devwiki](https://monolith-station.github.io/mono-docs/).
- [x] I have added media to this PR or it does not require an ingame showcase.
- [x] I can confirm this PR contains either no AI-generated content, or AI-generated content that meets our guidelines.

## How to test
Verified with a build, the NPC integration test suite, and a headless server boot. The quarantine path itself has no automated coverage; to exercise it manually, add a deliberately-throwing operator to any HTN domain and confirm the offending NPC goes inert with an error in the log while other NPCs keep updating. Without such a poison domain the path is unreachable in normal play.

## Breaking changes
None. No API surface changed; the only behavioral difference is that a planning-job exception no longer propagates out of `HTNSystem.UpdateNPC`.

**Changelog**
:cl:
- fix: A broken NPC brain no longer freezes AI updates for every other NPC on the server.
