### PR TITLE
Adding Monochromacy

### DIFF
--- a/Content.Client/Overlays/BlackAndWhiteOverlay.cs
+++ b/Content.Client/Overlays/BlackAndWhiteOverlay.cs
@@ -1,0 +1,47 @@
+using Robust.Client.Graphics;
+using Robust.Client.Player;
+using Robust.Shared.Enums;
+using Robust.Shared.Prototypes;
+
+namespace Content.Client.Overlays;
+
+public sealed partial class BlackAndWhiteOverlay : Overlay
+{
+    [Dependency] private readonly IEntityManager _entityManager = default!;
+    [Dependency] private readonly IPrototypeManager _prototypeManager = default!;
+    [Dependency] private readonly IPlayerManager _playerManager = default!;
+
+    public override OverlaySpace Space => OverlaySpace.WorldSpace;
+    public override bool RequestScreenTexture => true;
+    private readonly ShaderInstance _greyscaleShader;
+
+    public BlackAndWhiteOverlay()
+    {
+        IoCManager.InjectDependencies(this);
+        _greyscaleShader = _prototypeManager.Index<ShaderPrototype>("GreyscaleFullscreen").InstanceUnique();
+        ZIndex = 10; // draw this over the DamageOverlay, RainbowOverlay etc.
+    }
+
+    protected override bool BeforeDraw(in OverlayDrawArgs args)
+    {
+        if (!_entityManager.TryGetComponent(_playerManager.LocalEntity, out EyeComponent? eyeComp))
+            return false;
+
+        if (args.Viewport.Eye != eyeComp.Eye)
+            return false;
+
+        return true;
+    }
+
+    protected override void Draw(in OverlayDrawArgs args)
+    {
+        if (ScreenTexture == null)
+            return;
+
+        var handle = args.WorldHandle;
+        _greyscaleShader.SetParameter("SCREEN_TEXTURE", ScreenTexture);
+        handle.UseShader(_greyscaleShader);
+        handle.DrawRect(args.WorldBounds, Color.White);
+        handle.UseShader(null);
+    }
+}

--- a/Content.Client/Overlays/BlackAndWhiteOverlaySystem.cs
+++ b/Content.Client/Overlays/BlackAndWhiteOverlaySystem.cs
@@ -1,0 +1,34 @@
+using Content.Shared.Inventory.Events;
+using Content.Shared.Overlays;
+using Robust.Client.Graphics;
+using Robust.Client.Player;
+
+namespace Content.Client.Overlays;
+
+public sealed partial class BlackAndWhiteOverlaySystem : EquipmentHudSystem<BlackAndWhiteOverlayComponent>
+{
+    [Dependency] private readonly IOverlayManager _overlayMan = default!;
+
+    private BlackAndWhiteOverlay _overlay = default!;
+
+    public override void Initialize()
+    {
+        base.Initialize();
+
+        _overlay = new();
+    }
+
+    protected override void UpdateInternal(RefreshEquipmentHudEvent<BlackAndWhiteOverlayComponent> component)
+    {
+        base.UpdateInternal(component);
+
+        _overlayMan.AddOverlay(_overlay);
+    }
+
+    protected override void DeactivateInternal()
+    {
+        base.DeactivateInternal();
+
+        _overlayMan.RemoveOverlay(_overlay);
+    }
+}

--- a/Content.Shared/Overlays/BlackAndWhiteOverlayComponent.cs
+++ b/Content.Shared/Overlays/BlackAndWhiteOverlayComponent.cs
@@ -1,0 +1,10 @@
+using Robust.Shared.GameStates;
+
+namespace Content.Shared.Overlays;
+
+/// <summary>
+/// Makes the entity see everything in black and white by adding an overlay.
+/// When added to a clothing item it will also grant the wearer the same overlay.
+/// </summary>
+[RegisterComponent, NetworkedComponent]
+public sealed partial class BlackAndWhiteOverlayComponent : Component;

