### PR TITLE
Knallstock Extended Mags

### DIFF
--- a/Resources/Prototypes/_Mono/Entities/Objects/Weapons/Guns/SMGs/smgs.yml
+++ b/Resources/Prototypes/_Mono/Entities/Objects/Weapons/Guns/SMGs/smgs.yml
@@ -324,7 +324,9 @@
         whitelist:
           tags:
           - Magazine45_ACPPistolFMJ
+          - Magazine45_ACPPistolHighCapacityFMJ
           - Magazine9x19mmPistolFMJ
+          - Magazine9x19mmPistolHighCapacityFMJ
       gun_chamber:
         name: Chamber
         startingItem: Cartridge45_ACPFMJ


### PR DESCRIPTION
## About the PR
Gave Knallstock the ability to take extended mags of its respective ammo

## Why / Balance
Why not, it makes sense.

## Media

## Requirements
<!-- Confirm the following by placing an X in the brackets [X]: -->
- [X] I have read relevant guidelines/documentation to this PR found on [our devwiki](https://monolith-station.github.io/mono-docs/).
- [X] I have added media to this PR or it does not require an ingame showcase.
- [X] I can confirm this PR contains either no AI-generated content, or AI-generated content that meets our guidelines.
<!-- You should understand that not following the above may get your PR closed at maintainer’s discretion -->
<!-- When using AI, make sure you are already proficient in creating whatever content you are attempting to generate and that you already have experience contributing to SS14. This means using AI to enhance your preexisting workflow, not vibecoding. -->

## How to test
Boot up dev env
Spawn knallstock and compatible extended mags
Insert and fire


**Changelog**
<!-- Add a Changelog entry to make players aware of new features or changes that could affect gameplay.
Make sure to read the guidelines and take this Changelog template out of the comment block in order for it to show up.
Changelog must have a :cl: symbol, so the bot recognizes the changes and adds them to the game's changelog.
Remove this symbol for non-player facing PRs.-->
:cl:
- tweak: Knallstock can take extendeds now
