### PR TITLE
Fix: Rework Edison Plant Access, Roles, and Department

### DIFF
--- a/Content.Shared/Access/Components/IdCardConsoleComponent.cs
+++ b/Content.Shared/Access/Components/IdCardConsoleComponent.cs
@@ -59,8 +59,8 @@ public sealed partial class IdCardConsoleComponent : Component
         //"ChiefMedicalOfficer",
         "Command",
         //"Cryogenics",
-        //"Engineering",
-        "External",
+        "Engineering", // Triad: restored - engineering is a player-delegatable role on Triad (plant + ship engineers)
+        //"External", // Triad: removed - universal baseline via GeneralAccess, every ID already has it, nothing to grant
         "Frontier", // Frontier
         "HeadOfPersonnel",
         "TdfChiefEnforcer", // Triad
@@ -72,7 +72,7 @@ public sealed partial class IdCardConsoleComponent : Component
         //"Quartermaster",
         //"Research",
         "Lawyer",
-        "Maintenance",
+        //"Maintenance", // Triad: removed - universal baseline via GeneralAccess, every ID already has it, nothing to grant
         "Medical", // Frontier
         //"Quartermaster",
         //"Research",

--- a/Resources/Locale/en-US/_NF/navmap-beacons/station-beacons.ftl
+++ b/Resources/Locale/en-US/_NF/navmap-beacons/station-beacons.ftl
@@ -39,7 +39,7 @@ station-beacon-dock-six-c = Dock 6c
 
 # Triad: Edison Power Plant POI beacons
 station-beacon-dock-seven = Dock 7
-station-beacon-managers-office = PM's Office
-station-beacon-managers-quarters = PM's Quarters
+station-beacon-managers-office = Director's Office
+station-beacon-managers-quarters = Director's Quarters
 station-beacon-break-room = Break Room
 station-beacon-aux-chamber = Aux. Chamber

--- a/Resources/Locale/en-US/_Triad/job/department-desc.ftl
+++ b/Resources/Locale/en-US/_Triad/job/department-desc.ftl
@@ -1,2 +1,2 @@
 ﻿department-TriadDefenseForce-description = Ensure the residents of the Triad sectors are safe and obey the law. Coordinate with the Overseer to ensure the safety of the TFA stations.
-department-Industrial-description = Operate the sector's power plants and heavy industry, keeping the lights on for the Colonial Outposts.
+department-Infrastructure-description = Operate the sector's power plants and heavy infrastructure, keeping the lights on for the Colonial Outposts.

--- a/Resources/Locale/en-US/_Triad/job/department.ftl
+++ b/Resources/Locale/en-US/_Triad/job/department.ftl
@@ -1,4 +1,4 @@
 department-TriadDefenseForce = Triad Defense Force
 department-SolarianDirective = Solarian Directive PMCs
 department-ImperialCoalition = The Imperial Coalition
-department-Industrial = Industrial
+department-Infrastructure = Infrastructure

--- a/Resources/Locale/en-US/_Triad/job/job-description.ftl
+++ b/Resources/Locale/en-US/_Triad/job/job-description.ftl
@@ -21,4 +21,4 @@ job-description-stc = Expertly de-conflict the space around the station and help
 job-description-security-guard = Hand over criminals to the TDF, ensure the TFA's stations are safe, and listen to the Overseer.
 job-description-doc = Provide guidance and direction for shift medics and work to safeguard the health of TFA colonial personnel and Triad residents.
 job-description-plant-manager = Answer to command, keep your technicians paid, and safeguard the health and safety of the Edison Power Plant and its crew.
-job-description-plant-technician = Be the working hands of the Edison Power Plant: tend the supermatter, run the gas and fuel lines, and keep the reactor online for the Plant Manager.
+job-description-plant-technician = Be the working hands of the Edison Power Plant: tend the supermatter, run the gas and fuel lines, and keep the reactor online for the Director of Infrastructure.

--- a/Resources/Locale/en-US/_Triad/job/job-names.ftl
+++ b/Resources/Locale/en-US/_Triad/job/job-names.ftl
@@ -5,8 +5,8 @@ job-name-tdf-patrol-team-leader = Patrol Team Leader
 job-name-tdf-medic = Combat Medic
 job-name-tdf-enforcer = Enforcer
 job-name-tdf-cadet = Junior Enforcer
