### PR TITLE
Cherrypick: Allow Tank Harnesses and Hospital Gowns to Be Operated Through (#2678)

### DIFF
--- a/Content.Shared/_Shitmed/Surgery/SharedSurgerySystem.Steps.cs
+++ b/Content.Shared/_Shitmed/Surgery/SharedSurgerySystem.Steps.cs
@@ -286,6 +286,9 @@ public abstract partial class SharedSurgerySystem
                 if (!containerSlot.ContainedEntity.HasValue)
                     continue;
 
+                if (_tagSystem.HasTag(containerSlot.ContainedEntity.Value, "PermissibleForSurgery")) // DeltaV: allow some clothing items to be operated through
+                    continue;
+
                 args.Invalid = StepInvalidReason.Armor;
                 args.Popup = Loc.GetString("surgery-ui-window-steps-error-armor");
                 return;

--- a/Content.Shared/_Shitmed/Surgery/SharedSurgerySystem.Steps.cs
+++ b/Content.Shared/_Shitmed/Surgery/SharedSurgerySystem.Steps.cs
@@ -23,6 +23,7 @@ using Content.Shared.Item;
 using Content.Shared._Shitmed.Body.Organ;
 using Content.Shared._Shitmed.Body.Part;
 using Content.Shared.Popups;
+using Content.Shared.Tag; // Triad
 using Robust.Shared.Prototypes;
 using Robust.Shared.Toolshed.TypeParsers;
 using System.Linq;
@@ -34,6 +35,7 @@ public abstract partial class SharedSurgerySystem
 {
     private static readonly string[] BruteDamageTypes = { "Slash", "Blunt", "Piercing" };
     private static readonly string[] BurnDamageTypes = { "Heat", "Shock", "Cold", "Caustic" };
+    private static readonly ProtoId<TagPrototype> PermissibleForSurgeryTag = "PermissibleForSurgery"; // Triad - Refactor DeltaV's PermissibleForSurgery tag.
     private void InitializeSteps()
     {
         SubscribeLocalEvent<SurgeryStepComponent, SurgeryStepEvent>(OnToolStep);
@@ -286,7 +288,8 @@ public abstract partial class SharedSurgerySystem
                 if (!containerSlot.ContainedEntity.HasValue)
                     continue;
 
-                if (_tagSystem.HasTag(containerSlot.ContainedEntity.Value, "PermissibleForSurgery")) // DeltaV: allow some clothing items to be operated through
+                // Triad - PermissibleForSurgery refactored here to not be a string.
+                if (_tagSystem.HasTag(containerSlot.ContainedEntity.Value, PermissibleForSurgeryTag)) // DeltaV: allow some clothing items to be operated through
                     continue;
 
                 args.Invalid = StepInvalidReason.Armor;

--- a/Content.Shared/_Shitmed/Surgery/SharedSurgerySystem.cs
+++ b/Content.Shared/_Shitmed/Surgery/SharedSurgerySystem.cs
@@ -21,6 +21,7 @@ using Content.Shared.Interaction;
 using Content.Shared.Inventory;
 using Content.Shared.Popups;
 using Content.Shared.Standing;
+using Content.Shared.Tag; // DeltaV: surgery can operate through some clothing
 using Robust.Shared.Audio.Systems;
 using Robust.Shared.Map;
 using Robust.Shared.Network;
@@ -49,6 +50,7 @@ public abstract partial class SharedSurgerySystem : EntitySystem
     [Dependency] private readonly StandingStateSystem _standing = default!;
     [Dependency] private readonly SharedTransformSystem _transform = default!;
     [Dependency] private readonly SharedCorticalBorerSystem _corticalBorer = default!;
+    [Dependency] private readonly TagSystem _tagSystem = default!; // DeltaV: surgery can operate through some clothing
 
     private readonly Dictionary<EntProtoId, EntityUid> _surgeries = new();
 

--- a/Resources/Prototypes/Entities/Clothing/OuterClothing/misc.yml
+++ b/Resources/Prototypes/Entities/Clothing/OuterClothing/misc.yml
@@ -266,6 +266,10 @@
     sprite: Clothing/OuterClothing/Misc/hospitalgown.rsi
   - type: Clothing
     sprite: Clothing/OuterClothing/Misc/hospitalgown.rsi
+  - type: Tag # DeltaV: tank harnesses can be used for surgery
+    tags:
+    - PermissibleForSurgery
+    - WhitelistChameleon
 
 - type: entity
   parent: ClothingOuterBase

--- a/Resources/Prototypes/Entities/Clothing/OuterClothing/vests.yml
+++ b/Resources/Prototypes/Entities/Clothing/OuterClothing/vests.yml
@@ -104,3 +104,7 @@
     sprite: Clothing/OuterClothing/Vests/tankharness.rsi
   - type: Clothing
     sprite: Clothing/OuterClothing/Vests/tankharness.rsi
+  - type: Tag # DeltaV: tank harnesses can be used for surgery
+    tags:
+    - PermissibleForSurgery
+    - WhitelistChameleon

--- a/Resources/Prototypes/_DV/tags.yml
+++ b/Resources/Prototypes/_DV/tags.yml
@@ -38,3 +38,6 @@
 
 - type: Tag
   id: PreventLabel
+
+- type: Tag
+  id: PermissibleForSurgery # Can be worn on the body during surgery


### PR DESCRIPTION
## About the PR
Cherrypicks https://github.com/DeltaV-Station/Delta-v/pull/2678, which allows surgery even while wearing certain clothings based on tags

Also they got added to the chameleon whitelist but whatever. This was part of the PR and it's DV namespaced

## Why / Balance
To my knowledge I was not nude during my surgery. Also it's cool

## Media
<img width="931" height="450" alt="image" src="https://github.com/user-attachments/assets/6618d5b3-b15b-4445-a957-883873257f50" />

## Requirements
<!-- Confirm the following by placing an X in the brackets [X]: -->
- [X] I have read relevant guidelines/documentation to this PR found on [our devwiki](https://monolith-station.github.io/mono-docs/).
- [X] I have added media to this PR or it does not require an ingame showcase.
- [X] I can confirm this PR contains either no AI-generated content, or AI-generated content that meets our guidelines.
<!-- You should understand that not following the above may get your PR closed at maintainer’s discretion -->
<!-- When using AI, make sure you are already proficient in creating whatever content you are attempting to generate and that you already have experience contributing to SS14. This means using AI to enhance your preexisting workflow, not vibecoding. -->

## How to test
1. Spawn in two operating tables and two Urists. Dress one in a hospital gown/tank harness, and the other in whatever else
2. Get a scalpel and attempt to start __a surgical step__ on either. The one in the hospital gown/tank harness will work fine, but the clothed one wont

**Changelog**
Changelog tweaked from original PR

:cl: DeltaV
- tweak: Tank harnesses and hospital gowns are now valid clothing for surgery.