### PR TITLE
Makes Every Currently Purchaseable Ship Exped Capable.

### DIFF
--- a/Resources/Prototypes/_Mono/Shipyard/BlackMarket/bastion.yml
+++ b/Resources/Prototypes/_Mono/Shipyard/BlackMarket/bastion.yml
@@ -23,7 +23,7 @@
   minPlayers: 0
   stations:
     Bastion:
-      stationProto: StandardFrontierVessel
+      stationProto: StandardFrontierExpeditionVessel
       components:
         - type: StationNameSetup
           mapNameTemplate: 'Bastion PDV{1}'

--- a/Resources/Prototypes/_Mono/Shipyard/BlackMarket/carrion.yml
+++ b/Resources/Prototypes/_Mono/Shipyard/BlackMarket/carrion.yml
@@ -24,7 +24,7 @@
   minPlayers: 0
   stations:
     Carrion:
-      stationProto: StandardFrontierVessel
+      stationProto: StandardFrontierExpeditionVessel
       components:
         - type: StationNameSetup
           mapNameTemplate: 'Carrion PDV{1}'

--- a/Resources/Prototypes/_Mono/Shipyard/BlackMarket/europa.yml
+++ b/Resources/Prototypes/_Mono/Shipyard/BlackMarket/europa.yml
@@ -28,7 +28,7 @@
       gridComponents:
       - type: VesselInfo
         description: "The Saturn's Sister ship."
-      stationProto: StandardFrontierVessel
+      stationProto: StandardFrontierExpeditionVessel
       components:
         - type: StationNameSetup
           mapNameTemplate: 'Europa PDV{1}'

--- a/Resources/Prototypes/_Mono/Shipyard/BlackMarket/fenrir.yml
+++ b/Resources/Prototypes/_Mono/Shipyard/BlackMarket/fenrir.yml
@@ -24,7 +24,7 @@
   minPlayers: 0
   stations:
     Fenrir:
-      stationProto: StandardFrontierVessel
+      stationProto: StandardFrontierExpeditionVessel
       components:
         - type: StationNameSetup
           mapNameTemplate: 'Fenrir PDV{1}'

--- a/Resources/Prototypes/_Mono/Shipyard/BlackMarket/hazel.yml
+++ b/Resources/Prototypes/_Mono/Shipyard/BlackMarket/hazel.yml
@@ -24,7 +24,7 @@
   minPlayers: 0
   stations:
     Hazel:
-      stationProto: StandardFrontierVessel
+      stationProto: StandardFrontierExpeditionVessel
       components:
         - type: StationNameSetup
           mapNameTemplate: 'Hazel PDV{1}'

--- a/Resources/Prototypes/_Mono/Shipyard/BlackMarket/hourglass.yml
+++ b/Resources/Prototypes/_Mono/Shipyard/BlackMarket/hourglass.yml
@@ -23,7 +23,7 @@
   minPlayers: 0
   stations:
     Hourglass:
-      stationProto: StandardFrontierVessel
+      stationProto: StandardFrontierExpeditionVessel
       components:
         - type: StationNameSetup
           mapNameTemplate: 'Hourglass PDV{1}'

--- a/Resources/Prototypes/_Mono/Shipyard/BlackMarket/motleyanne.yml
+++ b/Resources/Prototypes/_Mono/Shipyard/BlackMarket/motleyanne.yml
@@ -26,7 +26,7 @@
   minPlayers: 0
   stations:
     MotleyAnne:
-      stationProto: StandardFrontierVessel
+      stationProto: StandardFrontierExpeditionVessel
       components:
       - type: StationNameSetup
         mapNameTemplate: 'Motley Anne PDV{1}'

--- a/Resources/Prototypes/_Mono/Shipyard/BlackMarket/neptune.yml
+++ b/Resources/Prototypes/_Mono/Shipyard/BlackMarket/neptune.yml
@@ -25,7 +25,7 @@
   minPlayers: 0
   stations:
     Neptune:
-      stationProto: StandardFrontierVessel
+      stationProto: StandardFrontierExpeditionVessel
       components:
         - type: StationNameSetup
           mapNameTemplate: 'Neptune PDV{1}'

--- a/Resources/Prototypes/_Mono/Shipyard/BlackMarket/saintie.yml
+++ b/Resources/Prototypes/_Mono/Shipyard/BlackMarket/saintie.yml
@@ -25,7 +25,7 @@
   minPlayers: 0
   stations:
     Saintie:
-      stationProto: StandardFrontierVessel
+      stationProto: StandardFrontierExpeditionVessel
       components:
         - type: StationNameSetup
           mapNameTemplate: 'Saintie PDV{1}'

--- a/Resources/Prototypes/_Mono/Shipyard/BlackMarket/scorpion.yml
+++ b/Resources/Prototypes/_Mono/Shipyard/BlackMarket/scorpion.yml
@@ -25,7 +25,7 @@
   minPlayers: 0
   stations:
     Scorpion:
-      stationProto: StandardFrontierVessel
+      stationProto: StandardFrontierExpeditionVessel
       components:
         - type: StationNameSetup
           mapNameTemplate: 'Scorpion PDV{1}'

--- a/Resources/Prototypes/_Mono/Shipyard/BlackMarket/spyglassmk2.yml
+++ b/Resources/Prototypes/_Mono/Shipyard/BlackMarket/spyglassmk2.yml
@@ -24,7 +24,7 @@
   minPlayers: 0
   stations:
     SpyglassMKII:
-      stationProto: StandardFrontierVessel
+      stationProto: StandardFrontierExpeditionVessel
       components:
         - type: StationNameSetup
           mapNameTemplate: 'Spyglass MKII PDV{1}'

--- a/Resources/Prototypes/_Mono/Shipyard/BlackMarket/tethys.yml
+++ b/Resources/Prototypes/_Mono/Shipyard/BlackMarket/tethys.yml
@@ -23,7 +23,7 @@
   minPlayers: 0
   stations:
     Tethys:
-      stationProto: StandardFrontierVessel
+      stationProto: StandardFrontierExpeditionVessel
       components:
         - type: StationNameSetup
           mapNameTemplate: 'Tethys PDV{1}'

--- a/Resources/Prototypes/_Mono/Shipyard/BlackMarket/vulture.yml
+++ b/Resources/Prototypes/_Mono/Shipyard/BlackMarket/vulture.yml
@@ -25,7 +25,7 @@
   minPlayers: 0
   stations:
     Vulture:
-      stationProto: StandardFrontierVessel
+      stationProto: StandardFrontierExpeditionVessel
       gridComponents:
       - type: VesselInfo
         description: "Its rumored that a Vulture razed a small planet on its own. Now its your turn to find out for yourself."

--- a/Resources/Prototypes/_Mono/Shipyard/Carrier/ample.yml
+++ b/Resources/Prototypes/_Mono/Shipyard/Carrier/ample.yml
@@ -21,7 +21,7 @@
   minPlayers: 0
   stations:
     Ample:
-      stationProto: StandardFrontierVessel
+      stationProto: StandardFrontierExpeditionVessel
       components:
       - type: StationNameSetup
         mapNameTemplate: 'Ample SNB{1}'

--- a/Resources/Prototypes/_Mono/Shipyard/Carrier/antlion.yml
+++ b/Resources/Prototypes/_Mono/Shipyard/Carrier/antlion.yml
@@ -22,7 +22,7 @@
   minPlayers: 0
   stations:
     Antlion:
