### PR TITLE
Executed the Self Execute Command Due to Rulebreaks

### DIFF
--- a/Content.Server/_DV/Execution/ExecutionSystem.cs
+++ b/Content.Server/_DV/Execution/ExecutionSystem.cs
@@ -110,8 +110,8 @@ public sealed class ExecutionSystem : EntitySystem
         if (victim != attacker && _actionBlockerSystem.CanInteract(victim, null))
             return false;
 
-        //if (victim == attacker)
-        //    return false; // DeltaV - Fucking seriously? // Mono - Yes, seriously
+        if (victim == attacker)
+            return false; // DeltaV - Fucking seriously? // Mono - Yes, seriously // Triad - Seriously? Removed again
 
         // All checks passed
         return true;


### PR DESCRIPTION
## About the PR
Readded the if (victim==attacker) to prevent self executions

## Why / Balance
Prevent self execution/suicide rulebreaks

## Media
<img width="638" height="438" alt="image" src="https://github.com/user-attachments/assets/81cee1ff-2a9a-45a4-8e19-2ba9f5a08e64" />

Still allows execution of others
<img width="439" height="232" alt="image" src="https://github.com/user-attachments/assets/b07a3854-f0b1-4b5c-b7c8-997102961f2a" />

## Requirements

- [x] I have read relevant guidelines/documentation to this PR found on [our devwiki](https://monolith-station.github.io/mono-docs/).
- [x] I have added media to this PR or it does not require an ingame showcase.
- [x] I can confirm this PR contains either no AI-generated content, or AI-generated content that meets our guidelines.

## How to test
Grab a gun and try to *not* execute yourself

## Breaking changes
Literally just re add // before the lines 113 and 114 in executionsystems.cs

**Changelog**

:cl:
- remove: Removed the ability to self execute
