### PR TITLE
Allow Construction Bags/Boxes to Store Electronics and Tiles

### DIFF
--- a/Resources/Prototypes/_NF/Entities/Objects/Specific/Engineering/construction_bag.yml
+++ b/Resources/Prototypes/_NF/Entities/Objects/Specific/Engineering/construction_bag.yml
@@ -41,6 +41,10 @@
       - CableCoil
       components:
       - ConstructionMaterials
+      - BaseElectronics # Triad
+      - FloorTile # Triad
+      - ComputerBoard # Triad
+      - MachineBoard # Triad
     blacklist:
       tags:
       - PrizeTicket

--- a/Resources/Prototypes/_NF/Entities/Structures/Storage/magnetbox.yml
+++ b/Resources/Prototypes/_NF/Entities/Structures/Storage/magnetbox.yml
@@ -145,6 +145,10 @@
       components:
       - ConstructionMaterials
       - AtmosDevice # Frontier #4228
+      - BaseElectronics # Triad
+      - FloorTile # Triad
+      - ComputerBoard # Triad
+      - MachineBoard # Triad
     blacklist:
       tags:
       - PrizeTicket


### PR DESCRIPTION
## About the PR
<!-- What did you change? -->
<!-- If this is a code change, summarize at high level how your new code works. This makes it easier to review. -->
Added door, computer and machine electronics to the whitelist of both the construction bag and construction box.
Also made it so they can pick up tiles, no more accidentally placing tiles when you mean to pick them up. 
## Why / Balance
The construction bag can now store more.... construction!

## Media
<!-- Attach media if the PR makes ingame changes (clothing, items, features, etc). 
Small fixes/refactors are exempt. Media may be used in SS14 progress reports with credit. -->
<img width="1150" height="819" alt="image" src="https://github.com/user-attachments/assets/5ada81bd-2b88-4e33-9c91-147c05c5557b" />

## Requirements
<!-- Confirm the following by placing an X in the brackets [X]: -->
- [X] I have read relevant guidelines/documentation to this PR found on [our devwiki](https://monolith-station.github.io/mono-docs/).
- [X] I have added media to this PR or it does not require an ingame showcase.
- [X] I can confirm this PR contains either no AI-generated content, or AI-generated content that meets our guidelines.
- [X] Does anyone even read these?
<!-- You should understand that not following the above may get your PR closed at maintainer’s discretion -->
<!-- When using AI, make sure you are already proficient in creating whatever content you are attempting to generate and that you already have experience contributing to SS14. This means using AI to enhance your preexisting workflow, not vibecoding. -->

## How to test
bag.
circuit board.
put in bag. 
:D

## Breaking changes
<!-- List any breaking changes, including namespaces, public class/method/field changes, prototype renames; and provide instructions for fixing them. -->

**Changelog**
<!-- Add a Changelog entry to make players aware of new features or changes that could affect gameplay.
Make sure to read the guidelines and take this Changelog template out of the comment block in order for it to show up.
Changelog must have a :cl: symbol, so the bot recognizes the changes and adds them to the game's changelog.
Remove this symbol for non-player facing PRs.-->
:cl:
- add: You can now put circuit boards and tiles into construction bags and boxes.