-      stationProto: StandardFrontierVessel
+      stationProto: StandardFrontierExpeditionVessel
       components:
       - type: StationNameSetup
         mapNameTemplate: 'Antlion DIS{1}'

--- a/Resources/Prototypes/_Mono/Shipyard/Carrier/hound.yml
+++ b/Resources/Prototypes/_Mono/Shipyard/Carrier/hound.yml
@@ -10,7 +10,7 @@
   id: Hound
   parent: BaseVessel
   name: Hound
-  description: A security drone equiped with a prometheus cannon. 
+  description: A security drone equiped with a prometheus cannon.
   price: 35000
   category: Small
   group: Custom
@@ -30,7 +30,7 @@
   minPlayers: 0
   stations:
     Hound:
-      stationProto: StandardFrontierVessel
+      stationProto: StandardFrontierExpeditionVessel
       components:
       - type: StationNameSetup
         mapNameTemplate: 'Hound SEC{1}'

--- a/Resources/Prototypes/_Mono/Shipyard/Carrier/inertia.yml
+++ b/Resources/Prototypes/_Mono/Shipyard/Carrier/inertia.yml
@@ -31,7 +31,7 @@
   minPlayers: 0
   stations:
     Inertia:
-      stationProto: StandardFrontierVessel
+      stationProto: StandardFrontierExpeditionVessel
       components:
       - type: StationNameSetup
         mapNameTemplate: 'Inertia PDV{1}'

--- a/Resources/Prototypes/_Mono/Shipyard/Carrier/mock.yml
+++ b/Resources/Prototypes/_Mono/Shipyard/Carrier/mock.yml
@@ -31,7 +31,7 @@
   minPlayers: 0
   stations:
     Mock:
-      stationProto: StandardFrontierVessel
+      stationProto: StandardFrontierExpeditionVessel
       components:
       - type: StationNameSetup
         mapNameTemplate: 'Mock PDV{1}'

--- a/Resources/Prototypes/_Mono/Shipyard/Carrier/qj270.yml
+++ b/Resources/Prototypes/_Mono/Shipyard/Carrier/qj270.yml
@@ -24,7 +24,7 @@
   minPlayers: 0
   stations:
     QJ270:
-      stationProto: StandardFrontierVessel
+      stationProto: StandardFrontierExpeditionVessel
       components:
       - type: StationNameSetup
         mapNameTemplate: 'QJ-270 TSF{1}'

--- a/Resources/Prototypes/_Mono/Shipyard/Carrier/qj340.yml
+++ b/Resources/Prototypes/_Mono/Shipyard/Carrier/qj340.yml
@@ -24,7 +24,7 @@
   minPlayers: 0
   stations:
     QJ340:
-      stationProto: StandardFrontierVessel
+      stationProto: StandardFrontierExpeditionVessel
       components:
       - type: StationNameSetup
         mapNameTemplate: 'QJ-340 TSF{1}'

--- a/Resources/Prototypes/_Mono/Shipyard/Carrier/qj490.yml
+++ b/Resources/Prototypes/_Mono/Shipyard/Carrier/qj490.yml
@@ -24,7 +24,7 @@
   minPlayers: 0
   stations:
     QJ490:
-      stationProto: StandardFrontierVessel
+      stationProto: StandardFrontierExpeditionVessel
       components:
       - type: StationNameSetup
         mapNameTemplate: 'QJ-490 TSF{1}'

--- a/Resources/Prototypes/_Mono/Shipyard/Carrier/rook.yml
+++ b/Resources/Prototypes/_Mono/Shipyard/Carrier/rook.yml
@@ -30,7 +30,7 @@
   minPlayers: 0
   stations:
     Rook:
-      stationProto: StandardFrontierVessel
+      stationProto: StandardFrontierExpeditionVessel
       components:
       - type: StationNameSetup
         mapNameTemplate: 'Rook SEC{1}'

--- a/Resources/Prototypes/_Mono/Shipyard/Carrier/snakelet.yml
+++ b/Resources/Prototypes/_Mono/Shipyard/Carrier/snakelet.yml
@@ -31,7 +31,7 @@
   minPlayers: 0
   stations:
     Snakelet:
-      stationProto: StandardFrontierVessel
+      stationProto: StandardFrontierExpeditionVessel
       components:
       - type: StationNameSetup
         mapNameTemplate: 'Snakelet PDV{1}'

--- a/Resources/Prototypes/_Mono/Shipyard/Carrier/stratorat.yml
+++ b/Resources/Prototypes/_Mono/Shipyard/Carrier/stratorat.yml
@@ -21,7 +21,7 @@
   minPlayers: 0
   stations:
     StratoRat:
-      stationProto: StandardFrontierVessel
+      stationProto: StandardFrontierExpeditionVessel
       components:
       - type: StationNameSetup
         mapNameTemplate: 'Strato-Rat SNB{1}'

--- a/Resources/Prototypes/_Mono/Shipyard/Carrier/taser.yml
+++ b/Resources/Prototypes/_Mono/Shipyard/Carrier/taser.yml
@@ -30,7 +30,7 @@
   minPlayers: 0
   stations:
     Taser:
-      stationProto: StandardFrontierVessel
+      stationProto: StandardFrontierExpeditionVessel
       components:
       - type: StationNameSetup
         mapNameTemplate: 'Taser SEC{1}'

--- a/Resources/Prototypes/_Mono/Shipyard/Carrier/veska.yml
+++ b/Resources/Prototypes/_Mono/Shipyard/Carrier/veska.yml
@@ -24,7 +24,7 @@
   minPlayers: 0
   stations:
     Veska:
-      stationProto: StandardFrontierVessel
+      stationProto: StandardFrontierExpeditionVessel
       components:
       - type: StationNameSetup
         mapNameTemplate: 'Veska MIL{1}'

--- a/Resources/Prototypes/_Mono/Shipyard/Carrier/zephyr.yml
+++ b/Resources/Prototypes/_Mono/Shipyard/Carrier/zephyr.yml
@@ -24,7 +24,7 @@
   minPlayers: 0
   stations:
     Zephyr:
-      stationProto: StandardFrontierVessel
+      stationProto: StandardFrontierExpeditionVessel
       components:
       - type: StationNameSetup
         mapNameTemplate: 'Zephyr TSF{1}'

--- a/Resources/Prototypes/_Mono/Shipyard/Scrap/betelgeuse.yml
+++ b/Resources/Prototypes/_Mono/Shipyard/Scrap/betelgeuse.yml
@@ -25,7 +25,7 @@
   minPlayers: 0
   stations:
     Betelgeuse:
-      stationProto: StandardFrontierVessel
+      stationProto: StandardFrontierExpeditionVessel
       components:
         - type: StationNameSetup
           mapNameTemplate: 'Betelgeuse CIV{1}'

--- a/Resources/Prototypes/_Mono/Shipyard/Scrap/horsefly.yml
+++ b/Resources/Prototypes/_Mono/Shipyard/Scrap/horsefly.yml
@@ -27,7 +27,7 @@
   minPlayers: 0
   stations:
     Horsefly:
-      stationProto: StandardFrontierVessel
+      stationProto: StandardFrontierExpeditionVessel
       components:
         - type: StationNameSetup
           mapNameTemplate: 'Horsefly SRP-MIL{1}'

--- a/Resources/Prototypes/_Mono/Shipyard/Scrap/mite.yml
+++ b/Resources/Prototypes/_Mono/Shipyard/Scrap/mite.yml
@@ -27,7 +27,7 @@
   minPlayers: 0
   stations:
     Mite:
-      stationProto: StandardFrontierVessel
+      stationProto: StandardFrontierExpeditionVessel
       components:
         - type: StationNameSetup
           mapNameTemplate: 'Mite MIL{1}'

--- a/Resources/Prototypes/_Mono/Shipyard/Scrap/mudskipper.yml
+++ b/Resources/Prototypes/_Mono/Shipyard/Scrap/mudskipper.yml
@@ -26,7 +26,7 @@
   minPlayers: 0
   stations:
     Mudskipper:
-      stationProto: StandardFrontierVessel
+      stationProto: StandardFrontierExpeditionVessel
       components:
         - type: StationNameSetup
           mapNameTemplate: 'Mudskipper SRP{1}'

--- a/Resources/Prototypes/_Mono/Shipyard/Scrap/scallywag.yml
+++ b/Resources/Prototypes/_Mono/Shipyard/Scrap/scallywag.yml
@@ -29,7 +29,7 @@
   minPlayers: 0
   stations:
     Scallywag:
-      stationProto: StandardFrontierVessel
+      stationProto: StandardFrontierExpeditionVessel
       components:
         - type: StationNameSetup
           mapNameTemplate: 'Scallywag MIL{1}'

--- a/Resources/Prototypes/_Mono/Shipyard/Scrap/serkesh.yml
+++ b/Resources/Prototypes/_Mono/Shipyard/Scrap/serkesh.yml
@@ -28,7 +28,7 @@
   minPlayers: 0
   stations:
     Serkesh:
-      stationProto: StandardFrontierVessel
+      stationProto: StandardFrontierExpeditionVessel
       components:
         - type: StationNameSetup
           mapNameTemplate: 'Serkesh MIL{1}'

--- a/Resources/Prototypes/_Mono/Shipyard/Scrap/tick.yml
+++ b/Resources/Prototypes/_Mono/Shipyard/Scrap/tick.yml
@@ -27,7 +27,7 @@
   minPlayers: 0
   stations:
     Tick:
-      stationProto: StandardFrontierVessel
+      stationProto: StandardFrontierExpeditionVessel
       components:
         - type: StationNameSetup
           mapNameTemplate: 'Tick SRP-MIL{1}'

--- a/Resources/Prototypes/_Mono/Shipyard/Sr/bucket.yml
+++ b/Resources/Prototypes/_Mono/Shipyard/Sr/bucket.yml
@@ -21,7 +21,7 @@
   minPlayers: 0
   stations:
     Bucket:
-      stationProto: StandardFrontierVessel
+      stationProto: StandardFrontierExpeditionVessel
       components:
         - type: StationNameSetup
           mapNameTemplate: 'Bucket SRV{1}'

--- a/Resources/Prototypes/_Mono/Shipyard/Sr/hermes.yml
+++ b/Resources/Prototypes/_Mono/Shipyard/Sr/hermes.yml
@@ -21,7 +21,7 @@
   minPlayers: 0
   stations:
     Hermes:
-      stationProto: StandardFrontierVessel
+      stationProto: StandardFrontierExpeditionVessel
       components:
         - type: StationNameSetup
           mapNameTemplate: 'Hermes SRV{1}'

--- a/Resources/Prototypes/_Mono/Shipyard/Sr/manus.yml
+++ b/Resources/Prototypes/_Mono/Shipyard/Sr/manus.yml
@@ -26,7 +26,7 @@
   minPlayers: 0
   stations:
     Manus:
-      stationProto: StandardFrontierVessel
+      stationProto: StandardFrontierExpeditionVessel
       components:
         - type: StationNameSetup
           mapNameTemplate: 'Manus SEC{1}'

--- a/Resources/Prototypes/_Mono/Shipyard/Sr/pacem.yml
+++ b/Resources/Prototypes/_Mono/Shipyard/Sr/pacem.yml
@@ -5,7 +5,7 @@
 - type: vessel
   id: Pacem
   parent: BaseVessel
-  name: Pacem 
+  name: Pacem
   description: A patrol corvette for inner ring defense and patrol. Recommended crew of 2.
   price: 130000 #Roughly 20% markup from appraisegrid
   category: Medium
@@ -26,7 +26,7 @@
   minPlayers: 0
   stations:
     Pacem:
-      stationProto: StandardFrontierVessel
+      stationProto: StandardFrontierExpeditionVessel
       components:
         - type: StationNameSetup
           mapNameTemplate: 'Pacem SEC{1}'

--- a/Resources/Prototypes/_Mono/Shipyard/Sr/parabellum.yml
+++ b/Resources/Prototypes/_Mono/Shipyard/Sr/parabellum.yml
@@ -6,7 +6,7 @@
   id: Parabellum
   parent: BaseVessel
   name: Parabellum
-  description: The parabellum is a patrol boat, made for escorting and unsuprisingly; patrolling stations and depots from any malicious ships. It's equipped with EMP launchers, as well as a hybrid EMP Missile launcher for more tougher encounters. 
+  description: The parabellum is a patrol boat, made for escorting and unsuprisingly; patrolling stations and depots from any malicious ships. It's equipped with EMP launchers, as well as a hybrid EMP Missile launcher for more tougher encounters.
   price: 92000
   category: Medium
   group: Sr
@@ -26,7 +26,7 @@
   minPlayers: 0
   stations:
     Parabellum:
-      stationProto: StandardFrontierVessel
+      stationProto: StandardFrontierExpeditionVessel
       components:
         - type: StationNameSetup
           mapNameTemplate: 'Parabellum SEC{1}'

--- a/Resources/Prototypes/_Mono/Shipyard/Sr/solarsail.yml
+++ b/Resources/Prototypes/_Mono/Shipyard/Sr/solarsail.yml
@@ -21,7 +21,7 @@
   minPlayers: 0
   stations:
     Solarsail:
-      stationProto: StandardFrontierVessel
+      stationProto: StandardFrontierExpeditionVessel
       components:
         - type: StationNameSetup
           mapNameTemplate: 'Solarsail SRV{1}'

--- a/Resources/Prototypes/_Mono/Shipyard/Sr/spitfire.yml
+++ b/Resources/Prototypes/_Mono/Shipyard/Sr/spitfire.yml
@@ -26,7 +26,7 @@
   minPlayers: 0
   stations:
     Spitfire:
-      stationProto: StandardFrontierVessel
+      stationProto: StandardFrontierExpeditionVessel
       components:
         - type: StationNameSetup
           mapNameTemplate: 'Spitfire SEC{1}'

--- a/Resources/Prototypes/_Mono/Shipyard/Sr/sunrise.yml
+++ b/Resources/Prototypes/_Mono/Shipyard/Sr/sunrise.yml
@@ -26,7 +26,7 @@
   minPlayers: 0
   stations:
     Sunrise:
-      stationProto: StandardFrontierVessel
+      stationProto: StandardFrontierExpeditionVessel
       components:
         - type: StationNameSetup
           mapNameTemplate: 'Sunrise SEC{1}'

--- a/Resources/Prototypes/_Mono/Shipyard/Sr/thorax.yml
+++ b/Resources/Prototypes/_Mono/Shipyard/Sr/thorax.yml
@@ -26,7 +26,7 @@
   minPlayers: 0
   stations:
     Thorax:
-      stationProto: StandardFrontierVessel
+      stationProto: StandardFrontierExpeditionVessel
       components:
         - type: StationNameSetup
           mapNameTemplate: 'Thorax SEC{1}'