-job-name-plant-manager = Plant Manager
-job-name-plant-technician = Plant Technician
+job-name-plant-manager = Director of Infrastructure
+job-name-plant-technician = Sector Technician
 
 # TDF High Command
 job-name-tdf-high-commander = High Commander

--- a/Resources/Locale/en-US/_Triad/job/job-supervisors.ftl
+++ b/Resources/Locale/en-US/_Triad/job/job-supervisors.ftl
@@ -4,4 +4,4 @@ job-supervisors-tdf-patrol-team-leader = your assigned patrol team leader
 job-supervisors-tdf-cadet = all higher ranking TDF members
 job-supervisors-tdf-prisoner = all TDF personnel
 job-supervisors-tdf = Patrol Team Leaders, and the Chief Enforcer
-job-supervisors-plant-manager = the Plant Manager
+job-supervisors-plant-manager = the Director of Infrastructure

--- a/Resources/Locale/en-US/_Triad/preferences/loadout-groups.ftl
+++ b/Resources/Locale/en-US/_Triad/preferences/loadout-groups.ftl
@@ -6,7 +6,6 @@ loadout-group-plant-glasses = glasses
 loadout-group-plant-ears = headset
 loadout-group-plant-manager-jumpsuit = jumpsuit
 loadout-group-plant-manager-backpack = backpack
-loadout-group-plant-manager-belt = chief's toolbelt
 loadout-group-plant-technician-head = head
 loadout-group-plant-technician-neck = neck
 loadout-group-plant-technician-jumpsuit = jumpsuit

--- a/Resources/Maps/_NF/POI/edison.yml
+++ b/Resources/Maps/_NF/POI/edison.yml
@@ -5610,7 +5610,14 @@ entities:
       rot: 3.141592653589793 rad
       pos: -11.5,15.5
       parent: 1
-- proto: AirlockChiefEngineerGlassLocked
+- proto: AirlockCommandLocked
+  entities:
+  - uid: 168
+    components:
+    - type: Transform
+      pos: 26.5,18.5
+      parent: 1
+- proto: AirlockCommandGlassLocked
   entities:
   - uid: 109
     components:
@@ -5959,11 +5966,6 @@ entities:
     - type: Transform
       pos: 17.5,-4.5
       parent: 1
-  - uid: 168
-    components:
-    - type: Transform
-      pos: 26.5,18.5
-      parent: 1
   - uid: 169
     components:
     - type: Transform
@@ -6195,7 +6197,7 @@ entities:
       rot: 1.5707963267948966 rad
       pos: 12.5,12.5
       parent: 1
-- proto: AirlockFrontierCommandLocked
+- proto: AirlockEngineeringLocked
   entities:
   - uid: 189
     components:
@@ -40057,12 +40059,12 @@ entities:
   - uid: 6702
     components:
     - type: MetaData
-      name: Edison Plant Manager Office fax machine
+      name: Edison Director of Infrastructure Office fax machine
     - type: Transform
       pos: -10.5,37.5
       parent: 1
     - type: FaxMachine
-      name: Edison Plant Manager Office
+      name: Edison Director of Infrastructure Office
   - uid: 6703
     components:
     - type: MetaData
@@ -67389,7 +67391,7 @@ entities:
     - type: Transform
       pos: -11.5,28.5
       parent: 1
-- proto: HighSecFrontierCommandLocked
+- proto: HighSecCommandLocked
   entities:
   - uid: 10408
     components:
