### PR TITLE
[Mapping] Add New Command for Showing Network Links (#5188)

### DIFF
--- a/Content.Client/_DV/NetworkConfigurator/MappingNetworkConfiguratorLinkOverlay.cs
+++ b/Content.Client/_DV/NetworkConfigurator/MappingNetworkConfiguratorLinkOverlay.cs
@@ -1,0 +1,77 @@
+using Content.Client.NetworkConfigurator.Systems;
+using Content.Shared.DeviceNetwork.Components;
+using Robust.Client.Graphics;
+using Robust.Shared.Enums;
+using Robust.Shared.Map;
+using Robust.Shared.Random;
+
+namespace Content.Client._DV.NetworkConfigurator;
+
+/// <summary>
+/// Mapping version of <see cref="NetworkConfiguratorLinkOverlay"> that shows the linkages
+/// as we move around the map, rather than using component markers.
+/// Using markers means it only applies to objects the user is currently in PVS range, but this
+/// version continually searches for device networks to draw.
+/// </summary>
+public sealed class MappingNetworkConfiguratorLinkOverlay : Overlay
+{
+    [Dependency] private readonly IEntityManager _entityManager = default!;
+    [Dependency] private readonly IRobustRandom _random = default!;
+    private readonly DeviceListSystem _deviceListSystem;
+    private readonly SharedTransformSystem _transformSystem;
+
+    public Dictionary<EntityUid, Color> Colors = [];
+
+    public override OverlaySpace Space => OverlaySpace.WorldSpace;
+
+    public MappingNetworkConfiguratorLinkOverlay()
+    {
+        IoCManager.InjectDependencies(this);
+
+        _deviceListSystem = _entityManager.System<DeviceListSystem>();
+        _transformSystem = _entityManager.System<SharedTransformSystem>();
+    }
+
+    protected override void Draw(in OverlayDrawArgs args)
+    {
+        var query = _entityManager.AllEntityQueryEnumerator<DeviceNetworkComponent>();
+        while (query.MoveNext(out var uid, out _))
+        {
+            if (_entityManager.Deleted(uid) || !_entityManager.TryGetComponent(uid, out DeviceListComponent? deviceList))
+                continue; // Deleted or doesn't have any device linkages
+
+            var sourceTransform = _entityManager.GetComponent<TransformComponent>(uid);
+            if (sourceTransform.MapID == MapId.Nullspace)
+            {
+                // Can happen if the item is outside the client's view. In that case,
+                // we don't have a sensible transform to draw, so we need to skip it.
+                continue;
+            }
+
+            if (!Colors.TryGetValue(uid, out var color))
+            {
+                color = new Color(
+                    _random.NextByte(0, 255),
+                    _random.NextByte(0, 255),
+                    _random.NextByte(0, 255));
+                Colors.Add(uid, color);
+            }
+
+            foreach (var device in _deviceListSystem.GetAllDevices(uid, deviceList))
+            {
+                if (_entityManager.Deleted(device))
+                {
+                    continue;
+                }
+
+                var linkTransform = _entityManager.GetComponent<TransformComponent>(device);
+                if (linkTransform.MapID == MapId.Nullspace)
+                {
+                    continue;
+                }
+
+                args.WorldHandle.DrawLine(_transformSystem.GetWorldPosition(sourceTransform), _transformSystem.GetWorldPosition(linkTransform), color);
+            }
+        }
+    }
+}

--- a/Content.Client/_DV/NetworkConfigurator/ShowNetworkLinksCommand.cs
+++ b/Content.Client/_DV/NetworkConfigurator/ShowNetworkLinksCommand.cs
@@ -1,0 +1,20 @@
+using Robust.Client.Graphics;
+using Robust.Shared.Console;
+
+namespace Content.Client._DV.NetworkConfigurator;
+
+public sealed class ToggleNetworkLinksCommand : LocalizedEntityCommands
+{
+    [Dependency] private readonly IOverlayManager _overlay = default!;
+
+    public override string Command => "togglenetworklinks";
+    public override string Description => Loc.GetString("cmd-togglenetworklinks-desc");
+
+    public override void Execute(IConsoleShell shell, string argStr, string[] args)
+    {
+        if (_overlay.RemoveOverlay<MappingNetworkConfiguratorLinkOverlay>())
+            return;
+
+        _overlay.AddOverlay(new MappingNetworkConfiguratorLinkOverlay());
+    }
+}

--- a/Resources/Locale/en-US/_DV/commands/togglenetworklinks-command.ftl
+++ b/Resources/Locale/en-US/_DV/commands/togglenetworklinks-command.ftl
@@ -1,0 +1,1 @@
+cmd-togglenetworklinks-desc = Toggles seeing network configurator links


### PR DESCRIPTION
* Add new command for showing network links

* Use AllEntityQueryEnumerator to bypass EntityPaused check

* Localise description


## About the PR
<!-- What did you change? -->
<!-- If this is a code change, summarize at high level how your new code works. This makes it easier to review. -->
Network links command

## Why / Balance
<!-- Discuss how this would affect game balance or explain why it was changed. Link any relevant discussions or issues. -->
I want it

## Media
<!-- Attach media if the PR makes ingame changes (clothing, items, features, etc). 
Small fixes/refactors are exempt. Media may be used in SS14 progress reports with credit. -->
<img width="1508" height="1174" alt="image" src="https://github.com/user-attachments/assets/cf1977f8-121a-4cb9-9906-c285f7d29b04" />

## Requirements
<!-- Confirm the following by placing an X in the brackets [X]: -->
- [X] I have read relevant guidelines/documentation to this PR found on [our devwiki](https://monolith-station.github.io/mono-docs/).
- [X] I have added media to this PR or it does not require an ingame showcase.
- [X] I can confirm this PR contains either no AI-generated content, or AI-generated content that meets our guidelines.
<!-- You should understand that not following the above may get your PR closed at maintainer’s discretion -->
<!-- When using AI, make sure you are already proficient in creating whatever content you are attempting to generate and that you already have experience contributing to SS14. This means using AI to enhance your preexisting workflow, not vibecoding. -->

## How to test
<!-- Describe the way it can be tested -->

## Breaking changes
<!-- List any breaking changes, including namespaces, public class/method/field changes, prototype renames; and provide instructions for fixing them. -->

**Changelog**
<!-- Add a Changelog entry to make players aware of new features or changes that could affect gameplay.
Make sure to read the guidelines and take this Changelog template out of the comment block in order for it to show up.
Changelog must have a :cl: symbol, so the bot recognizes the changes and adds them to the game's changelog.
Remove this symbol for non-player facing PRs.-->
:cl:
- add: ToggleNetworkLinks Command to help with mappping