### PR TITLE
Expands Marking Points for About All Species

### DIFF
--- a/Resources/Prototypes/Nyanotrasen/Species/felinid.yml
+++ b/Resources/Prototypes/Nyanotrasen/Species/felinid.yml
@@ -26,7 +26,7 @@
       required: true
       defaultMarkings: [ FelinidEarsBasic ]
     Chest:
-      points: 4 # Frontier 1<4
+      points: 8 # Triad - Increased to 8.
       required: false
     Legs:
       points: 8 # Frontier 2<8

--- a/Resources/Prototypes/Nyanotrasen/Species/oni.yml
+++ b/Resources/Prototypes/Nyanotrasen/Species/oni.yml
@@ -37,17 +37,17 @@
       required: false
     # Triad changes - Underwear.
     UndergarmentTop:
-      points: 1
+      points: 8
       required: false
     UndergarmentBottom:
-      points: 1
+      points: 8
       required: false
     # End Triad.
     Chest:
-      points: 4 # Frontier 1<4
+      points: 8 # Triad - Increased to 8.
       required: false
     Legs:
-      points: 8 # Frontier 2<8
+      points: 8 # Triad - Increased to 8.
       required: false
     Arms:
       points: 8 # Frontier 2<8

--- a/Resources/Prototypes/Species/arachnid.yml
+++ b/Resources/Prototypes/Species/arachnid.yml
@@ -65,7 +65,7 @@
       required: true
       defaultMarkings: [ ArachnidCheliceraeDownwards ]
     Chest:
-      points: 1
+      points: 8 # Triad - Increased to 8.
       required: false
     Legs:
       points: 8 # imp 2<8

--- a/Resources/Prototypes/Species/diona.yml
+++ b/Resources/Prototypes/Species/diona.yml
@@ -48,19 +48,19 @@
       points: 1
       required: false
     UndergarmentTop:
-      points: 1
+      points: 8 # Triad - Increased to 8.
       required: false
     UndergarmentBottom:
-      points: 1
+      points: 8 # Triad - Increased to 8.
       required: false
     Chest:
-      points: 1
+      points: 8 # Triad - Increased to 8.
       required: false
     Legs:
-      points: 2
+      points: 8 # Triad - Increased to 8.
       required: false
     Arms:
-      points: 2
+      points: 8 # Triad - Increased to 8.
       required: false
     Overlay:
       points: 1

--- a/Resources/Prototypes/Species/human.yml
+++ b/Resources/Prototypes/Species/human.yml
@@ -62,13 +62,13 @@
       points: 1
       required: false
     UndergarmentTop:
-      points: 1
+      points: 8 # Triad - Increased to 8.
       required: false
     UndergarmentBottom:
-      points: 1
+      points: 8 # Triad - Increased to 8.
       required: false
     Chest:
-      points: 1
+      points: 8 # Triad - Increased to 8.
       required: false
     Legs:
       points: 8 # imp 2<8

--- a/Resources/Prototypes/Species/moth.yml
+++ b/Resources/Prototypes/Species/moth.yml
@@ -67,22 +67,22 @@
       points: 1
       required: false
     Head:
-      points: 4 # imp 1<4
+      points: 8 # Triad - Increased to 8.
       required: false
     UndergarmentTop:
-      points: 1
+      points: 8 # Triad - Increased to 8.
       required: false
     UndergarmentBottom:
-      points: 1
+      points: 8 # Triad - Increased to 8.
       required: false
     Chest:
-      points: 4 # imp 1<4
+      points: 8 # Triad - Increased to 8.
       required: false
     Legs:
-      points: 4 # imp 2<4
+      points: 8 # Triad - Increased to 8.
       required: false
     Arms:
-      points: 4 # imp 2<4
+      points: 8 # Triad - Increased to 8.
       required: false
 
 - type: humanoidBaseSprite

--- a/Resources/Prototypes/Species/reptilian.yml
+++ b/Resources/Prototypes/Species/reptilian.yml
@@ -61,19 +61,19 @@
       points: 2 # WWDP-Edit
       required: false
     UndergarmentTop:
-      points: 1
+      points: 8 # Triad - Increased to 8.
       required: false
     UndergarmentBottom:
-      points: 1
+      points: 8 # Triad - Increased to 8.
       required: false
     Chest:
-      points: 3
+      points: 8 # Triad - Increased to 8.
       required: false
     Legs:
-      points: 2
+      points: 8 # Triad - Increased to 8.
       required: false
     Arms:
-      points: 2
+      points: 8 # Triad - Increased to 8.
       required: false
 
 - type: humanoidBaseSprite

--- a/Resources/Prototypes/Species/slime.yml
+++ b/Resources/Prototypes/Species/slime.yml
@@ -40,7 +40,7 @@
       points: 1
       required: false
     Chest:
-      points: 4 # imp 1<4
+      points: 8 # Triad - Increased to 8.
       required: false
     Legs:
       points: 8 # imp 4<8

--- a/Resources/Prototypes/Species/vox.yml
+++ b/Resources/Prototypes/Species/vox.yml
@@ -48,7 +48,7 @@
       points: 1
       required: false
     Head:
-      points: 1
+      points: 8 # Triad - Increased to 8.
       required: true
     Snout:
       points: 1
@@ -63,13 +63,13 @@
       required: true
       defaultMarkings: [ VoxLLegScales, VoxRLegScales, VoxRFootScales, VoxLFootScales ]
     UndergarmentTop:
-      points: 1
+      points: 8 # Triad - Increased to 8.
       required: false
     UndergarmentBottom:
-      points: 1
+      points: 8 # Triad - Increased to 8.
       required: false
     Chest:
-      points: 1
+      points: 8 # Triad - Increased to 8.
       required: false
     Overlay: # imp
       points: 4

--- a/Resources/Prototypes/_DV/Species/avali.yml
+++ b/Resources/Prototypes/_DV/Species/avali.yml
@@ -71,17 +71,17 @@
       defaultMarkings: [ AvaliEarsBase ]
     # Triad changes - Underwear.
     UndergarmentTop:
-      points: 1
+      points: 8
       required: false
     UndergarmentBottom:
-      points: 1
+      points: 8
       required: false
     # End Triad.
     Chest:
-      points: 1
+      points: 8 # Triad - Increased to 8.
       required: false
     Legs:
-      points: 2
+      points: 8 # Triad - Increased to 8.
       required: false
 #    UndergarmentTop:
 #      points: 1
@@ -90,7 +90,7 @@
 #      points: 1
 #      required: false
     Arms:
-      points: 4
+      points: 8 # Triad - Increased to 8.
       required: false
 
 - type: humanoidBaseSprite

--- a/Resources/Prototypes/_DV/Species/chitinid.yml
+++ b/Resources/Prototypes/_DV/Species/chitinid.yml
@@ -70,20 +70,20 @@
       required: false
     # Triad changes - Underwear.
     UndergarmentTop:
-      points: 1
+      points: 8
       required: false
     UndergarmentBottom:
-      points: 1
+      points: 8
       required: false
     # End Triad.
     Chest:
-      points: 1
+      points: 8 # Triad - Increased to 8.
       required: false
     Legs:
-      points: 6
+      points: 8 # Triad - Increased to 8.
       required: false
     Arms:
-      points: 6
+      points: 8 # Triad - Increased to 8.
       required: false
 
 - type: humanoidBaseSprite

--- a/Resources/Prototypes/_DV/Species/feroxi.yml
+++ b/Resources/Prototypes/_DV/Species/feroxi.yml
@@ -47,7 +47,7 @@
       points: 1
       required: false
     Head:
-      points: 3
+      points: 8 # Triad - Increased to 8.
       required: false
     HeadTop:
       points: 1
@@ -59,20 +59,20 @@
       defaultMarkings: [ FeroxiSnout ]
     # Triad changes - Underwear.
     UndergarmentTop:
-      points: 1
+      points: 8
       required: false
     UndergarmentBottom:
-      points: 1
+      points: 8
       required: false
     # End Triad.
     Chest:
-      points: 3
+      points: 8 # Triad - Increased to 8.
       required: false
     Arms:
-      points: 1
+      points: 8 # Triad - Increased to 8.
       required: false
     Legs:
-      points: 1
+      points: 8 # Triad - Increased to 8.
       required: false
     Tail:
       points: 1

--- a/Resources/Prototypes/_DV/Species/harpy.yml
+++ b/Resources/Prototypes/_DV/Species/harpy.yml
@@ -54,10 +54,10 @@
       defaultMarkings: [ HarpyEarsDefault ]
     # Triad changes - Underwear.
     UndergarmentTop:
