### PR TITLE
Finally Fix Station Records Computers with Ships

### DIFF
--- a/Content.Server/StationRecords/Systems/GeneralStationRecordConsoleSystem.cs
+++ b/Content.Server/StationRecords/Systems/GeneralStationRecordConsoleSystem.cs
@@ -14,15 +14,15 @@ using Content.Shared._NF.StationRecords; // Frontier
 
 namespace Content.Server.StationRecords.Systems;
 
-public sealed class GeneralStationRecordConsoleSystem : EntitySystem
+public sealed partial class GeneralStationRecordConsoleSystem : EntitySystem
 {
-    [Dependency] private readonly UserInterfaceSystem _ui = default!;
-    [Dependency] private readonly StationSystem _station = default!;
-    [Dependency] private readonly StationRecordsSystem _stationRecords = default!;
-    [Dependency] private readonly StationJobsSystem _stationJobsSystem = default!; // Frontier
-    [Dependency] private readonly AccessReaderSystem _access = default!; // Frontier
-    [Dependency] private readonly IPrototypeManager _proto = default!; // Frontier
-    [Dependency] private readonly IAdminLogManager _adminLog = default!; // Frontier
+    [Dependency] private UserInterfaceSystem _ui = default!;
+    [Dependency] private StationSystem _station = default!;
+    [Dependency] private StationRecordsSystem _stationRecords = default!;
+    [Dependency] private StationJobsSystem _stationJobsSystem = default!; // Frontier
+    [Dependency] private AccessReaderSystem _access = default!; // Frontier
+    [Dependency] private IPrototypeManager _proto = default!; // Frontier
+    [Dependency] private IAdminLogManager _adminLog = default!; // Frontier
 
     public override void Initialize()
     {
@@ -177,4 +177,16 @@ public sealed class GeneralStationRecordConsoleSystem : EntitySystem
         GeneralStationRecordConsoleState newState = new(id, record, listing, jobList, console.Filter, ent.Comp.CanDeleteEntries, advertisement);
         _ui.SetUiState(uid, GeneralStationRecordConsoleKey.Key, newState);
     }
+
+    // Triad start - accessing active keys and filters
+    public static void SetActiveKey(Entity<GeneralStationRecordConsoleComponent> ent, uint? key)
+    {
+        ent.Comp.ActiveKey = key;
+    }
+
+    public static void SetFilter(Entity<GeneralStationRecordConsoleComponent> ent, StationRecordsFilter? filter)
+    {
+        ent.Comp.Filter = filter;
+    }
+    // Triad end
 }

--- a/Content.Server/_Triad/Shipyard/ShipyardGridSaveSystem.cs
+++ b/Content.Server/_Triad/Shipyard/ShipyardGridSaveSystem.cs
@@ -24,12 +24,12 @@ using Robust.Shared.Serialization;
 using Robust.Shared.Serialization.Markdown.Mapping;
 using YamlDotNet.Core;
 using YamlDotNet.RepresentationModel;
-using Content.Server.Lathe.Components; // Triad
+using Content.Server.Lathe.Components;
 using Content.Server.Light.Components;
-using Content.Shared._Triad.Shipyard.Save; // Triad
-using Content.Shared.Lathe; // Triad
-using Content.Shared._Triad.Shipyard.Load; // Triad
-using Content.Shared._Triad.Shipyard.Save.Contraband; // Triad
+using Content.Shared._Triad.Shipyard.Save;
+using Content.Shared.Lathe;
+using Content.Shared._Triad.Shipyard.Load;
+using Content.Shared._Triad.Shipyard.Save.Contraband;
 using System.Linq;
 using Content.Shared.Containers;
 using Content.Shared.Doors.Components;
@@ -41,6 +41,8 @@ using Content.Server.Cargo.Systems;
 using Content.Shared._Triad.CCVar;
 using Robust.Shared.Configuration;
 using Content.Server.GameTicking;
+using Content.Server.StationRecords.Components;
+using Content.Server.StationRecords.Systems;
 
 namespace Content.Server._Triad.Shipyard;
 