--- a/Resources/Prototypes/_Mono/Shipyard/Syndicate/hunter.yml
+++ b/Resources/Prototypes/_Mono/Shipyard/Syndicate/hunter.yml
@@ -20,7 +20,7 @@
   minPlayers: 0
   stations:
     Hunter:
-      stationProto: StandardFrontierVessel
+      stationProto: StandardFrontierExpeditionVessel
       components:
         - type: StationNameSetup
           mapNameTemplate: 'Hunter SYN{1}'

--- a/Resources/Prototypes/_Mono/Shipyard/Syndicate/hydra.yml
+++ b/Resources/Prototypes/_Mono/Shipyard/Syndicate/hydra.yml
@@ -20,7 +20,7 @@
   minPlayers: 0
   stations:
     Hydra:
-      stationProto: StandardFrontierVessel
+      stationProto: StandardFrontierExpeditionVessel
       components:
         - type: StationNameSetup
           mapNameTemplate: 'Hydra SYN{1}'

--- a/Resources/Prototypes/_Mono/Shipyard/Syndicate/infiltrator.yml
+++ b/Resources/Prototypes/_Mono/Shipyard/Syndicate/infiltrator.yml
@@ -20,7 +20,7 @@
   minPlayers: 0
   stations:
     Infiltrator:
-      stationProto: StandardFrontierVessel
+      stationProto: StandardFrontierExpeditionVessel
       components:
         - type: StationNameSetup
           mapNameTemplate: 'Infiltrator SYN{1}'

--- a/Resources/Prototypes/_Mono/Shipyard/Syndicate/talon.yml
+++ b/Resources/Prototypes/_Mono/Shipyard/Syndicate/talon.yml
@@ -20,7 +20,7 @@
   minPlayers: 0
   stations:
     Talon:
-      stationProto: StandardFrontierVessel
+      stationProto: StandardFrontierExpeditionVessel
       components:
         - type: StationNameSetup
           mapNameTemplate: 'Talon SYN{1}'

--- a/Resources/Prototypes/_Mono/Shipyard/Valkyrie.yml
+++ b/Resources/Prototypes/_Mono/Shipyard/Valkyrie.yml
@@ -27,7 +27,7 @@
   minPlayers: 0
   stations:
     Valkyrie:
-      stationProto: StandardFrontierVessel
+      stationProto: StandardFrontierExpeditionVessel
       components:
         - type: StationNameSetup
           mapNameTemplate: 'Valkyrie MIL{1}'

--- a/Resources/Prototypes/_Mono/Shipyard/archer.yml
+++ b/Resources/Prototypes/_Mono/Shipyard/archer.yml
@@ -27,7 +27,7 @@
   minPlayers: 0
   stations:
     Archer:
-      stationProto: StandardFrontierVessel
+      stationProto: StandardFrontierExpeditionVessel
       components:
         - type: StationNameSetup
           mapNameTemplate: 'Archer MIL{1}'

--- a/Resources/Prototypes/_Mono/Shipyard/argent.yml
+++ b/Resources/Prototypes/_Mono/Shipyard/argent.yml
@@ -26,7 +26,7 @@
   minPlayers: 0
   stations:
     Argent:
-      stationProto: StandardFrontierVessel
+      stationProto: StandardFrontierExpeditionVessel
       components:
         - type: StationNameSetup
           mapNameTemplate: 'Argent CIV{1}'

--- a/Resources/Prototypes/_Mono/Shipyard/arribane.yml
+++ b/Resources/Prototypes/_Mono/Shipyard/arribane.yml
@@ -26,7 +26,7 @@
   minPlayers: 0
   stations:
     Arribane:
-      stationProto: StandardFrontierVessel
+      stationProto: StandardFrontierExpeditionVessel
       components:
         - type: StationNameSetup
           mapNameTemplate: 'Arribane CIV{1}'

--- a/Resources/Prototypes/_Mono/Shipyard/artemis.yml
+++ b/Resources/Prototypes/_Mono/Shipyard/artemis.yml
@@ -9,7 +9,7 @@
   parent: BaseVessel
   name: HME Artemis
   description: The Artemis is a compact ambulance ship, designed to rescue patients quickly, and exfiltrate as fast as they arrived.
-  price: 34000 # Its a barebones med ship, basically acting as a paramedic ship. 
+  price: 34000 # Its a barebones med ship, basically acting as a paramedic ship.
   category: Small
   group: Medical
   shuttlePath: /Maps/_Mono/Shuttles/artemis.yml
@@ -26,7 +26,7 @@
   minPlayers: 0
   stations:
     Artemis:
-      stationProto: StandardFrontierVessel
+      stationProto: StandardFrontierExpeditionVessel
       components:
         - type: StationNameSetup
           mapNameTemplate: 'Artemis MED{1}'

--- a/Resources/Prototypes/_Mono/Shipyard/autumn.yml
+++ b/Resources/Prototypes/_Mono/Shipyard/autumn.yml
@@ -26,7 +26,7 @@
   minPlayers: 0
   stations:
     Autumn:
-      stationProto: StandardFrontierVessel
+      stationProto: StandardFrontierExpeditionVessel
       components:
         - type: StationNameSetup
           mapNameTemplate: 'Autumn CIV{1}'

--- a/Resources/Prototypes/_Mono/Shipyard/baeg.yml
+++ b/Resources/Prototypes/_Mono/Shipyard/baeg.yml
@@ -27,7 +27,7 @@
   minPlayers: 0
   stations:
     Baeg:
-      stationProto: StandardFrontierVessel
+      stationProto: StandardFrontierExpeditionVessel
       components:
         - type: StationNameSetup
           mapNameTemplate: 'Baeg CIV{1}'

--- a/Resources/Prototypes/_Mono/Shipyard/borer.yml
+++ b/Resources/Prototypes/_Mono/Shipyard/borer.yml
@@ -26,7 +26,7 @@
   minPlayers: 0
   stations:
     Borer:
-      stationProto: StandardFrontierVessel
+      stationProto: StandardFrontierExpeditionVessel
       components:
         - type: StationNameSetup
           mapNameTemplate: 'Borer CIV{1}'

--- a/Resources/Prototypes/_Mono/Shipyard/bratan.yml
+++ b/Resources/Prototypes/_Mono/Shipyard/bratan.yml
@@ -13,7 +13,7 @@
   id: Bratan
   parent: BaseVessel
   name: PB Bratan
-  description: A mobile nightclub, cafeteria, hydroponics, and secret drug lab and smuggling ship, all in one package! Brought to you by the Paycheck Bratva. 
+  description: A mobile nightclub, cafeteria, hydroponics, and secret drug lab and smuggling ship, all in one package! Brought to you by the Paycheck Bratva.
   price: 142000
   category: Large
   group: Shipyard
@@ -38,7 +38,7 @@
   minPlayers: 0
   stations:
     Bratan:
-      stationProto: StandardFrontierVessel
+      stationProto: StandardFrontierExpeditionVessel
       components:
         - type: StationNameSetup
           mapNameTemplate: 'Bratan CIV{1}'

--- a/Resources/Prototypes/_Mono/Shipyard/brute.yml
+++ b/Resources/Prototypes/_Mono/Shipyard/brute.yml
@@ -26,7 +26,7 @@
   minPlayers: 0
   stations:
     Brute:
-      stationProto: StandardFrontierVessel
+      stationProto: StandardFrontierExpeditionVessel
       components:
         - type: StationNameSetup
           mapNameTemplate: 'Brute CIV{1}'