-      points: 1
+      points: 8
       required: false
     UndergarmentBottom:
-      points: 1
+      points: 8
       required: false
     # End Triad.
     Chest:
@@ -65,7 +65,7 @@
       required: true
       defaultMarkings: [ HarpyChestDefault ]
     Legs:
-      points: 2
+      points: 8 # Triad - Increased to 8.
       required: false
     Arms:
       points: 1

--- a/Resources/Prototypes/_DV/Species/rodentia.yml
+++ b/Resources/Prototypes/_DV/Species/rodentia.yml
@@ -52,10 +52,10 @@
       required: true
       defaultMarkings: [ RodentiaTailDefault ]
     Legs:
-      points: 4
+      points: 8 # Triad - Increased to 8.
       required: false
     Arms:
-      points: 4
+      points: 8 # Triad - Increased to 8.
       required: false
     Snout:
       points: 1
@@ -69,14 +69,14 @@
       required: false
     # Triad changes - Underwear.
     UndergarmentTop:
-      points: 1
+      points: 8
       required: false
     UndergarmentBottom:
-      points: 1
+      points: 8
       required: false
     # End Triad.
     Chest:
-      points: 2
+      points: 8 # Triad - Increased to 8.
       required: false
 
 - type: humanoidBaseSprite

--- a/Resources/Prototypes/_DV/Species/vulpkanin.yml
+++ b/Resources/Prototypes/_DV/Species/vulpkanin.yml
@@ -51,21 +51,21 @@
       required: true
       defaultMarkings: [ VulpTail ]
     Head:
-      points: 3
+      points: 8 # Triad - Increased to 8.
       required: false
     # Triad changes - Underwear.
     UndergarmentTop:
-      points: 1
+      points: 8
       required: false
     UndergarmentBottom:
-      points: 1
+      points: 8
       required: false
     # End Triad.
     Legs:
-      points: 1
+      points: 8 # Triad - Increased to 8.
       required: false
     Arms:
-      points: 1
+      points: 8 # Triad - Increased to 8.
       required: false
     Snout:
       points: 1

--- a/Resources/Prototypes/_EinsteinEngines/Species/ipc.yml
+++ b/Resources/Prototypes/_EinsteinEngines/Species/ipc.yml
@@ -57,10 +57,10 @@
       defaultMarkings: [ MobIPCHeadDefault ]
     # Triad changes - Underwear.
     UndergarmentTop:
-      points: 1
+      points: 8
       required: false
     UndergarmentBottom:
-      points: 1
+      points: 8
       required: false
     # End Triad.
     Chest:

--- a/Resources/Prototypes/_Goobstation/Species/tajaran.yml
+++ b/Resources/Prototypes/_Goobstation/Species/tajaran.yml
@@ -31,20 +31,20 @@
       defaultMarkings: [ TajaranEarsBasic ]
     # Triad changes - Underwear.
     UndergarmentTop:
-      points: 1
+      points: 8
       required: false
     UndergarmentBottom:
-      points: 1
+      points: 8
       required: false
     # End Triad.
     Chest:
-      points: 1
+      points: 8 # Triad - Increased to 8.
       required: false
     Legs:
-      points: 2
+      points: 8 # Triad - Increased to 8.
       required: false
     Arms:
-      points: 2
+      points: 8 # Triad - Increased to 8.
       required: false
 
 - type: speciesBaseSprites

--- a/Resources/Prototypes/_Goobstation/Species/yowie.yml
+++ b/Resources/Prototypes/_Goobstation/Species/yowie.yml
@@ -61,10 +61,10 @@
       required: false
     # Triad changes - Underwear.
     UndergarmentTop:
-      points: 1
+      points: 8
       required: false
     UndergarmentBottom:
-      points: 1
+      points: 8
       required: false
     # End Triad.
     Chest:

--- a/Resources/Prototypes/_Moffstation/Species/resomi.yml
+++ b/Resources/Prototypes/_Moffstation/Species/resomi.yml
@@ -53,22 +53,22 @@
       required: true
       defaultMarkings: [ ResomiTailFeathered ]
     Legs:
-      points: 6
+      points: 8 # Triad - Increased to 8.
       required: false
     Arms:
-      points: 6
+      points: 8 # Triad - Increased to 8.
       required: false
     Head:
-      points: 4
+      points: 8 # Triad - Increased to 8.
       required: false
     HeadTop:
-      points: 4
+      points: 8 # Triad - Increased to 8.
       required: false
     HeadSide:
       points: 2
       required: false
     Chest:
-      points: 4
+      points: 8 # Triad - Increased to 8.
       required: false
 
 - type: humanoidBaseSprite

--- a/Resources/Prototypes/_Mono/Species/asakim.yml
+++ b/Resources/Prototypes/_Mono/Species/asakim.yml
@@ -153,10 +153,10 @@
       required: false
     # Triad changes - Underwear.
     UndergarmentTop:
-      points: 1
+      points: 8
       required: false
     UndergarmentBottom:
-      points: 1
+      points: 8
       required: false
     # End Triad.
     Chest:

--- a/Resources/Prototypes/_Mono/Species/protogen.yml
+++ b/Resources/Prototypes/_Mono/Species/protogen.yml
@@ -56,10 +56,10 @@
       defaultMarkings: [ ProtogenEars ]
     # Triad changes - Underwear.
     UndergarmentTop:
-      points: 1
+      points: 8
       required: false
     UndergarmentBottom:
-      points: 1
+      points: 8
       required: false
     # End Triad.
     Chest:

--- a/Resources/Prototypes/_NF/Species/goblin_species.yml
+++ b/Resources/Prototypes/_NF/Species/goblin_species.yml
@@ -56,20 +56,20 @@
 #      defaultMarkings: [ GoblinNoseBasic ]
     # Triad changes - Underwear.
     UndergarmentTop:
-      points: 1
+      points: 8 # Triad - Increased to 8.
       required: false
     UndergarmentBottom:
-      points: 1
+      points: 8 # Triad - Increased to 8.
       required: false
     # End Triad.
     Chest:
-      points: 1
+      points: 8 # Triad - Increased to 8.
       required: false
     Legs:
-      points: 2
+      points: 8 # Triad - Increased to 8.
       required: false
     Arms:
-      points: 2
+      points: 8 # Triad - Increased to 8.
       required: false
 
 - type: humanoidBaseSprite

--- a/Resources/Prototypes/_Obelisk/Species/hydrakin.yml
+++ b/Resources/Prototypes/_Obelisk/Species/hydrakin.yml
@@ -73,14 +73,14 @@
       defaultMarkings: [ HydrakinEarsDefault ]
     # Triad changes - Underwear.
     UndergarmentTop:
-      points: 1
+      points: 8
       required: false
     UndergarmentBottom:
-      points: 1
+      points: 8
       required: false
     # End Triad.
     Chest:
-      points: 4
+      points: 8 # Triad - Increased to 8.
       required: false
     Legs:
       points: 8 # imp 2<8


### PR DESCRIPTION
## About the PR
This PR changes marking points to 8 in most cases, excluding logical conflicts wherever I found them

Do not trust me on this PR because I have spent over 4 hours on this PR alone. Yes, the number changes were that annoying

## Why / Balance
This gives far, far more opportunities for customization. Players can get creative with markings in ways we cannot expect, and they undoubtedly love messing around with the lifted restrictions

This *also* fixes at least one issue with Vulpkanin being far too limited in arm markings

## Media
Players will make more comprehensible, good-looking characters than a somewhat sleep-deprived woman
<img width="189" height="299" alt="image" src="https://github.com/user-attachments/assets/99d63acd-2882-490a-8cca-31f75923a5ea" />


## Requirements
<!-- Confirm the following by placing an X in the brackets [X]: -->
- [X] I have read relevant guidelines/documentation to this PR found on [our devwiki](https://monolith-station.github.io/mono-docs/).
- [X] I have added media to this PR or it does not require an ingame showcase.
- [X] I can confirm this PR contains either no AI-generated content, or AI-generated content that meets our guidelines.
<!-- You should understand that not following the above may get your PR closed at maintainer’s discretion -->
<!-- When using AI, make sure you are already proficient in creating whatever content you are attempting to generate and that you already have experience contributing to SS14. This means using AI to enhance your preexisting workflow, not vibecoding. -->

## How to test
1. Try out all species
2. Check the new marking points. Make sure there are no logical conflicts worth worrying about

**Changelog**
:cl: Minerva
- tweak: Marking points have been increased for all species, with a few exclusions for categories. Have fun!
