### PR TITLE
TDF Data Farm

### DIFF
--- a/Resources/Maps/_Triad/POI/tdfoutpost.yml
+++ b/Resources/Maps/_Triad/POI/tdfoutpost.yml
@@ -21310,7 +21310,7 @@ entities:
       rot: 1.5707963267948966 rad
       pos: -12.5,62.5
       parent: 1
-- proto: DatafarmResearchFaction
+- proto: DatafarmResearchTDF
   entities:
   - uid: 3156
     components:

--- a/Resources/Prototypes/_Triad/Entities/Structures/Machines/datafarms.yml
+++ b/Resources/Prototypes/_Triad/Entities/Structures/Machines/datafarms.yml
@@ -1,0 +1,13 @@
+- type: entity
+  id: DatafarmResearchTDF
+  parent: BaseDataFarmIndestructible
+  name: bolted data farm (Research)
+  description: A power-hungry TDF server dedicated towards scraping data from... somewhere. This one generates research points at a rate of 45 per second. It seems to be bolted to the floor.
+  suffix: TDF
+  components:
+  - type: ResearchClient
+  - type: ResearchPointSource
+    pointsPerSecond: 45
+    active: true
+  - type: ApcPowerReceiver
+    powerLoad: 10000


### PR DESCRIPTION
## About the PR
Makes the TDF data farm generate 45 a second, rather than 200
It was way too much

**Changelog**
:cl:
- tweak: TDF Data Farm now generates 45 research points a second, from 200 points a second.
