### PR TITLE
Blast Door Fix

### DIFF
--- a/Resources/Prototypes/Entities/Structures/Doors/Shutter/blast_door.yml
+++ b/Resources/Prototypes/Entities/Structures/Doors/Shutter/blast_door.yml
@@ -26,6 +26,7 @@
       path: /Audio/Machines/blastdoor.ogg
     closeSound:
       path: /Audio/Machines/blastdoor.ogg
+    performCollisionCheck: false # Triad
   - type: Occluder
   - type: Appearance
   - type: RadiationBlocker

--- a/Resources/Prototypes/Entities/Structures/Doors/Shutter/blast_door.yml
+++ b/Resources/Prototypes/Entities/Structures/Doors/Shutter/blast_door.yml
@@ -19,9 +19,8 @@
     openingAnimationTime: 1.0
     closingAnimationTime: 1.0
     canPry: false
-    crushDamage:
-      types:
-        Blunt: 25 # yowch
+    crushDamage: null # Triad
+    canCrush: false # Triad
     openSound:
       path: /Audio/Machines/blastdoor.ogg
     closeSound:

--- a/Resources/Prototypes/_Triad/Entities/Structures/Doors/Shutter/blast_door.yml
+++ b/Resources/Prototypes/_Triad/Entities/Structures/Doors/Shutter/blast_door.yml
@@ -1,0 +1,15 @@
+- type: entity
+  id: BlastDoorIndestructibleOpen
+  parent: BlastDoorIndestructible
+  suffix: Indestructible, Open
+  components:
+  - type: Door
+    state: Open
+  - type: Occluder
+    enabled: false
+  - type: Physics
+    canCollide: false
+  - type: Airtight
+    airBlocked: false
+  - type: RadiationBlocker
+    enabled: false


### PR DESCRIPTION
## About the PR
- Fixed blast doors not closing on-top of airlocks
- Added an indestructible variant of the open blast door for mapping dungeons and such

Unfortunately, it can't crush anymore
but it didn't do that in the first place

**Changelog**
:cl:
- fix: Fixed blast doors not closing on-top of airlocks
