### PR TITLE
Rule 1.7D

### DIFF
--- a/Resources/ServerInfo/_Triad/Guidebook/Rules/CoreRules/RuleC1.xml
+++ b/Resources/ServerInfo/_Triad/Guidebook/Rules/CoreRules/RuleC1.xml
@@ -20,4 +20,6 @@
   - [color=#a4885c]1.7B[/color] Entering a public area cordoned off by a privacy holobarrier, automatically grants consent to view NSFW content contained within.  Agreeing to abide by the terms in the holobarrier description. Additional explicit consent is required before participating in any NSFW activity.
 
   - [color=#a4885c]1.7C[/color] Never open a bolted door with someone else's privacy holobarrier on it.
+
+  - [color=#a4885c]1.7D[/color] Do not hide contraband or other antagonistic activity behind a holobarrier.  Keep all antagonistic activity in a location publicly accessible.
 </Document>


### PR DESCRIPTION
## About the PR
<!-- What did you change? -->
<!-- If this is a code change, summarize at high level how your new code works. This makes it easier to review. -->
  - [color=#a4885c]1.7D[/color] Do not hide contraband or other antagonistic activity behind a holobarrier.  Keep all antagonistic activity in a location publicly accessible.
 
## Why / Balance
<!-- Discuss how this would affect game balance or explain why it was changed. Link any relevant discussions or issues. -->
grrrr
## Media
<!-- Attach media if the PR makes ingame changes (clothing, items, features, etc). 
Small fixes/refactors are exempt. Media may be used in SS14 progress reports with credit. -->

## Requirements
<!-- Confirm the following by placing an X in the brackets [X]: -->
- [ ] I have read relevant guidelines/documentation to this PR found on [our devwiki](https://monolith-station.github.io/mono-docs/).
- [ ] I have added media to this PR or it does not require an ingame showcase.
- [ ] I can confirm this PR contains either no AI-generated content, or AI-generated content that meets our guidelines.
<!-- You should understand that not following the above may get your PR closed at maintainer’s discretion -->
<!-- When using AI, make sure you are already proficient in creating whatever content you are attempting to generate and that you already have experience contributing to SS14. This means using AI to enhance your preexisting workflow, not vibecoding. -->

## How to test
<!-- Describe the way it can be tested -->

## Breaking changes
<!-- List any breaking changes, including namespaces, public class/method/field changes, prototype renames; and provide instructions for fixing them. -->

**Changelog**
<!-- Add a Changelog entry to make players aware of new features or changes that could affect gameplay.
Make sure to read the guidelines and take this Changelog template out of the comment block in order for it to show up.
Changelog must have a :cl: symbol, so the bot recognizes the changes and adds them to the game's changelog.
Remove this symbol for non-player facing PRs.-->