@@ -53,17 +55,17 @@ public sealed partial class ShipyardGridSaveSystem : EntitySystem
 {
     [Dependency] private IEntityManager _entityManager = default!;
     [Dependency] private IEntitySystemManager _entitySystemManager = default!;
-    [Dependency] private PricingSystem _pricing = default!; // Triad
-    [Dependency] private IConfigurationManager _configManager = default!; // Triad
+    [Dependency] private PricingSystem _pricing = default!;
+    [Dependency] private IConfigurationManager _configManager = default!;
     [Dependency] private SharedContainerSystem _containerSystem = default!;
     [Dependency] private EntityLookupSystem _lookup = default!;
     [Dependency] private SharedDeviceLinkSystem _deviceLink = default!;
     [Dependency] private IPrototypeManager _prototypeManager = default!; // HardLight
-    [Dependency] private SharedTransformSystem _transform = default!; // Triad
-    [Dependency] private StationSystem _station = default!; // Triad
-    [Dependency] private ShuttleRecordsSystem _shuttleRecords = default!; // Triad
-    [Dependency] private TriadTamperPolicyService _tamperPolicy = default!; // Triad: tamper protection
-    [Dependency] private GameTicker _gameTicker = default!; // Triad: stamp audit rows with the round id
+    [Dependency] private SharedTransformSystem _transform = default!;
+    [Dependency] private StationSystem _station = default!;
+    [Dependency] private ShuttleRecordsSystem _shuttleRecords = default!;
+    [Dependency] private TriadTamperPolicyService _tamperPolicy = default!;
+    [Dependency] private GameTicker _gameTicker = default!;
 
     public List<ShipSaveLimitsPrototype> ShipSaveEntityLimits { get; private set; } = new();
 
@@ -279,12 +281,14 @@ public sealed partial class ShipyardGridSaveSystem : EntitySystem
             // Purge invalid entities
             PurgeInvalidEntities(gridUid);
 
-            // Triad: remove any edge spreaders, we cannot save these
+            // remove any edge spreaders, we cannot save these
             RemoveEdgeSpreaderComponentComponentsOnGrid(gridUid);
 
-            // Triad
             // Reset fabricators: disable loop/skip and cancel active jobs to prevent mid-save exceptions
             ResetFabricatorsOnGrid(gridUid);
+
+            // reset station records computers to prevent errors with StationRecordsFilter
+            ResetGeneralRecordsConsolesOnGrid(gridUid);
 
             // Remove repair data, it is re-added on load
             RemComp<ShipRepairDataComponent>(gridUid);
@@ -388,7 +392,6 @@ public sealed partial class ShipyardGridSaveSystem : EntitySystem
         }
     }
 
-    // Triad
     /// <summary>
     /// Resets all fabricators on the grid before saving: disables loop mode, disables skip mode,
     /// clears the queue, and cancels any active production job.
@@ -407,6 +410,22 @@ public sealed partial class ShipyardGridSaveSystem : EntitySystem
             lathe.Queue.Clear();
             lathe.CurrentRecipe = null;
             RemComp<LatheProducingComponent>(uid);
+        }
+    }
+
+    /// <summary>
+    /// Resets station records consoles on the grid to prevent serialization issues.
+    /// </summary>
+    private void ResetGeneralRecordsConsolesOnGrid(EntityUid gridUid)
+    {
+        var consoleQuery = _entityManager.EntityQueryEnumerator<GeneralStationRecordConsoleComponent, TransformComponent>();
+        while (consoleQuery.MoveNext(out var uid, out var console, out var xform))
+        {
+            if (xform.GridUid != gridUid)
+                continue;
+
+            GeneralStationRecordConsoleSystem.SetActiveKey((uid, console), null);
+            GeneralStationRecordConsoleSystem.SetFilter((uid, console), null);
         }
     }
 

--- a/Content.Server/_Triad/Shipyard/ShipyardSystem.Triad.cs
+++ b/Content.Server/_Triad/Shipyard/ShipyardSystem.Triad.cs
@@ -14,8 +14,8 @@ namespace Content.Server._NF.Shipyard.Systems;
 
 public sealed partial class ShipyardSystem : SharedShipyardSystem
 {
-    [Dependency] private readonly ShipyardGridSaveSystem _shipyardGridSave = default!;
-    [Dependency] private readonly UseDelaySystem _useDelay = default!;
+    [Dependency] private ShipyardGridSaveSystem _shipyardGridSave = default!;
+    [Dependency] private UseDelaySystem _useDelay = default!;
 
     /// <summary>
     /// Writes YAML data to a temporary file and attempts the same initial strict load path as purchase-from-file.


### PR DESCRIPTION
## About the PR
``StationRecordsFilter`` was causing serialization issues, so we reset the consoles when a ship is saved
This wouldn't throw if a player didn't mess with their station records computers, it's still good to fix this

## Technical details
Added ``SetActiveKey`` and ``SetFilter`` static methods to general records system so you can set that data

**Changelog**
:cl:
- fix: Fixed station records computer filters causing your ship to be unable to be saved.
