### PR TITLE
Fax Event Blacklist/Whitelist

### DIFF
--- a/Content.Server/_NF/StationEvents/Components/RandomFaxRuleComponent.cs
+++ b/Content.Server/_NF/StationEvents/Components/RandomFaxRuleComponent.cs
@@ -1,6 +1,7 @@
 using Content.Server.StationEvents.Events;
 using Content.Shared.Fax.Components;
 using Content.Shared.Paper;
+using Content.Shared.Whitelist; // Triad
 using Robust.Shared.Prototypes;
 
 namespace Content.Server.StationEvents.Components;
@@ -41,7 +42,7 @@ public sealed partial class RandomFaxRuleComponent : Component
     [DataField]
     public string? FromAddress;
 
-    // TODO: run arbitrary functions 
+    // TODO: run arbitrary functions
 
     /// <summary>
     ///     All the valid IWireActions currently in this layout.
@@ -66,6 +67,18 @@ public sealed partial class RandomFaxRuleComponent : Component
     /// </summary>
     [DataField]
     public int MaxFaxes { get; private set; } = 1;
+
+    /// <summary>
+    ///     Triad - Whitelist for station entities that are eligible to be faxed to.
+    /// </summary>
+    [DataField]
+    public EntityWhitelist? Whitelist;
+
+    /// <summary>
+    ///     Triad - Blacklist for station entities that are NOT eligible to be faxed to.
+    /// </summary>
+    [DataField]
+    public EntityWhitelist? Blacklist;
 }
 
 // TODO: relocate these definitions.

--- a/Content.Server/_NF/StationEvents/Events/RandomFaxRule.cs
+++ b/Content.Server/_NF/StationEvents/Events/RandomFaxRule.cs
@@ -5,15 +5,17 @@ using Content.Shared.Fax.Components;
 using Content.Server.Fax;
 using Content.Server.Station.Systems;
 using Robust.Shared.Random;
+using Content.Shared.Whitelist; // Triad
 
 namespace Content.Server.StationEvents.Events;
 
-public sealed class RandomFaxRule : StationEventSystem<RandomFaxRuleComponent>
+public sealed partial class RandomFaxRule : StationEventSystem<RandomFaxRuleComponent>
 {
-    [Dependency] private readonly IEntityManager _entMan = default!;
-    [Dependency] private readonly FaxSystem _faxSystem = default!;
-    [Dependency] private readonly StationSystem _stationSystem = default!;
-    [Dependency] private readonly IRobustRandom _random = default!;
+    [Dependency] private IEntityManager _entMan = default!;
+    [Dependency] private FaxSystem _faxSystem = default!;
+    [Dependency] private StationSystem _stationSystem = default!;
+    [Dependency] private EntityWhitelistSystem _whitelist = default!; // Triad
+    [Dependency] private IRobustRandom _random = default!;
 
     private const int MaxRetries = 10;
     protected override void Added(EntityUid uid, RandomFaxRuleComponent component, GameRuleComponent gameRule, GameRuleAddedEvent args)
@@ -56,6 +58,11 @@ public sealed class RandomFaxRule : StationEventSystem<RandomFaxRuleComponent>
                 retries++;
                 continue;
             }
+
+            // Triad start - whitelist and blacklist for fax station event
+            if (!_whitelist.CheckBoth(chosenStation, component.Blacklist, component.Whitelist))
+                return;
+            // Triad end
 
             if (!TryComp<StationDataComponent>(chosenStation, out var stationData))
             {

--- a/Content.Server/_Triad/Shipyard/ShipyardSystem.Triad.Consoles.cs
+++ b/Content.Server/_Triad/Shipyard/ShipyardSystem.Triad.Consoles.cs
@@ -93,6 +93,14 @@ public sealed partial class ShipyardSystem : SharedShipyardSystem
             return;
         }
 
