### PR TITLE
Makes some Mercfab Nonlethal Weapons Printable Roundstart

### DIFF
--- a/Resources/Prototypes/_NF/Recipes/Lathes/Packs/Deprecated/mercenary_techfab.yml
+++ b/Resources/Prototypes/_NF/Recipes/Lathes/Packs/Deprecated/mercenary_techfab.yml
@@ -92,6 +92,11 @@
   - BaseBallBatNF
   - CrossbowModern
   - WeaponPistolPollock
+  # Triad changes - Nonlethal weapons moved to Static.
+  - Stunbaton
+  - WeaponDisabler
+  - WeaponDisablerSMG
+  # End Triad
   ## Cyborg Modules
   - BorgModuleMercenary # mono
 
@@ -162,7 +167,7 @@
   - KatanaNF
   - KukriKnifeNF
   - MacheteNF
-  - Stunbaton
+  #- Stunbaton # Triad - Moved to Static.
   - BolaNF
   - ExplosivePayload
   - FlashPayload
@@ -170,8 +175,8 @@
   - WeaponShotgunKammererNF
   - WeaponAdvancedLaser # After the changes made to windows shouldn't be that much of an issue now if it's widely available
   - WeaponLaserCarbine
-  - WeaponDisabler
-  - WeaponDisablerSMG
+  #- WeaponDisabler # Triad - Moved to Static.
+  #- WeaponDisablerSMG # Triad - Moved to Static.
   - WeaponLaserCannon
   - WeaponXrayCannon
 #Mono start


### PR DESCRIPTION
## About the PR
This PR moves the following nonlethal weapons to the Static (meaning always accessible) recipe pack of the Mercenary techfab.
- Disabler SMGs (they're in loadout)
- Disablers
- Stun batons

Mercfabs already have restraints, like handcuffs.

## Why / Balance
Partial implementation of changes discussed in recent staff meeting. Nonlethal weapons are hard to get and hard to use, so we may as well deal with at least *one* of these things as to encourage nonlethal force

## Media
<img width="790" height="683" alt="image" src="https://github.com/user-attachments/assets/e887c48c-6bc8-463a-b738-079e2d2e0245" />
<img width="776" height="587" alt="image" src="https://github.com/user-attachments/assets/b53871dd-cb2a-4baa-846d-aded1d6346f6" />

## Requirements
<!-- Confirm the following by placing an X in the brackets [X]: -->
- [X] I have read relevant guidelines/documentation to this PR found on [our devwiki](https://monolith-station.github.io/mono-docs/).
- [X] I have added media to this PR or it does not require an ingame showcase.
- [X] I can confirm this PR contains either no AI-generated content, or AI-generated content that meets our guidelines.
<!-- You should understand that not following the above may get your PR closed at maintainer’s discretion -->
<!-- When using AI, make sure you are already proficient in creating whatever content you are attempting to generate and that you already have experience contributing to SS14. This means using AI to enhance your preexisting workflow, not vibecoding. -->

## How to test
1. Open Mercfab
2. You have disablers and stun batons by default

**Changelog**
:cl: Minerva
- tweak: Mercenary fabricators now have the following items available roundstart: disablers, disabler SMGs, and stun batons.