--- a/Resources/Prototypes/_Mono/Shipyard/canister.yml
+++ b/Resources/Prototypes/_Mono/Shipyard/canister.yml
@@ -27,7 +27,7 @@
   minPlayers: 0
   stations:
     Canister:
-      stationProto: StandardFrontierVessel
+      stationProto: StandardFrontierExpeditionVessel
       components:
         - type: StationNameSetup
           mapNameTemplate: 'Canister CIV{1}'

--- a/Resources/Prototypes/_Mono/Shipyard/caracara.yml
+++ b/Resources/Prototypes/_Mono/Shipyard/caracara.yml
@@ -2,13 +2,13 @@
 # GitHub: UnicornOnLSD
 # Discord: unicornonlsd
 
-# Shuttle Notes: base is around 59K with 12K added markup 
+# Shuttle Notes: base is around 59K with 12K added markup
 #
 - type: vessel
   id: caracara
   parent: BaseVessel
   name: MI-COR Caracara
-  description: A Militia Ironworks salvage frigate fitted with an Apollo super‑mining laser. Its forward cockpit offers a clear view of the dig site. Includes an  ultra‑efficient pinch reactor, basic FTL, and a compact galley for long shifts in the belt. When paired with the Apollo, its three 20 mm mounts provide adequate defensive fire. 
+  description: A Militia Ironworks salvage frigate fitted with an Apollo super‑mining laser. Its forward cockpit offers a clear view of the dig site. Includes an  ultra‑efficient pinch reactor, basic FTL, and a compact galley for long shifts in the belt. When paired with the Apollo, its three 20 mm mounts provide adequate defensive fire.
   price: 71000
   category: Medium
   group: Shipyard
@@ -16,9 +16,9 @@
   guidebookPage: null
   class:
   - Salvage
-  - frigate 
+  - frigate
   engine:
-  - plasma 
+  - plasma
 
 - type: gameMap
   id: caracara
@@ -27,7 +27,7 @@
   minPlayers: 0
   stations:
     caracara:
-      stationProto: StandardFrontierVessel
+      stationProto: StandardFrontierExpeditionVessel
       components:
         - type: StationNameSetup
           mapNameTemplate: 'Caracara CIV{1}'

--- a/Resources/Prototypes/_Mono/Shipyard/claymore.yml
+++ b/Resources/Prototypes/_Mono/Shipyard/claymore.yml
@@ -1,5 +1,5 @@
 # Author Info
-# GitHub:Rubeebeebee 
+# GitHub:Rubeebeebee
 # Discord: rubeebee
 
 # Shuttle Notes:
@@ -29,7 +29,7 @@
   minPlayers: 0
   stations:
     Claymore:
-      stationProto: StandardFrontierVessel
+      stationProto: StandardFrontierExpeditionVessel
       components:
         - type: StationNameSetup
           mapNameTemplate: 'Claymore MIL{1}'

--- a/Resources/Prototypes/_Mono/Shipyard/dervi.yml
+++ b/Resources/Prototypes/_Mono/Shipyard/dervi.yml
@@ -24,7 +24,7 @@
   minPlayers: 0
   stations:
     Dervi:
-      stationProto: StandardFrontierVessel
+      stationProto: StandardFrontierExpeditionVessel
       components:
         - type: StationNameSetup
           mapNameTemplate: 'Dervi MED{1}'

--- a/Resources/Prototypes/_Mono/Shipyard/ethereal.yml
+++ b/Resources/Prototypes/_Mono/Shipyard/ethereal.yml
@@ -7,7 +7,7 @@
   id: Ethereal
   parent: BaseVessel
   name: NS Ethereal
-  description: A science vessel shaped like a butterfly. Comes facilities to accomodate botany and artifact research, as well as chemistry. Comes with a pool & bar. 
+  description: A science vessel shaped like a butterfly. Comes facilities to accomodate botany and artifact research, as well as chemistry. Comes with a pool & bar.
   price: 120000
   category: Large
   group: Shipyard
@@ -30,7 +30,7 @@
   minPlayers: 0
   stations:
     Ethereal:
-      stationProto: StandardFrontierVessel
+      stationProto: StandardFrontierExpeditionVessel
       components:
         - type: StationNameSetup
           mapNameTemplate: 'Ethereal CIV{1}'

--- a/Resources/Prototypes/_Mono/Shipyard/femur.yml
+++ b/Resources/Prototypes/_Mono/Shipyard/femur.yml
@@ -27,7 +27,7 @@
   minPlayers: 0
   stations:
     Femur:
-      stationProto: StandardFrontierVessel
+      stationProto: StandardFrontierExpeditionVessel
       components:
         - type: StationNameSetup
           mapNameTemplate: 'Femur MIL{1}'

--- a/Resources/Prototypes/_Mono/Shipyard/hammerhead.yml
+++ b/Resources/Prototypes/_Mono/Shipyard/hammerhead.yml
@@ -32,7 +32,7 @@
   minPlayers: 0
   stations:
     Hammerhead:
-      stationProto: StandardFrontierVessel
+      stationProto: StandardFrontierExpeditionVessel
       components:
         - type: StationNameSetup
           mapNameTemplate: 'Hammerhead MIL{1}'

--- a/Resources/Prototypes/_Mono/Shipyard/iapetus.yml
+++ b/Resources/Prototypes/_Mono/Shipyard/iapetus.yml
@@ -26,7 +26,7 @@
   minPlayers: 0
   stations:
     Iapetus:
-      stationProto: StandardFrontierVessel
+      stationProto: StandardFrontierExpeditionVessel
       components:
         - type: StationNameSetup
           mapNameTemplate: 'Iapetus CIV{1}'

--- a/Resources/Prototypes/_Mono/Shipyard/intermission.yml
+++ b/Resources/Prototypes/_Mono/Shipyard/intermission.yml
@@ -31,7 +31,7 @@
   minPlayers: 0
   stations:
     Intermission:
-      stationProto: StandardFrontierVessel
+      stationProto: StandardFrontierExpeditionVessel
       components:
         - type: StationNameSetup
           mapNameTemplate: 'Intermission MED{1}'

--- a/Resources/Prototypes/_Mono/Shipyard/jitterbug.yml
+++ b/Resources/Prototypes/_Mono/Shipyard/jitterbug.yml
@@ -29,7 +29,7 @@
   minPlayers: 0
   stations:
     Jitterbug:
-      stationProto: StandardFrontierVessel
+      stationProto: StandardFrontierExpeditionVessel
       components:
         - type: StationNameSetup
           mapNameTemplate: 'Jitterbug CIV{1}'

--- a/Resources/Prototypes/_Mono/Shipyard/kestrel.yml
+++ b/Resources/Prototypes/_Mono/Shipyard/kestrel.yml
@@ -26,7 +26,7 @@
   minPlayers: 0
   stations:
     Kestrel:
-      stationProto: StandardFrontierVessel
+      stationProto: StandardFrontierExpeditionVessel
       components:
         - type: StationNameSetup
           mapNameTemplate: 'Kestrel CIV{1}'

--- a/Resources/Prototypes/_Mono/Shipyard/kuldi.yml
+++ b/Resources/Prototypes/_Mono/Shipyard/kuldi.yml
@@ -29,7 +29,7 @@
   minPlayers: 0
   stations:
     Kuldi:
-      stationProto: StandardFrontierVessel
+      stationProto: StandardFrontierExpeditionVessel
       components:
         - type: StationNameSetup
           mapNameTemplate: 'Kuldi MED{1}'

