### PR TITLE
Bugfix: Emu Fork Oversight

### DIFF
--- a/Resources/Prototypes/Recipes/Lathes/Packs/robotics.yml
+++ b/Resources/Prototypes/Recipes/Lathes/Packs/robotics.yml
@@ -96,7 +96,7 @@
     - MechEquipmentGrabber
     - MechEquipmentHorn
     - MechEquipmentGrabberSmall
-    - MechEquipmentFork # Frontier
+    # - MechEquipmentFork # Frontier, Triad Edit
     - PowerCageSmall
     - PowerCageMedium
     - PowerCageHigh

--- a/Resources/Prototypes/_Mono/Research/mech_research.yml
+++ b/Resources/Prototypes/_Mono/Research/mech_research.yml
@@ -14,7 +14,6 @@
   - RipleyCentralElectronics
   - RipleyPeripheralsElectronics
   - MechEquipmentGrabber
-  - MechEquipmentFork # Triad - Cherrypick NF MechCargo. Moved here from RipleyAPLU.
   - RipleyMKIIHarness
   - RipleyUpgradeKit
   - ClarkeHarness
@@ -27,6 +26,7 @@
   technologyPrerequisites:
   - AdvancedParts
   position: 2, 10
+# Removed MechEquipmentFork - Triad change
 
 
 # - type: technology


### PR DESCRIPTION
## About the PR
Removed the PLU fork from the Ripley tech tree and exosuit fab

## Why / Balance
Frontier oversight, it was intended to be unremovable from the PLU and not intended to be installed elsewhere.

## Requirements
<!-- Confirm the following by placing an X in the brackets [X]: -->
- [X] I have read relevant guidelines/documentation to this PR found on [our devwiki](https://monolith-station.github.io/mono-docs/).
- [X] I have added media to this PR or it does not require an ingame showcase.
- [X] I can confirm this PR contains either no AI-generated content, or AI-generated content that meets our guidelines.
<!-- You should understand that not following the above may get your PR closed at maintainer’s discretion -->
<!-- When using AI, make sure you are already proficient in creating whatever content you are attempting to generate and that you already have experience contributing to SS14. This means using AI to enhance your preexisting workflow, not vibecoding. -->

## How to test
Boot up the envi
Check Ripley research tree
Spawn an exosuit fab
The recipe should not appear


**Changelog**
<!-- Add a Changelog entry to make players aware of new features or changes that could affect gameplay.
Make sure to read the guidelines and take this Changelog template out of the comment block in order for it to show up.
Changelog must have a :cl: symbol, so the bot recognizes the changes and adds them to the game's changelog.
Remove this symbol for non-player facing PRs.-->
:cl:
- remove: Removed Emu fork from tech tree and its respective fab
