### PR TITLE
Adds Hospital Gowns to Medical Techfab and Uniform Printer

### DIFF
--- a/Resources/Prototypes/Entities/Clothing/OuterClothing/misc.yml
+++ b/Resources/Prototypes/Entities/Clothing/OuterClothing/misc.yml
@@ -257,7 +257,7 @@
   - type: IdentityBlocker
 
 - type: entity
-  parent: ClothingOuterBase
+  parent: [ ClothingOuterBase, RecyclableItemClothSmall ] # Triad - Material arbitrage.
   id: ClothingOuterHospitalGown
   name: hospital gown
   description: Made from the wool of slaughtered baby lambs.  The cruelty makes it softer.

--- a/Resources/Prototypes/Entities/Clothing/OuterClothing/misc.yml
+++ b/Resources/Prototypes/Entities/Clothing/OuterClothing/misc.yml
@@ -257,7 +257,7 @@
   - type: IdentityBlocker
 
 - type: entity
-  parent: [ ClothingOuterBase, RecyclableItemClothSmall ] # Triad - Material arbitrage.
+  parent: [ RecyclableItemClothSmall, ClothingOuterBase ] # Triad - Material arbitrage.
   id: ClothingOuterHospitalGown
   name: hospital gown
   description: Made from the wool of slaughtered baby lambs.  The cruelty makes it softer.

--- a/Resources/Prototypes/Recipes/Lathes/Packs/clothing.yml
+++ b/Resources/Prototypes/Recipes/Lathes/Packs/clothing.yml
@@ -67,6 +67,7 @@
   - ClothingUniformJumpsuitParamedic
   - ClothingUniformJumpskirtParamedic
   - ClothingHeadHatParamedicsoft
+  - ClothingOuterHospitalGown # Triad
 
 - type: latheRecipePack
   id: ClothingScience

--- a/Resources/Prototypes/_NF/Recipes/Lathes/Packs/medical.yml
+++ b/Resources/Prototypes/_NF/Recipes/Lathes/Packs/medical.yml
@@ -13,6 +13,7 @@
   - BeltMedical
   - CraftMedicalBag
   - BoneGel # Shitmed Change
+  - ClothingOuterHospitalGown # Triad
 
 - type: latheRecipePack
   id: SM

--- a/Resources/Prototypes/_Triad/Recipes/Lathes/medical.yml
+++ b/Resources/Prototypes/_Triad/Recipes/Lathes/medical.yml
@@ -5,4 +5,4 @@
   - Coats # Uh, yeah, sure...
   completetime: 2 # Fast to encourage making them.
   materials:
-    Cloth: 250
+    Cloth: 300

--- a/Resources/Prototypes/_Triad/Recipes/Lathes/medical.yml
+++ b/Resources/Prototypes/_Triad/Recipes/Lathes/medical.yml
@@ -1,0 +1,8 @@
+- type: latheRecipe
+  id: ClothingOuterHospitalGown
+  result: ClothingOuterHospitalGown
+  categories:
+  - Coats # Uh, yeah, sure...
+  completetime: 2 # Fast to encourage making them.
+  materials:
+    Cloth: 300

--- a/Resources/Prototypes/_Triad/Recipes/Lathes/medical.yml
+++ b/Resources/Prototypes/_Triad/Recipes/Lathes/medical.yml
@@ -5,4 +5,4 @@
   - Coats # Uh, yeah, sure...
   completetime: 2 # Fast to encourage making them.
   materials:
-    Cloth: 200
+    Cloth: 250

--- a/Resources/Prototypes/_Triad/Recipes/Lathes/medical.yml
+++ b/Resources/Prototypes/_Triad/Recipes/Lathes/medical.yml
@@ -5,4 +5,4 @@
   - Coats # Uh, yeah, sure...
   completetime: 2 # Fast to encourage making them.
   materials:
-    Cloth: 300
+    Cloth: 200

--- a/Resources/Prototypes/_Triad/Recipes/Lathes/medical.yml
+++ b/Resources/Prototypes/_Triad/Recipes/Lathes/medical.yml
@@ -5,4 +5,4 @@
   - Coats # Uh, yeah, sure...
   completetime: 2 # Fast to encourage making them.
   materials:
-    Cloth: 300
+    Cloth: 150


### PR DESCRIPTION
## About the PR
This PR adds the cloth gowns to the Medical techfab and uniform printer. Cheap, quick print time. Coats category for lack of anywhere better

## Why / Balance
Medical techfab: https://github.com/Triad-Sector/Triad_Sector/pull/337 (adds allowed-for-surgery functionality) or not, this is good medical equipment. It's an outfit medics can throw on people who are naked before cryo/surgery, or on cognizined people
Uniform printer: Improvised surgery is a thing

## Media
<img width="848" height="443" alt="image" src="https://github.com/user-attachments/assets/6e3fc6f5-e42e-4510-8692-e7338016a5e8" />

## Requirements
<!-- Confirm the following by placing an X in the brackets [X]: -->
- [X] I have read relevant guidelines/documentation to this PR found on [our devwiki](https://monolith-station.github.io/mono-docs/).
- [X] I have added media to this PR or it does not require an ingame showcase.
- [X] I can confirm this PR contains either no AI-generated content, or AI-generated content that meets our guidelines.
<!-- You should understand that not following the above may get your PR closed at maintainer’s discretion -->
<!-- When using AI, make sure you are already proficient in creating whatever content you are attempting to generate and that you already have experience contributing to SS14. This means using AI to enhance your preexisting workflow, not vibecoding. -->

## How to test
1. Get a medical techfab and a uniform printer
2. You can print hospital gowns

**Changelog**
:cl: Minerva
- add: Hospital gowns can now be printed in uniform printers or the Medical techfab. They are fast and cheap to make.