--- a/Resources/Prototypes/_Mono/Shipyard/kunai.yml
+++ b/Resources/Prototypes/_Mono/Shipyard/kunai.yml
@@ -28,7 +28,7 @@
   minPlayers: 0
   stations:
     Kunai:
-      stationProto: StandardFrontierVessel
+      stationProto: StandardFrontierExpeditionVessel
       components:
         - type: StationNameSetup
           mapNameTemplate: 'Kunai MIL{1}'

--- a/Resources/Prototypes/_Mono/Shipyard/leaf.yml
+++ b/Resources/Prototypes/_Mono/Shipyard/leaf.yml
@@ -27,7 +27,7 @@
   minPlayers: 0
   stations:
     Leaf:
-      stationProto: StandardFrontierVessel
+      stationProto: StandardFrontierExpeditionVessel
       components:
         - type: StationNameSetup
           mapNameTemplate: 'Leaf MED{1}'

--- a/Resources/Prototypes/_Mono/Shipyard/mcchicken.yml
+++ b/Resources/Prototypes/_Mono/Shipyard/mcchicken.yml
@@ -26,7 +26,7 @@
   minPlayers: 0
   stations:
     McChicken:
-      stationProto: StandardFrontierVessel
+      stationProto: StandardFrontierExpeditionVessel
       components:
         - type: StationNameSetup
           mapNameTemplate: 'McChicken CIV{1}'

--- a/Resources/Prototypes/_Mono/Shipyard/mcchilly.yml
+++ b/Resources/Prototypes/_Mono/Shipyard/mcchilly.yml
@@ -28,7 +28,7 @@
   minPlayers: 0
   stations:
     McChilly:
-      stationProto: StandardFrontierVessel
+      stationProto: StandardFrontierExpeditionVessel
       components:
         - type: StationNameSetup
           mapNameTemplate: 'McChilly CIV{1}'

--- a/Resources/Prototypes/_Mono/Shipyard/mclass.yml
+++ b/Resources/Prototypes/_Mono/Shipyard/mclass.yml
@@ -26,7 +26,7 @@
   minPlayers: 0
   stations:
     MClass:
-      stationProto: StandardFrontierVessel
+      stationProto: StandardFrontierExpeditionVessel
       components:
         - type: StationNameSetup
           mapNameTemplate: 'M-Class CIV{1}'

--- a/Resources/Prototypes/_Mono/Shipyard/medicus.yml
+++ b/Resources/Prototypes/_Mono/Shipyard/medicus.yml
@@ -29,7 +29,7 @@
   minPlayers: 0
   stations:
     Medicus:
-      stationProto: StandardFrontierVessel
+      stationProto: StandardFrontierExpeditionVessel
       components:
         - type: StationNameSetup
           mapNameTemplate: 'Medicus MED{1}'

--- a/Resources/Prototypes/_Mono/Shipyard/noble.yml
+++ b/Resources/Prototypes/_Mono/Shipyard/noble.yml
@@ -25,7 +25,7 @@
   minPlayers: 0
   stations:
     Noble:
-      stationProto: StandardFrontierVessel
+      stationProto: StandardFrontierExpeditionVessel
       components:
         - type: StationNameSetup
           mapNameTemplate: 'Noble CIV{1}'

--- a/Resources/Prototypes/_Mono/Shipyard/notch.yml
+++ b/Resources/Prototypes/_Mono/Shipyard/notch.yml
@@ -26,7 +26,7 @@
   minPlayers: 0
   stations:
     Notch:
-      stationProto: StandardFrontierVessel
+      stationProto: StandardFrontierExpeditionVessel
       components:
         - type: StationNameSetup
           mapNameTemplate: 'Notch CIV{1}'

--- a/Resources/Prototypes/_Mono/Shipyard/odenta.yml
+++ b/Resources/Prototypes/_Mono/Shipyard/odenta.yml
@@ -8,7 +8,7 @@
 - type: vessel
   id: Odenta
   parent: BaseVessel
-  name: MI-COR Odenta 
+  name: MI-COR Odenta
   description: The Odenta is a heavily armored Medical Destroyer built for high-risk rescues and medical work. Armed with dual Prometheus Laser Cannons, a 255mm Bofors,a Draupnir 30mm Chaingun, 20mm, and PD lasers to shield its onboard Chemical Bay and Cryonics suite. Has MIL IFF.
   price: 112000 # 98K base + markup
   category: Medium
@@ -29,7 +29,7 @@
   minPlayers: 0
   stations:
     Odenta:
-      stationProto: StandardFrontierVessel
+      stationProto: StandardFrontierExpeditionVessel
       components:
         - type: StationNameSetup
           mapNameTemplate: 'Odenta MIL{1}'

--- a/Resources/Prototypes/_Mono/Shipyard/olympus.yml
+++ b/Resources/Prototypes/_Mono/Shipyard/olympus.yml
@@ -25,7 +25,7 @@
   minPlayers: 0
   stations:
     Olympus:
-      stationProto: StandardFrontierVessel
+      stationProto: StandardFrontierExpeditionVessel
       components:
         - type: StationNameSetup
           mapNameTemplate: 'Olympus CIV{1}'

--- a/Resources/Prototypes/_Mono/Shipyard/peregrine.yml
+++ b/Resources/Prototypes/_Mono/Shipyard/peregrine.yml
@@ -25,7 +25,7 @@
   minPlayers: 0
   stations:
     Peregrine:
-      stationProto: StandardFrontierVessel
+      stationProto: StandardFrontierExpeditionVessel
       components:
         - type: StationNameSetup
           mapNameTemplate: 'Peregrine CIV{1}'

--- a/Resources/Prototypes/_Mono/Shipyard/phaeron.yml
+++ b/Resources/Prototypes/_Mono/Shipyard/phaeron.yml
@@ -29,7 +29,7 @@
   minPlayers: 0
   stations:
     Phaeron:
-      stationProto: StandardFrontierVessel
+      stationProto: StandardFrontierExpeditionVessel
       components:
         - type: StationNameSetup
           mapNameTemplate: 'Phaeron CIV{1}'

--- a/Resources/Prototypes/_Mono/Shipyard/phantom.yml
+++ b/Resources/Prototypes/_Mono/Shipyard/phantom.yml
@@ -28,7 +28,7 @@
   minPlayers: 0
   stations:
     Phantom:
-      stationProto: StandardFrontierVessel
+      stationProto: StandardFrontierExpeditionVessel
       components:
         - type: StationNameSetup
           mapNameTemplate: 'Phantom MED{1}'

--- a/Resources/Prototypes/_Mono/Shipyard/pillbox.yml
+++ b/Resources/Prototypes/_Mono/Shipyard/pillbox.yml
@@ -20,7 +20,7 @@
   minPlayers: 0
   stations:
     Pillbox:
-      stationProto: StandardFrontierVessel
+      stationProto: StandardFrontierExpeditionVessel
       components:
         - type: StationNameSetup
           mapNameTemplate: 'Pillbox CIV{1}'

--- a/Resources/Prototypes/_Mono/Shipyard/piva.yml
+++ b/Resources/Prototypes/_Mono/Shipyard/piva.yml
@@ -26,7 +26,7 @@
   minPlayers: 0
   stations:
     Piva:
-      stationProto: StandardFrontierVessel
+      stationProto: StandardFrontierExpeditionVessel
       components:
         - type: StationNameSetup
           mapNameTemplate: 'Piva CIV{1}'

