### PR TITLE
Shadekin Modifier Fixes

### DIFF
--- a/Resources/Prototypes/_StarLight/Damage/modifier_sets.yml
+++ b/Resources/Prototypes/_StarLight/Damage/modifier_sets.yml
@@ -10,7 +10,5 @@
     Asphyxiation: 1
     Cold: 0.75
     Heat: 1.2
-    Cellular: 0.25
-    Bloodloss: 1.35
-    Shock: 1.25
-    Radiation: 1.3
+    Cellular: 0.1
+    Radiation: 0.35

--- a/Resources/Prototypes/_StarLight/Entities/Mobs/Species/shadekin.yml
+++ b/Resources/Prototypes/_StarLight/Entities/Mobs/Species/shadekin.yml
@@ -92,7 +92,6 @@
                   min: 1
                   max: 1
             - !type:BurnBodyBehavior {}
-
     # BaseMobSpeciesOrganic overrides
     - type: Barotrauma
       damage:

--- a/Resources/ServerInfo/Guidebook/Mobs/Shadekin.xml
+++ b/Resources/ServerInfo/Guidebook/Mobs/Shadekin.xml
@@ -79,7 +79,7 @@
 
   [color=#897236][mono]──── [color=#cc3333][bold]LIABILITIES / INSURANCE FLAGS[/bold][/color] ───────────────────[/mono][/color]
 
-  [color=red][bold]▲ Warning:[/bold][/color] take [color=#ffa500][bold]30% more Heat damage[/bold][/color] than baseline. [color=#ffa500][bold]Naturally hemophilic[/bold][/color]. Insurance Tier A near nuclear reactors.
+  [color=red][bold]▲ Warning:[/bold][/color] Takes [color=#ffa500][bold]20% more Heat damage[/bold][/color] than baseline. [color=#ffa500][bold]Naturally hemophilic[/bold][/color]. Insurance Tier A near nuclear reactors.
 
   [color=#897236][mono]──── [color=#aa88cc][bold]PROVENANCE NOTE[/bold][/color] ─────────────────────────────────[/mono][/color]
 

--- a/Resources/ServerInfo/Guidebook/Mobs/Shadekin.xml
+++ b/Resources/ServerInfo/Guidebook/Mobs/Shadekin.xml
@@ -46,8 +46,6 @@
 
   [mono]  Pressure  [color=#897236]■■■[/color][color=#555555]□□[/color]  baseline[/mono]
 
-  [mono]  Shock     [color=#cc3333]■■[/color][color=#555555]□□□[/color]  25% vulnerable[/mono]
-
   [mono]  Bloodloss     [color=#ffa500]■[/color][color=#555555]□□□[/color]  100% higher bleedrate, 75% slower blood regeneration[/mono]
 
   [mono]  Genetic     [color=#1e90ff]■■■■■■■[/color][color=#555555]□[/color]  90% resistance
@@ -81,7 +79,7 @@
 
   [color=#897236][mono]──── [color=#cc3333][bold]LIABILITIES / INSURANCE FLAGS[/bold][/color] ───────────────────[/mono][/color]
 
-  [color=red][bold]▲ Warning:[/bold][/color] take [color=#ffa500][bold]30% more Heat damage, 25% more Shock damage[/bold][/color] than baseline. [color=#ffa500][bold]Naturally hemophilic[/bold][/color]. Insurance Tier A near nuclear reactors.
+  [color=red][bold]▲ Warning:[/bold][/color] take [color=#ffa500][bold]30% more Heat damage[/bold][/color] than baseline. [color=#ffa500][bold]Naturally hemophilic[/bold][/color]. Insurance Tier A near nuclear reactors.
 
   [color=#897236][mono]──── [color=#aa88cc][bold]PROVENANCE NOTE[/bold][/color] ─────────────────────────────────[/mono][/color]
 

--- a/Resources/ServerInfo/Guidebook/Mobs/Shadekin.xml
+++ b/Resources/ServerInfo/Guidebook/Mobs/Shadekin.xml
@@ -50,9 +50,9 @@
 
   [mono]  Bloodloss     [color=#ffa500]■[/color][color=#555555]□□□[/color]  100% higher bleedrate, 75% slower blood regeneration[/mono]
 
-  [mono]  Genetic     [color=#1e90ff]■■■■■[/color][color=#555555]□□□[/color]  75% resistance
+  [mono]  Genetic     [color=#1e90ff]■■■■■■■[/color][color=#555555]□[/color]  90% resistance
 
-  [mono]  Radiation    [color=#ffa500]■■[/color][color=#555555]□□□[/color]  30% vulnerable
+  [mono]  Radiation    [color=#ffa500]■■■[/color][color=#555555]□□[/color]  65% resistance
 
   [color=#999999][italic]“Their blood is nothing like anything we have seen before, yet it works similar to iron based blood. It's needlessly complex. Nightvision that outperforms anything we have made and strangely resilient genomes. Yet quite fragile. Weird cats. ”  — J.[/italic][/color]
 
@@ -65,7 +65,7 @@
   [color=#897236][mono]──── [color=#00ccff][bold]RESPIRATORY PROTOCOL[/bold][/color] ────────────────────────────[/mono][/color]
 
   - Breathes Oxygen.
-  - Pressure tolerance: safe [color=#1e90ff][bold]50–385 kPa[/bold][/color]; barotrauma outside [color=#ffa500][bold]20–550 kPa[/bold][/color].
+  - Pressure tolerance: safe [color=#1e90ff][bold]50-385 kPa[/bold][/color]; barotrauma outside [color=#ffa500][bold]20–550 kPa[/bold][/color].
 
   [color=#897236][mono]──── [color=#1e90ff][bold]WORKPLACE APTITUDES[/bold][/color] ─────────────────────────────[/mono][/color]
 
@@ -81,7 +81,7 @@
 
   [color=#897236][mono]──── [color=#cc3333][bold]LIABILITIES / INSURANCE FLAGS[/bold][/color] ───────────────────[/mono][/color]
 
-  [color=red][bold]▲ Warning:[/bold][/color] take [color=#ffa500][bold]30% more Heat damage, 25% more Shock damage and 30% more radiation damage[/bold][/color] than baseline. [color=#ffa500][bold]Naturally hemophilic[/bold][/color]. Insurance Tier A near nuclear reactors.
+  [color=red][bold]▲ Warning:[/bold][/color] take [color=#ffa500][bold]30% more Heat damage, 25% more Shock damage[/bold][/color] than baseline. [color=#ffa500][bold]Naturally hemophilic[/bold][/color]. Insurance Tier A near nuclear reactors.
 
   [color=#897236][mono]──── [color=#aa88cc][bold]PROVENANCE NOTE[/bold][/color] ─────────────────────────────────[/mono][/color]
 


### PR DESCRIPTION
## About the PR
- Gave shadekins 65% resistance to rads after discussion about modifier weaknesses. They should be able to resist uncommon hazards, as per their strange exodimensional biology.
- They now have a 90% resistance to genetic damage, from 75%
- Fixed them taking around 210% bloodloss damage, instead of 100%. They had a modifier that was causing them to take way too much

**Changelog**
:cl:
- tweak: Shadekins now have a 65% resistance to radiation
- tweak: Shadekins now have a 90% resistance to genetic damage, from 75%.
- fix: Fixed Shadekins taking too much bloodloss damage. They now take exactly twice as much from baseline, as intended.