+        // do not.
+        if (HasComp<ShipSavingBlacklistComponent>(shuttleUid))
+        {
+            ConsolePopup(player, $"ERROR! UNAUTHORIZED DEED DETECTED.");
+            PlayDenySound(player, uid, component);
+            return;
+        }
+
         // Ensure the limits for limited entites doesn't exceed while saving
         if (!_shipyardGridSave.CheckGridEntityLimits(shuttleUid.Value, out var message))
         {

--- a/Content.Shared/_Triad/Shipyard/Save/ShipSavingBlacklistComponent.cs
+++ b/Content.Shared/_Triad/Shipyard/Save/ShipSavingBlacklistComponent.cs
@@ -3,6 +3,7 @@ namespace Content.Shared._Triad.Shipyard.Save;
 
 /// <summary>
 /// Entities with this component will be unable to save or load ships from the shipyard console.
+/// You can also add this to a grid to prevent it from being saved.
 /// </summary>
 [RegisterComponent, NetworkedComponent]
 public sealed partial class ShipSavingBlacklistComponent : Component;

--- a/Content.Shared/_Triad/Smuggling/StationFaxDeadDropHintExemptComponent.cs
+++ b/Content.Shared/_Triad/Smuggling/StationFaxDeadDropHintExemptComponent.cs
@@ -1,0 +1,7 @@
+namespace Content.Shared._Triad.Smuggling;
+
+/// <summary>
+///     A station that has this will not have midround smuggler faxes sent to it.
+/// </summary>
+[RegisterComponent]
+public sealed partial class StationFaxDeadDropHintExemptComponent : Component;

--- a/Resources/Prototypes/_Mono/Shipyard/Expedition/comet.yml
+++ b/Resources/Prototypes/_Mono/Shipyard/Expedition/comet.yml
@@ -2,7 +2,7 @@
   id: Comet
   parent: BaseVessel
   name: CDF Comet # Triad, name and description change
-  description: An old de-militarized, jack-of-all-trades, utility vessel that saw service when the Civilian Defense Militia was still around.
+  description: An old de-militarized, jack-of-all-trades, utility vessel that saw service when the Civilian Defense Force was still around.
   price: 120000
   category: Large
   group: Expedition

--- a/Resources/Prototypes/_NF/Entities/Stations/nanotrasen.yml
+++ b/Resources/Prototypes/_NF/Entities/Stations/nanotrasen.yml
@@ -115,6 +115,7 @@
   categories: [ HideSpawnMenu ]
   components:
   - type: Transform
+  - type: StationFaxDeadDropHintExempt # Triad
 
 # region Expedition Shuttles
 - type: entity

--- a/Resources/Prototypes/_NF/Entities/Structures/Machines/Computers/computers_shipyard.yml
+++ b/Resources/Prototypes/_NF/Entities/Structures/Machines/Computers/computers_shipyard.yml
@@ -26,7 +26,7 @@
       whitelist:
         components:
         - IdCard
-        - ShipyardVoucher
+        - NFShipyardVoucher # Triad, misprediction fix
     newAccessLevels: [Captain]
     shipSaveBlacklist:
       components:

--- a/Resources/Prototypes/_NF/Events/nf_events.yml
+++ b/Resources/Prototypes/_NF/Events/nf_events.yml
@@ -66,7 +66,7 @@
     duration: 35
     earliestStart: 50
     minimumPlayers: 2
-    reoccurrenceDelay: 75 # Triad 75 < 50 
+    reoccurrenceDelay: 75 # Triad 75 < 50
   - type: RandomFaxRule
     minFaxes: 2 # Mono
     maxFaxes: 3 # Mono
@@ -79,6 +79,9 @@
     stampState: paper_stamp-syndicate
     preFaxActions:
     - !type:GetRandomDeadDropAction
+    blacklist: # Triad - blacklist
+      components:
+      - StationDeadDropHintExempt
 
 - type: entity
   id: SmugglingFaxBig
@@ -101,3 +104,6 @@
     stampState: paper_stamp-syndicate
     preFaxActions:
     - !type:GetRandomDeadDropAction
+    blacklist: # Triad - blacklist
+      components:
+      - StationDeadDropHintExempt

--- a/Resources/Prototypes/_NF/Events/nf_events.yml
+++ b/Resources/Prototypes/_NF/Events/nf_events.yml
@@ -81,7 +81,7 @@
     - !type:GetRandomDeadDropAction
     blacklist: # Triad - blacklist
       components:
-      - StationDeadDropHintExempt
+      - StationFaxDeadDropHintExempt
 
 - type: entity
   id: SmugglingFaxBig
@@ -106,4 +106,4 @@
     - !type:GetRandomDeadDropAction
     blacklist: # Triad - blacklist
       components:
-      - StationDeadDropHintExempt
+      - StationFaxDeadDropHintExempt

--- a/Resources/Prototypes/_Triad/Shipyard/TDF/adjutant.yml
+++ b/Resources/Prototypes/_Triad/Shipyard/TDF/adjutant.yml
@@ -35,4 +35,5 @@
       - type: StationJobs
         availableJobs:
           TdfEnforcer: [ 0, 0 ]
+      - type: StationDeadDropHintExempt
 

--- a/Resources/Prototypes/_Triad/Shipyard/TDF/adjutant.yml
+++ b/Resources/Prototypes/_Triad/Shipyard/TDF/adjutant.yml
@@ -17,6 +17,8 @@
   - Corvette
   engine:
   - Bananium
+  addComponents:
+  - type: ShipSavingBlacklist
 
 - type: gameMap
   id: Adjutant

--- a/Resources/Prototypes/_Triad/Shipyard/TDF/adjutant.yml
+++ b/Resources/Prototypes/_Triad/Shipyard/TDF/adjutant.yml
@@ -37,5 +37,3 @@
       - type: StationJobs
         availableJobs:
           TdfEnforcer: [ 0, 0 ]
-      - type: StationDeadDropHintExempt
-

--- a/Resources/Prototypes/_Triad/Shipyard/TDF/fling.yml
+++ b/Resources/Prototypes/_Triad/Shipyard/TDF/fling.yml
@@ -13,6 +13,8 @@
   - Patrol
   engine:
   - AME
+  addComponents:
+  - type: ShipSavingBlacklist
 
 - type: gameMap
   id: Fling

--- a/Resources/Prototypes/_Triad/Shipyard/TDF/fling.yml
+++ b/Resources/Prototypes/_Triad/Shipyard/TDF/fling.yml
@@ -31,3 +31,4 @@
       - type: StationJobs
         availableJobs:
           TdfEnforcer: [ 0, 0 ]
+      - type: StationDeadDropHintExempt

--- a/Resources/Prototypes/_Triad/Shipyard/TDF/fling.yml
+++ b/Resources/Prototypes/_Triad/Shipyard/TDF/fling.yml
@@ -33,4 +33,3 @@
       - type: StationJobs
         availableJobs:
           TdfEnforcer: [ 0, 0 ]
-      - type: StationDeadDropHintExempt

--- a/Resources/Prototypes/_Triad/Shipyard/TDF/grunder.yml
+++ b/Resources/Prototypes/_Triad/Shipyard/TDF/grunder.yml
@@ -16,6 +16,8 @@
   - Patrol
   engine:
   - AME
+  addComponents:
+  - type: ShipSavingBlacklist
 
 - type: gameMap
   id: Grunder

--- a/Resources/Prototypes/_Triad/Shipyard/TDF/grunder.yml
+++ b/Resources/Prototypes/_Triad/Shipyard/TDF/grunder.yml
@@ -34,4 +34,5 @@
       - type: StationJobs
         availableJobs:
           TdfEnforcer: [ 0, 0 ]
+      - type: StationDeadDropHintExempt
 

--- a/Resources/Prototypes/_Triad/Shipyard/TDF/grunder.yml
+++ b/Resources/Prototypes/_Triad/Shipyard/TDF/grunder.yml
@@ -36,5 +36,4 @@
       - type: StationJobs
         availableJobs:
           TdfEnforcer: [ 0, 0 ]
-      - type: StationDeadDropHintExempt
 

--- a/Resources/Prototypes/_Triad/Shipyard/TDF/jester.yml
+++ b/Resources/Prototypes/_Triad/Shipyard/TDF/jester.yml
@@ -31,3 +31,4 @@
       - type: StationJobs
         availableJobs:
           TdfEnforcer: [ 0, 0 ]
+      - type: StationDeadDropHintExempt

--- a/Resources/Prototypes/_Triad/Shipyard/TDF/jester.yml
+++ b/Resources/Prototypes/_Triad/Shipyard/TDF/jester.yml
@@ -33,4 +33,3 @@
       - type: StationJobs
         availableJobs:
           TdfEnforcer: [ 0, 0 ]
-      - type: StationDeadDropHintExempt

--- a/Resources/Prototypes/_Triad/Shipyard/TDF/jester.yml
+++ b/Resources/Prototypes/_Triad/Shipyard/TDF/jester.yml
@@ -34,4 +34,3 @@
         availableJobs:
           TdfEnforcer: [ 0, 0 ]
       - type: StationDeadDropHintExempt
-      - type: ShipSavingBlacklist

--- a/Resources/Prototypes/_Triad/Shipyard/TDF/jester.yml
+++ b/Resources/Prototypes/_Triad/Shipyard/TDF/jester.yml
@@ -13,6 +13,8 @@
   - Patrol
   engine:
   - AME
+  addComponents:
+  - type: ShipSavingBlacklist
 
 - type: gameMap
   id: Jester
@@ -32,3 +34,4 @@
         availableJobs:
           TdfEnforcer: [ 0, 0 ]
       - type: StationDeadDropHintExempt
+      - type: ShipSavingBlacklist

--- a/Resources/Prototypes/_Triad/Shipyard/TDF/mercy.yml
+++ b/Resources/Prototypes/_Triad/Shipyard/TDF/mercy.yml
@@ -31,3 +31,4 @@
       - type: StationJobs
         availableJobs:
           TdfEnforcer: [ 0, 0 ]
+      - type: StationDeadDropHintExempt

--- a/Resources/Prototypes/_Triad/Shipyard/TDF/mercy.yml
+++ b/Resources/Prototypes/_Triad/Shipyard/TDF/mercy.yml
@@ -13,6 +13,8 @@
   - Patrol
   engine:
   - AME
+  addComponents:
+  - type: ShipSavingBlacklist
 
 - type: gameMap
   id: Mercy
@@ -32,3 +34,4 @@
         availableJobs:
           TdfEnforcer: [ 0, 0 ]
       - type: StationDeadDropHintExempt
+      - type: ShipSavingBlacklist

--- a/Resources/Prototypes/_Triad/Shipyard/TDF/mercy.yml
+++ b/Resources/Prototypes/_Triad/Shipyard/TDF/mercy.yml
@@ -33,4 +33,3 @@
       - type: StationJobs
         availableJobs:
           TdfEnforcer: [ 0, 0 ]
-      - type: StationDeadDropHintExempt

--- a/Resources/Prototypes/_Triad/Shipyard/TDF/mercy.yml
+++ b/Resources/Prototypes/_Triad/Shipyard/TDF/mercy.yml
@@ -34,4 +34,3 @@
         availableJobs:
           TdfEnforcer: [ 0, 0 ]
       - type: StationDeadDropHintExempt
-      - type: ShipSavingBlacklist

--- a/Resources/Prototypes/_Triad/Shipyard/TDF/ravager.yml
+++ b/Resources/Prototypes/_Triad/Shipyard/TDF/ravager.yml
@@ -40,4 +40,3 @@
           TdfEnforcer: [ 0, 0 ]
           Borg: [ 0, 0 ]
       - type: StationDeadDropHintExempt
-      - type: ShipSavingBlacklist

--- a/Resources/Prototypes/_Triad/Shipyard/TDF/ravager.yml
+++ b/Resources/Prototypes/_Triad/Shipyard/TDF/ravager.yml
@@ -37,3 +37,4 @@
         availableJobs:
           TdfEnforcer: [ 0, 0 ]
           Borg: [ 0, 0 ]
+      - type: StationDeadDropHintExempt

--- a/Resources/Prototypes/_Triad/Shipyard/TDF/ravager.yml
+++ b/Resources/Prototypes/_Triad/Shipyard/TDF/ravager.yml
@@ -19,6 +19,8 @@
   - Science
   engine:
   - AME
+  addComponents:
+  - type: ShipSavingBlacklist
 
 - type: gameMap
   id: Ravager
@@ -38,3 +40,4 @@
           TdfEnforcer: [ 0, 0 ]
           Borg: [ 0, 0 ]
       - type: StationDeadDropHintExempt
+      - type: ShipSavingBlacklist

--- a/Resources/Prototypes/_Triad/Shipyard/TDF/ravager.yml
+++ b/Resources/Prototypes/_Triad/Shipyard/TDF/ravager.yml
@@ -39,4 +39,3 @@
         availableJobs:
           TdfEnforcer: [ 0, 0 ]
           Borg: [ 0, 0 ]
-      - type: StationDeadDropHintExempt


### PR DESCRIPTION
## About the PR
Adds a whitelist and blacklist for the fax event, which is used by the smuggler event to check for ``StationDeadDropHintExempt``
Exempt stations won't get deaddrop faxes

TDF ships should not be getting faxes. Removes all investigation needed and simply gives you a direct passage. Especially hurts lowpop when the TDF ships are one of the only few ships, so it's pretty much guaranteed to get a fax

also fixes:
TDF ships being able to be saved through exploits of the respawn system

## Requirements
<!-- Confirm the following by placing an X in the brackets [X]: -->
- [x] I have read relevant guidelines/documentation to this PR found on [our devwiki](https://monolith-station.github.io/mono-docs/).
- [x] I have added media to this PR or it does not require an ingame showcase.
- [x] I can confirm this PR contains either no AI-generated content, or AI-generated content that meets our guidelines.
<!-- You should understand that not following the above may get your PR closed at maintainer’s discretion -->
<!-- When using AI, make sure you are already proficient in creating whatever content you are attempting to generate and that you already have experience contributing to SS14. This means using AI to enhance your preexisting workflow, not vibecoding. -->

**Changelog**
:cl:
- fix: Fixed TDF ships getting syndicate smuggler faxes
- fix: Fixed ship vouchers mispredicting when you put them into the console (being laggy and making no sound)