--- a/Resources/Prototypes/_Mono/Shipyard/plutomkii.yml
+++ b/Resources/Prototypes/_Mono/Shipyard/plutomkii.yml
@@ -26,7 +26,7 @@
   minPlayers: 0
   stations:
     Plutomkii:
-      stationProto: StandardFrontierVessel
+      stationProto: StandardFrontierExpeditionVessel
       components:
         - type: StationNameSetup
           mapNameTemplate: 'Pluto MK. II CIV{1}'

--- a/Resources/Prototypes/_Mono/Shipyard/praetorian.yml
+++ b/Resources/Prototypes/_Mono/Shipyard/praetorian.yml
@@ -27,7 +27,7 @@
   minPlayers: 0
   stations:
     Praetorian:
-      stationProto: StandardFrontierVessel
+      stationProto: StandardFrontierExpeditionVessel
       components:
         - type: StationNameSetup
           mapNameTemplate: 'Praetorian MIL{1}'

--- a/Resources/Prototypes/_Mono/Shipyard/promise.yml
+++ b/Resources/Prototypes/_Mono/Shipyard/promise.yml
@@ -27,7 +27,7 @@
   minPlayers: 0
   stations:
     Promise:
-      stationProto: StandardFrontierVessel
+      stationProto: StandardFrontierExpeditionVessel
       components:
         - type: StationNameSetup
           mapNameTemplate: 'Promise MED{1}'

--- a/Resources/Prototypes/_Mono/Shipyard/rig.yml
+++ b/Resources/Prototypes/_Mono/Shipyard/rig.yml
@@ -8,7 +8,7 @@
   id: Rig
   parent: BaseVessel
   name: DIS Rig
-  description: A heavy-class flying refinery manufactured by Drake Industries Shipyards. Able to extract, collect and process materials then refine them into whatever the ever changing Colossean market demands.  Comes equipped with two flare launchers for missile defense and four mining pulsers, along with mining bumpers to push minerals directly onto the built in belt system. 
+  description: A heavy-class flying refinery manufactured by Drake Industries Shipyards. Able to extract, collect and process materials then refine them into whatever the ever changing Colossean market demands.  Comes equipped with two flare launchers for missile defense and four mining pulsers, along with mining bumpers to push minerals directly onto the built in belt system.
   price: 104900 # +50% Markup from 69900 appraisegrid price. To amount for all of the QOL included in the vessel
   category: Medium
   group: Shipyard
@@ -26,7 +26,7 @@
   minPlayers: 0
   stations:
     Rig:
-      stationProto: StandardFrontierVessel
+      stationProto: StandardFrontierExpeditionVessel
       components:
         - type: StationNameSetup
           mapNameTemplate: 'Rig CIV{1}'

--- a/Resources/Prototypes/_Mono/Shipyard/sakuratsu.yml
+++ b/Resources/Prototypes/_Mono/Shipyard/sakuratsu.yml
@@ -27,7 +27,7 @@
   minPlayers: 0
   stations:
     Sakuratsu:
-      stationProto: StandardFrontierVessel
+      stationProto: StandardFrontierExpeditionVessel
       components:
         - type: StationNameSetup
           mapNameTemplate: 'Sakuratsu CIV{1}'

--- a/Resources/Prototypes/_Mono/Shipyard/sellsword.yml
+++ b/Resources/Prototypes/_Mono/Shipyard/sellsword.yml
@@ -10,7 +10,7 @@
   parent: BaseVessel
   name: UW Sellsword
   description: An escort picket comprising a claustrophobic, cast-plastitanium coffin enrobing a 255mm gun and VESPERA missile pod. Combat life expectancy of 4 minutes. Has a military IFF designation.
-  price: 56000 # markup 15% from 48600. 
+  price: 56000 # markup 15% from 48600.
   category: Small
   group: Shipyard
   access: Mercenary
@@ -28,7 +28,7 @@
   minPlayers: 0
   stations:
     Sellsword:
-      stationProto: StandardFrontierVessel
+      stationProto: StandardFrontierExpeditionVessel
       components:
         - type: StationNameSetup
           mapNameTemplate: 'Sellsword MIL{1}'

--- a/Resources/Prototypes/_Mono/Shipyard/shareholder.yml
+++ b/Resources/Prototypes/_Mono/Shipyard/shareholder.yml
@@ -26,7 +26,7 @@
   minPlayers: 0
   stations:
     Shareholder:
-      stationProto: StandardFrontierVessel
+      stationProto: StandardFrontierExpeditionVessel
       components:
         - type: StationNameSetup
           mapNameTemplate: 'Shareholder CIV{1}'

--- a/Resources/Prototypes/_Mono/Shipyard/spessbite.yml
+++ b/Resources/Prototypes/_Mono/Shipyard/spessbite.yml
@@ -30,7 +30,7 @@
   minPlayers: 0
   stations:
     Spessbite:
-      stationProto: StandardFrontierVessel
+      stationProto: StandardFrontierExpeditionVessel
       components:
         - type: StationNameSetup
           mapNameTemplate: 'Spessbite CIV{1}'

--- a/Resources/Prototypes/_Mono/Shipyard/spyglass.yml
+++ b/Resources/Prototypes/_Mono/Shipyard/spyglass.yml
@@ -21,7 +21,7 @@
   minPlayers: 0
   stations:
     Spyglass:
-      stationProto: StandardFrontierVessel
+      stationProto: StandardFrontierExpeditionVessel
       components:
         - type: StationNameSetup
           mapNameTemplate: 'Spyglass CIV{1}'

--- a/Resources/Prototypes/_Mono/Shipyard/stubby.yml
+++ b/Resources/Prototypes/_Mono/Shipyard/stubby.yml
@@ -10,7 +10,7 @@
   parent: BaseVessel
   name: UW Stubby
   description: An armored light transport fitted with minimal medical equipment. Cramped, but nimble and tough like a dog.
-  price: 31000 # appraised at ~25000 
+  price: 31000 # appraised at ~25000
   category: Small
   group: Medical
   shuttlePath: /Maps/_Mono/Shuttles/stubby.yml
@@ -27,7 +27,7 @@
   minPlayers: 0
   stations:
     Stubby:
-      stationProto: StandardFrontierVessel
+      stationProto: StandardFrontierExpeditionVessel
       components:
         - type: StationNameSetup
           mapNameTemplate: 'Stubby MED{1}'

--- a/Resources/Prototypes/_Mono/Shipyard/takeaway.yml
+++ b/Resources/Prototypes/_Mono/Shipyard/takeaway.yml
@@ -33,7 +33,7 @@
   minPlayers: 0
   stations:
     Takeaway:
-      stationProto: StandardFrontierVessel
+      stationProto: StandardFrontierExpeditionVessel
       components:
         - type: StationNameSetup
           mapNameTemplate: 'Takeaway CIV{1}'

--- a/Resources/Prototypes/_Mono/Shipyard/tanuki.yml
+++ b/Resources/Prototypes/_Mono/Shipyard/tanuki.yml
@@ -27,7 +27,7 @@
   minPlayers: 0
   stations:
     Tanuki:
-      stationProto: StandardFrontierVessel
+      stationProto: StandardFrontierExpeditionVessel
       components:
         - type: StationNameSetup
           mapNameTemplate: 'Tanuki MIL{1}'

--- a/Resources/Prototypes/_Mono/Shipyard/tiger.yml
+++ b/Resources/Prototypes/_Mono/Shipyard/tiger.yml
@@ -8,8 +8,8 @@
   id: Tiger
   parent: BaseVessel
   name: NSK Tiger
