### PR TITLE
Fix: Set HTN Blackboard Owner on ComponentStartup (Port Wizden #…

### DIFF
--- a/Content.Server/NPC/HTN/HTNSystem.cs
+++ b/Content.Server/NPC/HTN/HTNSystem.cs
@@ -47,6 +47,7 @@ public sealed class HTNSystem : EntitySystem
         _loadedQuery = GetEntityQuery<LoadedChunkComponent>(); // Frontier
         SubscribeLocalEvent<HTNComponent, MobStateChangedEvent>(_npc.OnMobStateChange);
         SubscribeLocalEvent<HTNComponent, MapInitEvent>(_npc.OnNPCMapInit);
+        SubscribeLocalEvent<HTNComponent, ComponentStartup>(_npc.OnNPCStartup); // Triad: port of Wizden #40244, blackboard Owner must exist before MapInit
         SubscribeLocalEvent<HTNComponent, PlayerAttachedEvent>(_npc.OnPlayerNPCAttach);
         SubscribeLocalEvent<HTNComponent, PlayerDetachedEvent>(_npc.OnPlayerNPCDetach);
         SubscribeLocalEvent<HTNComponent, ComponentShutdown>(OnHTNShutdown);

--- a/Content.Server/NPC/Systems/NPCSystem.cs
+++ b/Content.Server/NPC/Systems/NPCSystem.cs
@@ -76,9 +76,16 @@ namespace Content.Server.NPC.Systems
             WakeNPC(uid, component);
         }
 
-        public void OnNPCMapInit(EntityUid uid, HTNComponent component, MapInitEvent args)
+        // Triad: port of Wizden #40244. Owner is set on ComponentStartup, not MapInit: components on
+        // pre-mapinit maps (e.g. the shipyard hold) are live and can be woken before MapInit ever fires,
+        // and every HTN operator assumes Owner is present.
+        public void OnNPCStartup(EntityUid uid, HTNComponent component, ComponentStartup args)
         {
             component.Blackboard.SetValue(NPCBlackboard.Owner, uid);
+        }
+
+        public void OnNPCMapInit(EntityUid uid, HTNComponent component, MapInitEvent args)
+        {
             WakeNPC(uid, component);
         }
 
@@ -178,6 +185,10 @@ namespace Content.Server.NPC.Systems
 
             while (npcQuery.MoveNext(out var npcUid, out var htn, out var npcTransform))
             {
+                // Triad: never wake/sleep an NPC that hasn't map-initialized; MapInit wakes it itself.
+                if (MetaData(npcUid).EntityLifeStage < EntityLifeStage.MapInitialized)
+                    continue;
+
                 // Skip NPCs that are players or have minds.
                 if (HasComp<ActorComponent>(npcUid) ||
                     (TryComp<MindContainerComponent>(npcUid, out var mindContainer) && mindContainer.HasMind))


### PR DESCRIPTION
## About the PR
Ports space-wizards/space-station-14#40244. The HTN blackboard's `Owner` key was only set on MapInit, but an NPC on a not-yet-initialized map has a live component and can be woken by the player-distance check before MapInit ever fires. Every HTN operator then throws `KeyNotFoundException` each tick, aborting the rest of that tick's NPC updates. `Owner` is now set on `ComponentStartup`, which fires on every add path regardless of map-init state, and the distance-based waker skips pre-MapInit NPCs entirely since MapInit wakes them itself.

## Why / Balance
No balance impact. Our production logs showed ~600k of these throws over July 8-10 via `ShipMoveToOperator`, freezing fleet AI for hours at a time until the affected NPCs were cleaned up.

## Media
N/A, server-side fix with no visual component.

## Requirements
- [x] I have read relevant guidelines/documentation to this PR found on [our devwiki](https://monolith-station.github.io/mono-docs/).
- [x] I have added media to this PR or it does not require an ingame showcase.
- [x] I can confirm this PR contains either no AI-generated content, or AI-generated content that meets our guidelines.

## How to test
Verified with a build, the NPC integration test suite, and a headless server boot. I have not reproduced the original pre-MapInit wake in a test; the diagnosis comes from production logs. To exercise it manually, spawn an HTN NPC onto a paused/pre-init map (e.g. a shipyard hold) and let the player-distance waker reach it: previously that threw `KeyNotFoundException` per tick, now the NPC stays dormant until MapInit and behaves normally after.

## Breaking changes
None. `OnNPCMapInit` no longer sets the blackboard `Owner` (moved to `ComponentStartup`); anything relying on MapInit setting it is covered, since ComponentStartup always precedes MapInit.

**Changelog**
:cl:
- fix: Fixed NPC ship AI freezing when drones woke up before their map finished loading.
