### PR TITLE
Sir Warock Charging Defib Cabinet Addition

### DIFF
--- a/Resources/Prototypes/Entities/Structures/Wallmounts/defib_cabinet.yml
+++ b/Resources/Prototypes/Entities/Structures/Wallmounts/defib_cabinet.yml
@@ -33,6 +33,15 @@
   - type: Damageable
     damageContainer: StructuralInorganic
     damageModifierSet: Metallic
+  # Begin DeltaV additions - Ported to Triad
+  - type: Charger
+    slotId: ItemCabinet
+  - type: ApcPowerReceiver
+    powerLoad: 1000
+  - type: ExtensionCableReceiver
+  - type: LightningTarget
+    priority: 1
+  # End DeltaV additions
   - type: Destructible
     thresholds:
     - trigger: !type:DamageTrigger


### PR DESCRIPTION
## About the PR
Added Sir Warocks defib cabinet charging

Link:
https://github.com/DeltaV-Station/Delta-v/pull/4321

## Why / Balance
No more going to revive someone and finding a dead defib in your cabinet halfway through the shift

## Media
<img width="714" height="374" alt="image" src="https://github.com/user-attachments/assets/c0e5eef5-3b23-4c76-b488-dac11976fe93" />

After defibing:
<img width="667" height="221" alt="image" src="https://github.com/user-attachments/assets/8946aa27-bdce-471c-811e-76de36946976" />

shortly after being placed in the cabinet:
<img width="684" height="439" alt="image" src="https://github.com/user-attachments/assets/00a2e2e3-5394-4ef6-8a4d-24dc80571e57" />

## Requirements
- [X] I have read relevant guidelines/documentation to this PR found on [our devwiki](https://monolith-station.github.io/mono-docs/).
- [X] I have added media to this PR or it does not require an ingame showcase.
- [X] I can confirm this PR contains either no AI-generated content, or AI-generated content that meets our guidelines.

## How to test
Put a drained battery in a defib and put it in the cabinet!


**Changelog**

:cl:
- add: Defibrillator cabinets recharge defibrillators now!