-  description: A retired racing ship, the Tiger hull has been found in use by the Nova Sharks as both a hotrod, as well as a ludicriously fast haulcraft. 
-  price: 32000 # race ship tax since its gonna be used for smuggling. 
+  description: A retired racing ship, the Tiger hull has been found in use by the Nova Sharks as both a hotrod, as well as a ludicriously fast haulcraft.
+  price: 32000 # race ship tax since its gonna be used for smuggling.
   category: Small
   group: Shipyard
   shuttlePath: /Maps/_Mono/Shuttles/tiger.yml
@@ -26,7 +26,7 @@
   minPlayers: 0
   stations:
     Tiger:
-      stationProto: StandardFrontierVessel
+      stationProto: StandardFrontierExpeditionVessel
       components:
         - type: StationNameSetup
           mapNameTemplate: 'Tiger CIV{1}'

--- a/Resources/Prototypes/_Mono/Shipyard/tokarev.yml
+++ b/Resources/Prototypes/_Mono/Shipyard/tokarev.yml
@@ -1,6 +1,6 @@
 # Author Info
 # GitHub: Leon-Krol
-# Discord: Vinny Shick 
+# Discord: Vinny Shick
 
 # Shuttle Notes:
 #
@@ -27,7 +27,7 @@
   minPlayers: 0
   stations:
     Tokarev:
-      stationProto: StandardFrontierVessel
+      stationProto: StandardFrontierExpeditionVessel
       components:
         - type: StationNameSetup
           mapNameTemplate: 'Tokarev MED{1}'

--- a/Resources/Prototypes/_Mono/Shipyard/triage.yml
+++ b/Resources/Prototypes/_Mono/Shipyard/triage.yml
@@ -26,7 +26,7 @@
   minPlayers: 0
   stations:
     Triage:
-      stationProto: StandardFrontierVessel
+      stationProto: StandardFrontierExpeditionVessel
       components:
         - type: StationNameSetup
           mapNameTemplate: 'Triage MIL{1}'

--- a/Resources/Prototypes/_Mono/Shipyard/twilight.yml
+++ b/Resources/Prototypes/_Mono/Shipyard/twilight.yml
@@ -26,7 +26,7 @@
   minPlayers: 0
   stations:
     Twilight:
-      stationProto: StandardFrontierVessel
+      stationProto: StandardFrontierExpeditionVessel
       components:
         - type: StationNameSetup
           mapNameTemplate: 'Twilight CIV{1}'

--- a/Resources/Prototypes/_Mono/Shipyard/tzipora.yml
+++ b/Resources/Prototypes/_Mono/Shipyard/tzipora.yml
@@ -27,7 +27,7 @@
   minPlayers: 0
   stations:
     Tzipora:
-      stationProto: StandardFrontierVessel
+      stationProto: StandardFrontierExpeditionVessel
       components:
         - type: StationNameSetup
           mapNameTemplate: 'Tzipora MED{1}'

--- a/Resources/Prototypes/_Mono/Shipyard/vaquita.yml
+++ b/Resources/Prototypes/_Mono/Shipyard/vaquita.yml
@@ -26,7 +26,7 @@
   minPlayers: 0
   stations:
     Vaquita:
-      stationProto: StandardFrontierVessel
+      stationProto: StandardFrontierExpeditionVessel
       components:
         - type: StationNameSetup
           mapNameTemplate: 'Vaquita CIV{1}'

--- a/Resources/Prototypes/_Mono/Shipyard/velios.yml
+++ b/Resources/Prototypes/_Mono/Shipyard/velios.yml
@@ -27,7 +27,7 @@
   minPlayers: 0
   stations:
     Velios:
-      stationProto: StandardFrontierVessel
+      stationProto: StandardFrontierExpeditionVessel
       components:
         - type: StationNameSetup
           mapNameTemplate: 'Velios MED{1}'

--- a/Resources/Prototypes/_Mono/Shipyard/victoria.yml
+++ b/Resources/Prototypes/_Mono/Shipyard/victoria.yml
@@ -27,7 +27,7 @@
   minPlayers: 0
   stations:
     Victoria:
-      stationProto: StandardFrontierVessel
+      stationProto: StandardFrontierExpeditionVessel
       components:
         - type: StationNameSetup
           mapNameTemplate: 'Victoria CIV{1}'

--- a/Resources/Prototypes/_Mono/Shipyard/windreign.yml
+++ b/Resources/Prototypes/_Mono/Shipyard/windreign.yml
@@ -22,7 +22,7 @@
   minPlayers: 0
   stations:
     Windreign:
-      stationProto: StandardFrontierVessel
+      stationProto: StandardFrontierExpeditionVessel
       components:
         - type: StationNameSetup
           mapNameTemplate: 'Windreign CIV{1}'

--- a/Resources/Prototypes/_Mono/Shipyard/zeros.yml
+++ b/Resources/Prototypes/_Mono/Shipyard/zeros.yml
@@ -3,7 +3,7 @@
 # Discord: tsunameme
 
 # Shuttle Notes:
-# 
+#
 
 - type: vessel
   id: Zeros
@@ -29,7 +29,7 @@
   minPlayers: 0
   stations:
     Zeros:
-      stationProto: StandardFrontierVessel
+      stationProto: StandardFrontierExpeditionVessel
       components:
         - type: StationNameSetup
           mapNameTemplate: 'Zeros CIV{1}'

--- a/Resources/Prototypes/_Triad/Shipyard/CIV/horizon.yml
+++ b/Resources/Prototypes/_Triad/Shipyard/CIV/horizon.yml
@@ -27,7 +27,7 @@
   minPlayers: 0
   stations:
     Horizon:
-      stationProto: StandardFrontierVessel
+      stationProto: StandardFrontierExpeditionVessel
       components:
       - type: StationNameSetup
         mapNameTemplate: 'Horizon CIV{1}'

--- a/Resources/Prototypes/_Triad/Shipyard/gondola.yml
+++ b/Resources/Prototypes/_Triad/Shipyard/gondola.yml
@@ -28,7 +28,7 @@
   minPlayers: 0
   stations:
     gondola:
-      stationProto: StandardFrontierVessel
+      stationProto: StandardFrontierExpeditionVessel
       components:
         - type: StationNameSetup
           mapNameTemplate: 'Gondola CIV{1}'


### PR DESCRIPTION
## About the PR
Added Expedition to every single stationProto. Newly purchased ships will be expedition capable.

## Why / Balance
we love expeds yay! yay! yay!

## Media
<img width="340" height="23" alt="image" src="https://github.com/user-attachments/assets/2047a67a-e51d-4d1e-903a-2114984ee033" />

## Requirements
<!-- Confirm the following by placing an X in the brackets [X]: -->
- [x] I have read relevant guidelines/documentation to this PR found on [our devwiki](https://monolith-station.github.io/mono-docs/).
- [x] I have added media to this PR or it does not require an ingame showcase.
- [x] I can confirm this PR contains either no AI-generated content, or AI-generated content that meets our guidelines.
<!-- You should understand that not following the above may get your PR closed at maintainer’s discretion -->
<!-- When using AI, make sure you are already proficient in creating whatever content you are attempting to generate and that you already have experience contributing to SS14. This means using AI to enhance your preexisting workflow, not vibecoding. -->

## How to test
Buy ship, give it an exped console, follow your dreams.

## Breaking changes
mew mrrrrp mrow :3  

**Changelog**
:cl:
- tweak: Every newly-purchased ship is now expedition-capable.

