### PR TITLE
Mech Fork Bugfix

### DIFF
--- a/Resources/Prototypes/Recipes/Lathes/Packs/robotics.yml
+++ b/Resources/Prototypes/Recipes/Lathes/Packs/robotics.yml
@@ -96,7 +96,7 @@
     - MechEquipmentGrabber
     - MechEquipmentHorn
     - MechEquipmentGrabberSmall
-    - MechEquipmentFork # Frontier
+    # - MechEquipmentFork # Frontier, Triad Edit
     - PowerCageSmall
     - PowerCageMedium
     - PowerCageHigh

--- a/Resources/Prototypes/Recipes/Lathes/Packs/robotics.yml
+++ b/Resources/Prototypes/Recipes/Lathes/Packs/robotics.yml
@@ -96,7 +96,7 @@
     - MechEquipmentGrabber
     - MechEquipmentHorn
     - MechEquipmentGrabberSmall
-    # - MechEquipmentFork # Frontier, Triad Edit
+    - MechEquipmentFork # Frontier
     - PowerCageSmall
     - PowerCageMedium
     - PowerCageHigh

--- a/Resources/Prototypes/_Mono/Research/mech_research.yml
+++ b/Resources/Prototypes/_Mono/Research/mech_research.yml
@@ -14,7 +14,6 @@
   - RipleyCentralElectronics
   - RipleyPeripheralsElectronics
   - MechEquipmentGrabber
-  - MechEquipmentFork # Triad - Cherrypick NF MechCargo. Moved here from RipleyAPLU.
   - RipleyMKIIHarness
   - RipleyUpgradeKit
   - ClarkeHarness
@@ -27,6 +26,7 @@
   technologyPrerequisites:
   - AdvancedParts
   position: 2, 10
+# Removed MechEquipmentFork - Triad change
 
 
 # - type: technology

--- a/Resources/Prototypes/_Mono/Research/mech_research.yml
+++ b/Resources/Prototypes/_Mono/Research/mech_research.yml
@@ -14,6 +14,7 @@
   - RipleyCentralElectronics
   - RipleyPeripheralsElectronics
   - MechEquipmentGrabber
+  - MechEquipmentFork
   - RipleyMKIIHarness
   - RipleyUpgradeKit
   - ClarkeHarness
@@ -26,7 +27,6 @@
   technologyPrerequisites:
   - AdvancedParts
   position: 2, 10
-# Removed MechEquipmentFork - Triad change
 
 
 # - type: technology

--- a/Resources/Prototypes/_NF/Entities/Objects/Specific/Mech/mecha_equipment.yml
+++ b/Resources/Prototypes/_NF/Entities/Objects/Specific/Mech/mecha_equipment.yml
@@ -24,3 +24,7 @@
   - type: ContainerContainer
     containers:
       item-container: !type:Container
+  - type: Tag
+    tags:
+    - IndustrialMech
+    - SmallMech


### PR DESCRIPTION
## About the PR
Reverts #367 and allows power fork to be inserted into small/industrial mechs

## Why / Balance
Intended behavior is that they're supposed to fit in mechs, problem was some tag fuckery between Goob and Frontier that prevented them from working normally.

## Requirements
<!-- Confirm the following by placing an X in the brackets [X]: -->
- [X] I have read relevant guidelines/documentation to this PR found on [our devwiki](https://monolith-station.github.io/mono-docs/).
- [X] I have added media to this PR or it does not require an ingame showcase.
- [X] I can confirm this PR contains either no AI-generated content, or AI-generated content that meets our guidelines.
<!-- You should understand that not following the above may get your PR closed at maintainer’s discretion -->
<!-- When using AI, make sure you are already proficient in creating whatever content you are attempting to generate and that you already have experience contributing to SS14. This means using AI to enhance your preexisting workflow, not vibecoding. -->

## How to test
Load up dev env
Spawn a Ripley, Ripley MK 2 and a Clarke
Spawn power forks
Insert them and load crates into crate rack

**Changelog**
<!-- Add a Changelog entry to make players aware of new features or changes that could affect gameplay.
Make sure to read the guidelines and take this Changelog template out of the comment block in order for it to show up.
Changelog must have a :cl: symbol, so the bot recognizes the changes and adds them to the game's changelog.
Remove this symbol for non-player facing PRs.-->
:cl:
- fix: Power forks not being able to be put in mechs.
