### PR TITLE
Feat: Faction-Aware IFF for Ship NPC Targeting

### DIFF
--- a/Content.Server/NPC/Queries/Queries/NearbyHostileShuttlesQuery.cs
+++ b/Content.Server/NPC/Queries/Queries/NearbyHostileShuttlesQuery.cs
@@ -14,7 +14,6 @@ public sealed partial class NearbyNpcTargetsQuery : UtilityQuery
     // Triad: revert of Mono #3728 (2x targeting range), halved back for perf.
     public float Range = 2000f;
 
-    // TODO: make this use factions
     [DataField]
     public EntityWhitelist Blacklist = new();
 }

--- a/Content.Server/NPC/Systems/NPCUtilitySystem.cs
+++ b/Content.Server/NPC/Systems/NPCUtilitySystem.cs
@@ -520,6 +520,7 @@ public sealed class NPCUtilitySystem : EntitySystem
                 break;
             }
             // Mono - TODO: consider factions
+            // Triad: factions are now consulted below via the friendly-skip IFF check.
             case NearbyNpcTargetsQuery shuttlesQuery:
             {
                 var xform = Transform(owner);
@@ -535,6 +536,16 @@ public sealed class NPCUtilitySystem : EntitySystem
                         || (_transform.GetWorldPosition(target) - _transform.GetWorldPosition(xform)).Length() > shuttlesQuery.Range
                         || targetComp.NeedPower && !this.IsPowered(target, EntityManager)
                         || targetGrid != null && _whitelistSystem.IsBlacklistPass(shuttlesQuery.Blacklist, targetGrid.Value))
+                    {
+                        continue;
+                    }
+
+                    // Triad: IFF. Skip targets friendly to us (shared faction or declared friendly),
+                    // checking the target itself and then its grid so a faction stamped on the hull
+                    // covers everything aboard. Hostile, neutral, and factionless targets all remain
+                    // valid, so behavior is unchanged wherever no factions are authored.
+                    if (_npcFaction.IsEntityFriendly(owner, target)
+                        || targetGrid != null && _npcFaction.IsEntityFriendly(owner, targetGrid.Value))
                     {
                         continue;
                     }

--- a/Content.Server/NPC/Systems/NPCUtilitySystem.cs
+++ b/Content.Server/NPC/Systems/NPCUtilitySystem.cs
@@ -519,8 +519,6 @@ public sealed class NPCUtilitySystem : EntitySystem
                 }
                 break;
             }
-            // Mono - TODO: consider factions
-            // Triad: factions are now consulted below via the friendly-skip IFF check.
             case NearbyNpcTargetsQuery shuttlesQuery:
             {
                 var xform = Transform(owner);

--- a/Resources/Prototypes/_Mono/Entities/Mobs/NPCs/ai.yml
+++ b/Resources/Prototypes/_Mono/Entities/Mobs/NPCs/ai.yml
@@ -57,6 +57,9 @@
     powerLoad: 1000 # suspiciously low power-using AI
   - type: ExtensionCableReceiver
   - type: TargetSeekingTarget
+  - type: NpcFactionMember # Triad: IFF identity for all drone cores (inherited fleet-wide); relations empty, see _Triad/ai_factions.yml
+    factions:
+    - ShipDrone
 
 - type: entity
   id: NpcStationAiApproacher

--- a/Resources/Prototypes/_Triad/ai_factions.yml
+++ b/Resources/Prototypes/_Triad/ai_factions.yml
@@ -13,3 +13,14 @@
   - CC
   - SimpleNeutral
   defaultHostile: true
+
+# Identity faction for autonomous NPC combat drones. Relations are deliberately empty:
+# the ship-targeting IFF only skips FRIENDLY targets, so an empty-relations faction changes
+# no live behavior until content declares friendlies (e.g. escort drones friendly to a
+# faction-stamped player hull). Do not add this faction to player-side entities like
+# DroneController; NPC drones would stop engaging them.
+# defaultHostileIncluded false keeps drone cores out of defaultHostile umbrellas, so
+# carps/turrets/mobs don't newly aggro cores just because they gained a faction.
+- type: npcFaction
+  id: ShipDrone
+  defaultHostileIncluded: false


### PR DESCRIPTION
## About the PR
Adds faction-aware IFF to ship NPC targeting, resolving the long-standing `consider factions` TODO. `NearbyNpcTargetsQuery` now skips targets that are friendly to the querying brain (shared faction or declared friendly), checking the target entity first and then its grid, so a faction stamped on a hull covers everything aboard. All NPC drone cores gain a new `ShipDrone` identity faction through their shared root.

## Why / Balance
No behavior changes with current content: hostile, neutral, and factionless targets all remain valid, and the friendly check fails closed to "not friendly" when either side lacks a faction. `ShipDrone` has empty relations and `defaultHostileIncluded: false`, so carps, turrets, and other defaultHostile factions don't newly aggro drone cores. What this unlocks is expressiveness: escort drones, faction fleets that don't shoot their own, and neutral NPC traffic all become authorable by declaring faction relations, instead of the `ShuttleAIIgnore` grid tag being the only IFF lever. The player `DroneController` deliberately stays factionless so NPC drones keep engaging player carrier drones.

## Media
N/A, no visual changes; drone behavior is unchanged with current content.

## Requirements
- [x] I have read relevant guidelines/documentation to this PR found on [our devwiki](https://monolith-station.github.io/mono-docs/).
- [x] I have added media to this PR or it does not require an ingame showcase.
- [x] I can confirm this PR contains either no AI-generated content, or AI-generated content that meets our guidelines.

## How to test
Verified with a build, the NPC integration test, prototype validation, and a headless server boot. To see the IFF in action: spawn two NPC drones and give a target on one grid the `ShipDrone` faction (or a faction the drone's faction declares friendly) via VV; the drone will ignore it while continuing to engage everything else. With no factions authored, behavior is identical to before.

## Breaking changes
None. New faction prototype and one new component on the drone core root; no API changes.

**Changelog**
:cl:
- add: NPC ship drones now respect faction relations and will not attack friendly targets.
