### PR TITLE
Lower Tdf Playtime Reqs

### DIFF
--- a/Resources/Prototypes/_Triad/Roles/Jobs/Tdf/patrol_team_leader.yml
+++ b/Resources/Prototypes/_Triad/Roles/Jobs/Tdf/patrol_team_leader.yml
@@ -4,9 +4,18 @@
   description: job-description-tdf-patrol-team-leader
   playTimeTracker: JobTdfPatrolTeamLeader
   requirements:
+    - !type:OverallPlaytimeRequirement
+      time: 108000 # 30 hours
     - !type:DepartmentTimeRequirement
       department: Security
-      time: 90000 # 20 hours
+      time: 54000 # 15 hours
+  alternateRequirementSets:
+    longerPlaytimeLessSec:
+    - !type:OverallPlaytimeRequirement
+      time: 360000 # 100 hours
+    - !type:DepartmentTimeRequirement
+      department: Security
+      time: 18000 # 5 hours
   startingGear: TdfLeaderGear
   alwaysUseSpawner: true
   icon: JobIconTdfPatrolTeamLeader

--- a/Resources/Prototypes/_Triad/Roles/Jobs/Tdf/patrol_team_leader.yml
+++ b/Resources/Prototypes/_Triad/Roles/Jobs/Tdf/patrol_team_leader.yml
@@ -12,7 +12,7 @@
   alternateRequirementSets:
     longerPlaytimeLessSec:
     - !type:OverallPlaytimeRequirement
-      time: 360000 # 100 hours
+      time: 450000 # 125 hours
     - !type:DepartmentTimeRequirement
       department: Security
       time: 18000 # 5 hours

--- a/Resources/Prototypes/_Triad/Roles/Jobs/Tdf/warden.yml
+++ b/Resources/Prototypes/_Triad/Roles/Jobs/Tdf/warden.yml
@@ -6,10 +6,10 @@
   requirements:
     - !type:DepartmentTimeRequirement
       department: Security
-      time: 90000 # 25 hours
+      time: 72000 # 20 hours
     - !type:RoleTimeRequirement
       role: JobTdfPatrolTeamLeader
-      time: 3600 # 1 hour
+      time: 7200 # 2 hours
   startingGear: TdfWardenGear
   alwaysUseSpawner: true
   icon: JobIconTdfWarden


### PR DESCRIPTION
## About the PR
Noticed there has been a lack of leadership. Playtime requirements were quite high, so i lowered them.
Tweaked TDF playtime reqs:
- Warden now requires 20 hours of TDF and 2 hours of patrol team leader, rather than 25 and 1 hour of each respectively.
- PTL needs 30 hours overall playtime, with 15 hours in TDF. As an alternate playtime set, you can access patrol team leader with 5 hours in TDF if you have 125 hours overall playtime in the server.

**Changelog**
:cl:
- tweak: Warden now requires 20 hours of TDF time, rather than 25.
- tweak: Loosened patrol team leader requirements, now requires 15 hours of TDF and 30 hours of overall playtime.