--- a/Resources/Locale/en-US/traits/traits.ftl
+++ b/Resources/Locale/en-US/traits/traits.ftl
@@ -15,6 +15,9 @@ permanent-blindness-trait-examined = [color=lightblue]{CAPITALIZE(POSS-ADJ($targ
 trait-lightweight-name = Lightweight Drunk
 trait-lightweight-desc = Alcohol has a stronger effect on you.
 
+trait-monochromancy-name = Monochromancy
+trait-monochromancy-desc = You are fully colorblind, everything you perceive ranges from blacks to whites.
+
 trait-muted-name = Muted
 trait-muted-desc = You can't speak.
 

--- a/Resources/Locale/en-US/traits/traits.ftl
+++ b/Resources/Locale/en-US/traits/traits.ftl
@@ -15,8 +15,8 @@ permanent-blindness-trait-examined = [color=lightblue]{CAPITALIZE(POSS-ADJ($targ
 trait-lightweight-name = Lightweight Drunk
 trait-lightweight-desc = Alcohol has a stronger effect on you.
 
-trait-monochromancy-name = Monochromancy
-trait-monochromancy-desc = You are fully colorblind, everything you perceive ranges from blacks to whites.
+trait-monochromacy-name = Monochromacy
+trait-monochromacy-desc = You are fully colorblind, everything you perceive ranges from blacks to whites.
 
 trait-muted-name = Muted
 trait-muted-desc = You can't speak.

--- a/Resources/Prototypes/_DV/Traits/disabilities.yml
+++ b/Resources/Prototypes/_DV/Traits/disabilities.yml
@@ -16,9 +16,9 @@
   - !type:HasTraitCondition
     trait: UltraVision
     invert: true
-  # - !type:HasTraitCondition
-  #   trait: Monochromacy
-  #   invert: true
+  - !type:HasTraitCondition
+    trait: Monochromacy
+    invert: true
   - !type:HasCompCondition
     component: Blindable
   effects:
@@ -48,27 +48,26 @@
   - !type:SpawnItemInHandEffect
     item: ClothingEyesGlasses
 
-# Mono - not implemented
-# - type: trait
-#   id: Monochromacy
-#   name: trait-monochromacy-name
-#   description: trait-monochromacy-desc
-#   category: Disabilities
-#   cost: -1
-#   conditions:
-#   - !type:HasTraitCondition
-#     trait: Blindness
-#     invert: true
-#   - !type:HasTraitCondition
-#     trait: Deuteranopia
-#     invert: true
-#   - !type:HasTraitCondition
-#     trait: UltraVision
-#     invert: true
-#   effects:
-#   - !type:AddCompsEffect
-#     components:
-#     - type: BlackAndWhiteOverlay
+- type: trait
+  id: Monochromacy
+  name: trait-monochromacy-name
+  description: trait-monochromacy-desc
+  category: Disabilities
+  cost: 0 # Triad: disabilities are RP, not a point economy.
+  conditions:
+  - !type:HasTraitCondition
+    trait: Blindness
+    invert: true
+  - !type:HasTraitCondition
+    trait: Deuteranopia
+    invert: true
+  - !type:HasTraitCondition
+    trait: UltraVision
+    invert: true
+  effects:
+  - !type:AddCompsEffect
+    components:
+    - type: BlackAndWhiteOverlay
 
 - type: trait
   id: Deuteranopia
@@ -80,9 +79,9 @@
   - !type:HasTraitCondition
     trait: Blindness
     invert: true
-  # - !type:HasTraitCondition
-  #   trait: Monochromacy
-  #   invert: true
+  - !type:HasTraitCondition
+    trait: Monochromacy
+    invert: true
   - !type:HasTraitCondition
     trait: UltraVision
     invert: true
@@ -104,9 +103,9 @@
   - !type:HasTraitCondition
     trait: Blindness
     invert: true
-  # - !type:HasTraitCondition
-  #   trait: Monochromacy
-  #   invert: true
+  - !type:HasTraitCondition
+    trait: Monochromacy
+    invert: true
   - !type:HasTraitCondition
     trait: Deuteranopia
     invert: true


### PR DESCRIPTION
## About the PR
<!-- What did you change? -->
<!-- If this is a code change, summarize at high level how your new code works. This makes it easier to review. -->
Added the Monochromacy trait as a disabililty.

## Why / Balance
<!-- Discuss how this would affect game balance or explain why it was changed. Link any relevant discussions or issues. -->
Who doesn't like more character traits?

## Media
<!-- Attach media if the PR makes ingame changes (clothing, items, features, etc). 
Small fixes/refactors are exempt. Media may be used in SS14 progress reports with credit. -->
<img width="1274" height="719" alt="image" src="https://github.com/user-attachments/assets/6feee55e-38ca-42b1-8f75-224133755e1c" />


## Requirements
<!-- Confirm the following by placing an X in the brackets [X]: -->
- [X] I have read relevant guidelines/documentation to this PR found on [our devwiki](https://monolith-station.github.io/mono-docs/).
- [X] I have added media to this PR or it does not require an ingame showcase.
- [X] I can confirm this PR contains either no AI-generated content, or AI-generated content that meets our guidelines.
<!-- You should understand that not following the above may get your PR closed at maintainer’s discretion -->
<!-- When using AI, make sure you are already proficient in creating whatever content you are attempting to generate and that you already have experience contributing to SS14. This means using AI to enhance your preexisting workflow, not vibecoding. -->

## How to test
<!-- Describe the way it can be tested -->
Add the character trait in the character menu silly head

## Breaking changes
<!-- List any breaking changes, including namespaces, public class/method/field changes, prototype renames; and provide instructions for fixing them. -->
No(?)

**Changelog**
<!-- Add a Changelog entry to make players aware of new features or changes that could affect gameplay.
Make sure to read the guidelines and take this Changelog template out of the comment block in order for it to show up.
Changelog must have a :cl: symbol, so the bot recognizes the changes and adds them to the game's changelog.
Remove this symbol for non-player facing PRs.-->
:cl:
- add: Added the Monochromacy disability.