@@ -73269,7 +73271,7 @@ entities:
 
         [color=#E47A1F] [head=3][bold]Electra Dynamics™[/bold][/head][/color]  [color=gray][italic]                   Technical Specifications[/italic][/color]
 
-        [color=#F9B34F][/color] [head=4][color=#F9B34F][bold]Edison Shipyard     [/color][/bold][/head] [color=gray][italic]                       For plant manager use only[/bolditalic][/head][/color]
+        [color=#F9B34F][/color] [head=4][color=#F9B34F][bold]Edison Shipyard     [/color][/bold][/head] [color=gray][italic]                       For Director of Infrastructure use only[/bolditalic][/head][/color]
 
         [color=#134975]──────────────────────────────────────[/color]
 

--- a/Resources/Prototypes/_NF/Entities/Structures/Doors/Airlocks/access.yml
+++ b/Resources/Prototypes/_NF/Entities/Structures/Doors/Airlocks/access.yml
@@ -51,7 +51,7 @@
   components:
   - type: ContainerFill
     containers:
-      board: [ DoorElectronicsFrontierCommand ]
+      board: [ DoorElectronicsFrontierCommandEngineering ] # Triad: command OR engineering (was DoorElectronicsFrontierCommand)
 
 - type: entity
   parent: HighSecDoor
@@ -214,7 +214,7 @@
   components:
   - type: ContainerFill
     containers:
-      board: [ DoorElectronicsFrontierCommand ]
+      board: [ DoorElectronicsFrontierCommandEngineering ] # Triad: command OR engineering (was DoorElectronicsFrontierCommand)
 
 - type: entity
   parent: [ AirlockAtmosphericsGlass, AirlockFrontierCommandGlassLocked]
@@ -223,7 +223,7 @@
   components:
   - type: ContainerFill
     containers:
-      board: [ DoorElectronicsFrontierCommand ]
+      board: [ DoorElectronicsFrontierCommandEngineering ] # Triad: command OR engineering (was DoorElectronicsFrontierCommand)
 
 - type: entity
   parent: AirlockGlass

--- a/Resources/Prototypes/_NF/PointsOfInterest/EdisonPort/edison_content.yml
+++ b/Resources/Prototypes/_NF/PointsOfInterest/EdisonPort/edison_content.yml
@@ -29,7 +29,7 @@
 - type: entity
   id: CSComputerCargoOrdersEddison
   parent: ComputerCargoOrders
-  name: plant manager's request computer
+  name: Director of Infrastructure's request computer
   description: Used to purchase restricted engineering supplies.
   components:
   # Triad: dropped the NFCargoOrderConsole override (NF sector-cargo variant not ported) and
@@ -43,7 +43,7 @@
       Medical: 0.1
       Edison: 0.15
   - type: AccessReader
-    access: [["ChiefEngineer"]]
+    access: [["Command"]] # Triad: retired ChiefEngineer; the Director runs the plant on Command
 
 # --- EdisonTechFab  (coyote: _CS/Entities/Structures/Machines/lathe.yml) ---
 - type: entity
@@ -150,11 +150,11 @@
 - type: entity
   parent: GunSafe
   id: GunSafePlantManager
-  name: plant manager's gun safe
+  name: Director of Infrastructure's gun safe
   suffix: Filled
   components:
   - type: AccessReader
-    access: [["ChiefEngineer"]]
+    access: [["Command"]] # Triad: retired ChiefEngineer; the Director runs the plant on Command
   - type: StorageFill
     contents:
     - id: WeaponPistolMk58
@@ -183,6 +183,10 @@
     - map: [ "enum.WiresVisualLayers.MaintenancePanel" ]
       sprite: Structures/Machines/computers.rsi
       state: generic_panel_open
+  # Triad: plant comms console - overrides the stationwide ComputerComms access so the Director of
+  # Infrastructure (Command) and Sector Technician (Engineering) can use it.
+  - type: AccessReader
+    access: [["Command"], ["Engineering"]]
 
 # --- ComputerTabletopStationAdminBankATMEdison  (coyote: _NF/Entities/Structures/Machines/Computers/computers_tabletop.yml) ---
 - type: entity
@@ -193,9 +197,9 @@
   components:
   - type: StationBankATM
     account: Edison # Triad: restored coyote's Edison sector account
-  # Triad: the plant's chief engineer (Plant Manager) runs the terminal alongside the HoP/Chief Enforcer
+  # Triad: the plant's chief engineer (Director of Infrastructure) runs the terminal alongside the HoP/Chief Enforcer
   - type: AccessReader
-    access: [["HeadOfPersonnel"], ["TdfChiefEnforcer"], ["ChiefEngineer"]]
+    access: [["HeadOfPersonnel"], ["TdfChiefEnforcer"], ["Command"]] # Triad: retired ChiefEngineer (Director via Command)
 
 # --- AntiMatterFabricator  (coyote: _NF/Entities/Structures/Machines/ame_fab.yml) ---
 - type: entity

--- a/Resources/Prototypes/_NF/PointsOfInterest/EdisonPort/entities.yml
+++ b/Resources/Prototypes/_NF/PointsOfInterest/EdisonPort/entities.yml
@@ -4,15 +4,19 @@
 # so the map loads cleanly; refit later.
 
 # --- Lighting ------------------------------------------------------------------
-# Triad: dropped upstream `solarFlareShieldingCoefficient` (no solar-flare feature here),
-# the shielded RSI (not vendored), and the shielded construction node (graph node absent).
-# These behave as normal empty light fixtures until a shielded variant is built out.
+# Triad: dropped upstream `solarFlareShieldingCoefficient` (no solar-flare feature here) and
+# the shielded RSI (not vendored), so these use the normal light sprite. Buildable via the
+# self-contained ShieldedLightFixture graph (see shielded_light_construction.yml).
 - type: entity
   id: NFPoweredlightShieldedEmpty
   parent: PoweredlightEmpty
   name: shielded light
   description: A light fixture. Draws power and produces light when equipped with a light tube. Reinforced with plasteel to shield it from solar flares.
   suffix: Empty
+  components:
+  - type: Construction
+    graph: ShieldedLightFixture
+    node: shieldedTubeLight
 
 - type: entity
   id: NFPoweredSmallLightShieldedEmpty
@@ -20,6 +24,10 @@
   name: shielded small light
   description: A light fixture. Draws power and produces light when equipped with a light tube. Reinforced with plasteel to shield it from solar flares.
   suffix: Empty
+  components:
+  - type: Construction
+    graph: ShieldedLightFixture
+    node: shieldedBulbLight
 
 - type: entity
   parent: BaseLightTubeCrystal
@@ -36,7 +44,7 @@
 - type: entity
   id: SpawnPointPlantManager
   parent: SpawnPointJobBase
-  name: plant manager
+  name: Director of Infrastructure
   components:
   - type: SpawnPoint
     job_id: PlantManager
@@ -49,7 +57,7 @@
 - type: entity
   id: SpawnPointPlantTechnician
   parent: SpawnPointJobBase
-  name: plant technician
+  name: Sector Technician
   components:
   - type: SpawnPoint
     job_id: PlantTechnician
@@ -80,7 +88,7 @@
 - type: entity
   parent: DefaultStationBeaconCommand
   id: DefaultStationBeaconFrontierManagersOffice
-  suffix: PM's Office
+  suffix: Director's Office
   components:
   - type: NavMapBeacon
     defaultText: station-beacon-managers-office
@@ -88,7 +96,7 @@
 - type: entity
   parent: DefaultStationBeaconCommand
   id: DefaultStationBeaconFrontierManagersQuarters
-  suffix: PM's Quarters
+  suffix: Director's Quarters
   components:
   - type: NavMapBeacon
     defaultText: station-beacon-managers-quarters

--- a/Resources/Prototypes/_NF/PointsOfInterest/EdisonPort/shielded_light_construction.yml
+++ b/Resources/Prototypes/_NF/PointsOfInterest/EdisonPort/shielded_light_construction.yml
@@ -1,0 +1,100 @@
+# SPDX-License-Identifier: AGPL-3.0-or-later AND MIT
+#
+# Triad: makes the ported Edison shielded light fixtures buildable. Self-contained graph
+# (does not touch the upstream LightFixture graph); the shielded fixtures point their
+# Construction component here. Reinforced variants cost an extra plasteel sheet.
+
+- type: constructionGraph
+  id: ShieldedLightFixture
+  start: start
+  graph:
+  - node: start
+    edges:
+    - to: shieldedTubeLight
+      steps:
+      - material: Steel
+        amount: 2
+        doAfter: 2.0
+      - material: Plasteel
+        amount: 1
+        doAfter: 2.0
+    - to: shieldedBulbLight
+      steps:
+      - material: Steel
+        amount: 1
+        doAfter: 2.0
+      - material: Plasteel
+        amount: 1
+        doAfter: 2.0
+  - node: shieldedTubeLight
+    entity: NFPoweredlightShieldedEmpty
+    edges:
+    - to: start
+      conditions:
+      - !type:ContainerEmpty
+        container: "light_bulb"
+      steps:
+      - tool: Screwing
+        doAfter: 2.0
+      completed:
+      - !type:SpawnPrototype
+        prototype: SheetSteel1
+        amount: 2
+      - !type:SpawnPrototype
+        prototype: SheetPlasteel1
+        amount: 1
+      - !type:DeleteEntity {}
+  - node: shieldedBulbLight
+    entity: NFPoweredSmallLightShieldedEmpty
+    edges:
+    - to: start
+      conditions:
+      - !type:ContainerEmpty
+        container: "light_bulb"
+      steps:
+      - tool: Screwing
+        doAfter: 2.0
+      completed:
+      - !type:SpawnPrototype
+        prototype: SheetSteel1
+        amount: 1
+      - !type:SpawnPrototype
+        prototype: SheetPlasteel1
+        amount: 1
+      - !type:DeleteEntity {}
+
+- type: construction
+  name: shielded wall light
+  id: ShieldedLightTubeFixture
+  graph: ShieldedLightFixture
+  startNode: start
+  targetNode: shieldedTubeLight
+  category: construction-category-structures
+  description: A wall light fixture reinforced with plasteel to shield it from solar flares. Use light tubes.
+  icon:
+    sprite: Structures/Wallmounts/Lighting/light_tube.rsi
+    state: base
+  objectType: Structure
+  placementMode: SnapgridCenter
+  canRotate: true
+  canBuildInImpassable: false
+  conditions:
+  - !type:TileNotBlocked
+
+- type: construction
+  name: shielded small wall light
+  id: ShieldedLightSmallFixture
+  graph: ShieldedLightFixture
+  startNode: start
+  targetNode: shieldedBulbLight
+  category: construction-category-structures
+  description: A small wall light fixture reinforced with plasteel to shield it from solar flares. Use light bulbs.
+  icon:
+    sprite: Structures/Wallmounts/Lighting/light_small.rsi
+    state: base
+  objectType: Structure
+  placementMode: SnapgridCenter
+  canRotate: true
+  canBuildInImpassable: false
+  conditions:
+  - !type:TileNotBlocked

--- a/Resources/Prototypes/_NF/PointsOfInterest/edison.yml
+++ b/Resources/Prototypes/_NF/PointsOfInterest/edison.yml
@@ -30,7 +30,7 @@
   minPlayers: 0
   stations:
     Edison:
-      stationProto: RecordsFrontierOutpostCargo # Triad: Cargo variant carries StationCargoOrderDatabase; without it the plant manager's request computer can't take orders
+      stationProto: RecordsFrontierOutpostCargo # Triad: Cargo variant carries StationCargoOrderDatabase; without it the Director of Infrastructure's request computer can't take orders
       components:
         - type: StationNameSetup
           mapNameTemplate: 'Edison Power Plant'

--- a/Resources/Prototypes/_Triad/Entities/Objects/Devices/Electronics/door_access.yml
+++ b/Resources/Prototypes/_Triad/Entities/Objects/Devices/Electronics/door_access.yml
@@ -22,3 +22,13 @@
   components:
   - type: AccessReader
     access: [["TdfChiefEnforcer"]]
+
+# Triad: command-or-engineering board for the FrontierCommand engineering/atmos doors on the
+# outpost stations - command members OR engineering staff can open (was command-only HoS/HoP).
+- type: entity
+  parent: DoorElectronics
+  id: DoorElectronicsFrontierCommandEngineering
+  suffix: Command/Engineering, Locked
+  components:
+  - type: AccessReader
+    access: [["Command"], ["Engineering"]]

--- a/Resources/Prototypes/_Triad/Entities/Objects/Devices/plant_devices.yml
+++ b/Resources/Prototypes/_Triad/Entities/Objects/Devices/plant_devices.yml
@@ -3,24 +3,25 @@
 - type: entity
   parent: EngineerPDA
   id: PlantManagerPDA
-  name: plant manager PDA
+  name: Director of Infrastructure PDA
   description: Tracks reactor output and the plant's account balance.
   components:
   - type: Pda
     id: PlantManagerIDCard
   - type: PdaBorderColor
     borderColor: "#c59a3b"
-  - type: CartridgeLoader # Triad - extended with the ledger for the plant account
+  - type: CartridgeLoader # Triad - extended with the ledger for the plant account + cargo bounties
     preinstalled:
     - CrewManifestCartridge
     - NotekeeperCartridge
     - NewsReaderCartridge
     - LedgerCartridge
+    - BountyContractsCartridge
 
 - type: entity
   parent: EngineerPDA
   id: PlantTechnicianPDA
-  name: plant technician PDA
+  name: Sector Technician PDA
   description: Rugged, and smells faintly of coolant.
   components:
   - type: Pda
@@ -33,7 +34,7 @@
 - type: entity
   parent: IDCardStandard
   id: PlantManagerIDCard
-  name: plant manager ID card
+  name: Director of Infrastructure ID card
   components:
   - type: PresetIdCard
     job: PlantManager
@@ -50,7 +51,7 @@
 - type: entity
   parent: IDCardStandard
   id: PlantTechnicianIDCard
-  name: plant technician ID card
+  name: Sector Technician ID card
   components:
   - type: PresetIdCard
     job: PlantTechnician

--- a/Resources/Prototypes/_Triad/Loadouts/plant_loadout_groups.yml
+++ b/Resources/Prototypes/_Triad/Loadouts/plant_loadout_groups.yml
@@ -5,11 +5,6 @@
 # --- New loadout prototypes ---------------------------------------------------
 
 - type: loadout
-  id: PlantManagerChiefToolbelt
-  equipment:
-    belt: ClothingBeltChiefEngineerFilled
-
-- type: loadout
   id: PlantManagerMessengerBag
   equipment:
     back: ClothingBackpackMessengerChiefEngineer
@@ -99,13 +94,16 @@
 - type: loadoutGroup
   id: PlantBelt
   name: loadout-group-plant-belt
-  minLimit: 0
+  minLimit: 1
+  maxLimit: 1
   loadouts:
   - ContractorClothingBeltUtility
   - ContractorClothingBeltUtilityFilled
   - ContractorClothingBeltStorageWaistbag
   - ContractorClothingBeltSalvageWebbingFilledNF
   - ContractorBoxFolderClipboard
+  fallbacks:
+  - ContractorClothingBeltUtilityFilled
 
 - type: loadoutGroup
   id: PlantFace
@@ -155,7 +153,7 @@
   fallbacks:
   - ContractorClothingHeadsetEngineeringCommon
 
-# --- Plant Manager ------------------------------------------------------------
+# --- Director of Infrastructure -----------------------------------------------
 
 - type: loadoutGroup
   id: PlantManagerJumpsuit
@@ -185,14 +183,7 @@
   fallbacks:
   - StationEngineerBackpack
 
-- type: loadoutGroup
-  id: PlantManagerBelt
-  name: loadout-group-plant-manager-belt
-  minLimit: 0
-  loadouts:
-  - PlantManagerChiefToolbelt
-
-# --- Plant Technician ---------------------------------------------------------
+# --- Sector Technician --------------------------------------------------------
 
 - type: loadoutGroup
   id: PlantTechnicianHead

--- a/Resources/Prototypes/_Triad/Loadouts/role_loadouts.yml
+++ b/Resources/Prototypes/_Triad/Loadouts/role_loadouts.yml
@@ -22,7 +22,7 @@
   - NFSpeciesSpecific
   - ContractorArmorPlates
 
-# Plant Manager is the plant's chief engineer: CE wardrobe plus a curated engineering kit
+# The Director of Infrastructure is the plant's chief engineer: CE wardrobe plus a curated engineering kit
 # (the Plant* groups; the generic Contractor* groups carry too much cross-department gear).
 # No GroupTankHarness: NFSpeciesSpecific already forces LoadoutTankHarness (double vox harness otherwise).
 - type: roleLoadout
@@ -35,8 +35,6 @@
   - PlantManagerBackpack
   - ChiefEngineerOuterClothing
   - ChiefEngineerShoes
-  - PlantBelt
-  - PlantManagerBelt
   - PlantFace
   - PlantGlasses
   - PlantEars
@@ -48,7 +46,7 @@
   - ContractorBureaucracy
   - NFSpeciesSpecific
 
-# Plant Technician is station-engineer tier. No ID group, keeps the plant ID from starting gear.
+# The Sector Technician is station-engineer tier. No ID group, keeps the plant ID from starting gear.
 - type: roleLoadout
   id: JobPlantTechnician
   groups:

--- a/Resources/Prototypes/_Triad/Roles/Jobs/Infrastructure/plant_roles.yml
+++ b/Resources/Prototypes/_Triad/Roles/Jobs/Infrastructure/plant_roles.yml
@@ -12,16 +12,16 @@
   setPreference: true
   weight: 100
   displayWeight: 40
-  # The Plant Manager is the plant's chief engineer. ChiefEngineer access covers Coyote's plant-manager
-  # fixtures (gun safe, request computer, CE doors) and the admin bank terminal; Command for the
-  # manager-only areas; Engineering/Atmospherics for the rest of the plant.
+  # The Director of Infrastructure is the plant's chief engineer. Command covers the manager-only
+  # fixtures (gun safe, request computer, admin bank terminal) and the office/quarters + vault;
+  # Engineering/Atmospherics cover the rest of the plant. (ChiefEngineer retired - it isn't
+  # console-grantable and nothing plant-side needs it anymore.)
   access:
   - Engineering
   - Atmospherics
   - Maintenance
   - External
   - Command
-  - ChiefEngineer
   special:
   - !type:GiveItemOnHolidaySpecial
     holiday: FrontierBirthday
@@ -29,7 +29,6 @@
   - !type:AddComponentSpecial
     components:
       - type: CommandStaff
-      - type: ShipSavingBlacklist # Triad - can't save ships
       - type: NpcFactionMember
         factions:
         - TDF # Triad - not TDF, but friendly and works with them
@@ -41,9 +40,9 @@
   id: PlantManagerGear
   equipment:
     id: PlantManagerPDA
-    ears: ClothingHeadsetEngineering
-    eyes: ClothingEyesGlassesMeson
-    belt: ClothingBeltUtilityEngineering
+    belt: ClothingBeltChiefEngineerFilled # Triad: fixed CE toolbelt (no belt choice), lives in gear not a loadout category
+    # Triad: ears (guaranteed) and glasses (optional) come from the role loadout; kept out of gear
+    # so the loadout doesn't double-fill the slot and drop a duplicate.
 
 - type: job
   id: PlantTechnician
@@ -70,7 +69,6 @@
     prototype: FrontierBirthdayGift
   - !type:AddComponentSpecial
     components:
-      - type: ShipSavingBlacklist # Triad - can't save ships
       - type: NpcFactionMember
         factions:
         - TDF # Triad - not TDF, but friendly and works with them
@@ -82,6 +80,4 @@
   id: PlantTechnicianGear
   equipment:
     id: PlantTechnicianPDA
-    ears: ClothingHeadsetEngineering
-    eyes: ClothingEyesGlassesMeson
-    belt: ClothingBeltUtilityEngineering
+    # Triad: clothing comes from the role loadout (ears/belt guaranteed, glasses optional).

--- a/Resources/Prototypes/_Triad/Roles/Jobs/departments.yml
+++ b/Resources/Prototypes/_Triad/Roles/Jobs/departments.yml
@@ -1,7 +1,7 @@
 - type: department
-  id: Industrial
-  name: department-Industrial
-  description: department-Industrial-description
+  id: Infrastructure
+  name: department-Infrastructure
+  description: department-Infrastructure-description
   color: "#c59a3b"
   weight: 100
   roles:


### PR DESCRIPTION
## About the PR
Fixes the Edison plant's access controls end to end so the department is actually playable, renames the plant to Infrastructure, and cleans up the loadouts.

## Why / Balance
The Edison came over from the port with broken access: doors keyed to Overseer/Colonel and to Engineer/Chief-Engineer levels that couldn't be granted at a console, a manager locked out of the comms console, backup power, and the material vault, and both roles dropping duplicate gear every spawn. This scopes access to what the roles actually need and can hand out, no new power. Plant doors now run on Command (manager spaces + vault) and Engineering (the floor), both console-grantable; ChiefEngineer is retired from the plant; and the outpost engineering doors that were command-locked now also open for engineers.

## Media
N/A — the role rename, buildable shielded lights, and loadout changes are ingame-facing; can attach a clip if wanted.

## Requirements
- [x] I have read relevant guidelines/documentation to this PR found on our devwiki.
- [x] I have added media to this PR or it does not require an ingame showcase.
- [x] I can confirm this PR contains either no AI-generated content, or AI-generated content that meets our guidelines.

## How to test
Spawn as Director of Infrastructure and Sector Technician: confirm no duplicate gear drops, glasses are opt-in, and the Director spawns with the CE toolbelt. Swipe both IDs at the Edison doors (office/quarters/vault vs power/reactor), the comms console, and the material silo. Grant Engineering to a crew ID at an ID card console. Build a shielded wall light from the construction menu.

## Breaking changes
Department prototype id `Industrial` → `Infrastructure` (locale keys and folder renamed to match); nothing else references the old id. Job prototype ids (`PlantManager`/`PlantTechnician`) are unchanged, only their display names changed.

**Changelog**
:cl:
- add: The Edison is now run by the Director of Infrastructure and Sector Technician (the Infrastructure department).
- add: Shielded light fixtures can now be constructed.
- tweak: Reworked Edison and outpost access so infrastructure staff can reach their areas, consoles, and the material vault.
- fix: Plant roles no longer drop duplicate equipment when spawning.
- fix: Plant roles can save and load ships again.
