### PR TITLE
Syndicate Cache and AI Fixes

### DIFF
--- a/Content.Server/NPC/Components/NPCRangedCombatComponent.cs
+++ b/Content.Server/NPC/Components/NPCRangedCombatComponent.cs
@@ -42,13 +42,6 @@ public sealed partial class NPCRangedCombatComponent : Component
     public bool TargetInLOS = false;
 
     /// <summary>
-    /// If true, only opaque objects will block line of sight.
-    /// </summary>
-    [ViewVariables(VVAccess.ReadWrite)]
-    // ReSharper disable once InconsistentNaming
-    public bool UseOpaqueForLOSChecks = false;
-
-    /// <summary>
     /// Delay after target is in LOS before we start shooting.
     /// </summary>
     [ViewVariables(VVAccess.ReadWrite)]

--- a/Content.Server/NPC/HTN/Preconditions/TargetInLOSPrecondition.cs
+++ b/Content.Server/NPC/HTN/Preconditions/TargetInLOSPrecondition.cs
@@ -7,8 +7,11 @@ namespace Content.Server.NPC.HTN.Preconditions;
 
 public sealed partial class TargetInLOSPrecondition : HTNPrecondition
 {
-    [Dependency] private readonly IEntityManager _entManager = default!;
+    [Dependency] private IEntityManager _entManager = default!;
     private InteractionSystem _interaction = default!;
+    // Mono
+    private EntityQuery<PhysicsComponent> _physicsQuery;
+    private EntityQuery<RequireProjectileTargetComponent> _requireTargetQuery;
 
     [DataField("targetKey")]
     public string TargetKey = "Target";

--- a/Content.Server/NPC/HTN/Preconditions/TargetInLOSPrecondition.cs
+++ b/Content.Server/NPC/HTN/Preconditions/TargetInLOSPrecondition.cs
@@ -1,5 +1,7 @@
 using Content.Server.Interaction;
+using Content.Shared.Damage.Components;
 using Content.Shared.Physics;
+using Robust.Shared.Physics.Components;
 
 namespace Content.Server.NPC.HTN.Preconditions;
 
@@ -14,13 +16,21 @@ public sealed partial class TargetInLOSPrecondition : HTNPrecondition
     [DataField("rangeKey")]
     public string RangeKey = "RangeKey";
 
-    [DataField("opaqueKey")]
-    public bool UseOpaqueForLOSChecksKey = true;
+    // Mono
+    [DataField]
+    public CollisionGroup ObstructedMask = CollisionGroup.Opaque;
+
+    // Mono
+    [DataField]
+    public CollisionGroup BulletMask = CollisionGroup.Impassable | CollisionGroup.BulletImpassable;
 
     public override void Initialize(IEntitySystemManager sysManager)
     {
         base.Initialize(sysManager);
         _interaction = sysManager.GetEntitySystem<InteractionSystem>();
+        // Mono
+        _physicsQuery = _entManager.GetEntityQuery<PhysicsComponent>();
+        _requireTargetQuery = _entManager.GetEntityQuery<RequireProjectileTargetComponent>();
     }
 
     public override bool IsMet(NPCBlackboard blackboard)
@@ -31,8 +41,11 @@ public sealed partial class TargetInLOSPrecondition : HTNPrecondition
             return false;
 
         var range = blackboard.GetValueOrDefault<float>(RangeKey, _entManager);
-        var collisionGroup = UseOpaqueForLOSChecksKey ? CollisionGroup.Opaque : (CollisionGroup.Impassable | CollisionGroup.InteractImpassable);
 
-        return _interaction.InRangeUnobstructed(owner, target, range, collisionGroup);
+        return _interaction.InRangeUnobstructed(owner, target, range, ObstructedMask, predicate: (EntityUid entity) =>
+        {
+            return _physicsQuery.TryGetComponent(entity, out var physics) && (physics.CollisionLayer & (int)BulletMask) == 0 // ignore if it can't collide with bullets
+                || _requireTargetQuery.HasComponent(entity); // or if it requires targeting
+        });
     }
 }

--- a/Content.Server/NPC/HTN/PrimitiveTasks/Operators/Combat/Ranged/GunOperator.cs
+++ b/Content.Server/NPC/HTN/PrimitiveTasks/Operators/Combat/Ranged/GunOperator.cs
@@ -34,11 +34,13 @@ public sealed partial class GunOperator : HTNOperator, IHtnConditionalShutdown
     [DataField("requireLOS")]
     public bool RequireLOS = false;
 
-    /// <summary>
-    /// If true, only opaque objects will block line of sight.
-    /// </summary>
-    [DataField("opaqueKey")]
-    public bool UseOpaqueForLOSChecks = false;
+    // Mono
+    [DataField]
+    public CollisionGroup ObstructedMask = CollisionGroup.Opaque;
+
+    // Mono
+    [DataField]
+    public CollisionGroup BulletMask = CollisionGroup.Impassable | CollisionGroup.BulletImpassable;
 
     // Like movement we add a component and pass it off to the dedicated system.
 
@@ -66,7 +68,8 @@ public sealed partial class GunOperator : HTNOperator, IHtnConditionalShutdown
 
         var ranged = _entManager.EnsureComponent<NPCRangedCombatComponent>(blackboard.GetValue<EntityUid>(NPCBlackboard.Owner));
         ranged.Target = blackboard.GetValue<EntityUid>(TargetKey);
-        ranged.UseOpaqueForLOSChecks = UseOpaqueForLOSChecks;
+        ranged.ObstructedMask = ObstructedMask; // Mono
+        ranged.BulletMask = BulletMask; // Mono
 
         if (blackboard.TryGetValue<float>(NPCBlackboard.RotateSpeed, out var rotSpeed, _entManager))
         {

--- a/Content.Server/NPC/Systems/NPCCombatSystem.Ranged.cs
+++ b/Content.Server/NPC/Systems/NPCCombatSystem.Ranged.cs
@@ -160,10 +160,8 @@ public sealed partial class NPCCombatSystem
             if (comp.LOSAccumulator < 0f)
             {
                 comp.LOSAccumulator += UnoccludedCooldown;
-
-                // For consistency with NPC steering.
-                var collisionGroup = comp.UseOpaqueForLOSChecks ? CollisionGroup.Opaque : (CollisionGroup.Impassable | CollisionGroup.InteractImpassable);
-                comp.TargetInLOS = _interaction.InRangeUnobstructed(uid, comp.Target, distance + 0.1f, collisionGroup);
+                // Mono
+                comp.TargetInLOS = InRangeGoodTarget((gunUid, gun), uid, comp.Target, distance, comp.ShotsThreshold, comp.ObstructedMask, comp.BulletMask);
             }
 
             if (!comp.TargetInLOS)

--- a/Resources/Maps/_Triad/Bluespace/syndiecache.yml
+++ b/Resources/Maps/_Triad/Bluespace/syndiecache.yml
@@ -4,8 +4,8 @@ meta:
   engineVersion: 277.2.1
   forkId: ""
   forkVersion: ""
-  time: 07/24/2026 16:21:50
-  entityCount: 1106
+  time: 07/24/2026 22:46:23
+  entityCount: 1115
 maps: []
 grids:
 - 1
@@ -67,7 +67,7 @@ entities:
       chunks:
         0,0:
           ind: 0,0
-          tiles: egAAAAAAAAEAAAAAAAABAAAAAAAAAQAAAAAAAHoAAAAAAAAjAAAAAAIAAgAAAAAAAAIAAAAAAAB5AAAAAAAAAwAAAAAAADoAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAHoAAAAAAAABAAAAAAAAAQAAAAAAAHoAAAAAAAB6AAAAAAAAIwAAAAADAAAAAAAAAAAAAAAAAAAAeQAAAAAAAAAAAAAAAAB5AAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAB6AAAAAAAAegAAAAAAAHoAAAAAAAB6AAAAAAAAegAAAAAAAHoAAAAAAAAAAAAAAAAAAAAAAAAAAHkAAAAAAAADAAAAAAAAeQAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAABAAAAAAAAAQAAAAAAAAEAAAAAAAAAgAAAAAAAHoAAAAAAAB5AAAAAAAAAgAAAAAAAAIAAAAAAAB5AAAAAAAAAAAAAAAAAHkAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAUAAAAAAAAFAAAAAAAABQAAAAAAAAUAAAAAAAB5AAAAAAAAeQAAAAAAAAAAAAAAAAAAAAAAAAAAeQAAAAAAAAAAAAAAAAB5AAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAGAAAAAAAABgAAAAAAAHoAAAAAAAAnAAAAAAAAegAAAAAAAHkAAAAAAAAAAAAAAAAAAAAAAAAAAHkAAAAAAAAAAAAAAAAAeQAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAABQAAAAAAAAUAAAAAAAAFAAAAAAAABQAAAAAAAHkAAAAAAAB5AAAAAAAAAgAAAAAAAAIAAAAAAAB5AAAAAAAAAAAAAAAAADoAAAAAAAA6AAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAQAAAAAAAAEAAAAAAAABAAAAAAAAAIAAAAAAAAHAAAAAAAAeQAAAAAAAAAAAAAAAAAAAAAAAAAAeQAAAAAAAAIAAAAAAAA6AAAAAAAAOgAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAB5AAAAAAAAeQAAAAAAAHkAAAAAAAB5AAAAAAAAeQAAAAAAAHkAAAAAAAAAAAAAAAAAAAAAAAAAAHkAAAAAAAAAAAAAAAAAOgAAAAAAADoAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAeQAAAAAAAHkAAAAAAAACAAAAAAAAAgAAAAAAAHkAAAAAAAB5AAAAAAAAAwAAAAAAAAMAAAAAAAB5AAAAAAAAAAAAAAAAAHkAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAHkAAAAAAAB5AAAAAAAAeQAAAAAAAHkAAAAAAAB5AAAAAAAAeQAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAB5AAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAB5AAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAHkAAAAAAAB5AAAAAAAAeQAAAAAAAHkAAAAAAAB5AAAAAAAAeQAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAgAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAADoAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAA==
+          tiles: egAAAAAAAAEAAAAAAAABAAAAAAAAAQAAAAAAAHoAAAAAAAAjAAAAAAIAAgAAAAAAAAIAAAAAAAB5AAAAAAAAAwAAAAAAADoAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAHoAAAAAAAABAAAAAAAAAQAAAAAAAHoAAAAAAAB6AAAAAAAAIwAAAAADAAAAAAAAAAAAAAAAAAAAeQAAAAAAAAAAAAAAAAB5AAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAB6AAAAAAAAegAAAAAAAHoAAAAAAAB6AAAAAAAAegAAAAAAAHoAAAAAAAAAAAAAAAAAAAAAAAAAAHkAAAAAAAADAAAAAAAAeQAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAABAAAAAAAAAQAAAAAAAAEAAAAAAAAAgAAAAAAAHoAAAAAAAB5AAAAAAAAAgAAAAAAAAIAAAAAAAB5AAAAAAAAAAAAAAAAAHkAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAUAAAAAAAAFAAAAAAAABQAAAAAAAAUAAAAAAAB5AAAAAAAAeQAAAAAAAAAAAAAAAAAAAAAAAAAAeQAAAAAAAAAAAAAAAAB5AAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAGAAAAAAAABgAAAAAAAHoAAAAAAAAnAAAAAAAAegAAAAAAAHkAAAAAAAAAAAAAAAAAAAAAAAAAAHkAAAAAAAAAAAAAAAAAeQAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAABQAAAAAAAAUAAAAAAAAFAAAAAAAABQAAAAAAAHkAAAAAAAB5AAAAAAAAAgAAAAAAAAIAAAAAAAB5AAAAAAAAAAAAAAAAADoAAAAAAAA6AAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAQAAAAAAAAEAAAAAAAABAAAAAAAAAIAAAAAAAAHAAAAAAAAeQAAAAAAAAAAAAAAAAAAAAAAAAAAeQAAAAAAAAIAAAAAAAA6AAAAAAAAOgAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAB5AAAAAAAAeQAAAAAAAHkAAAAAAAB5AAAAAAAAeQAAAAAAAHkAAAAAAAAAAAAAAAAAAAAAAAAAAHkAAAAAAAAAAAAAAAAAOgAAAAAAADoAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAIAAAAAAAAHkAAAAAAAACAAAAAAAAAgAAAAAAAHkAAAAAAAB5AAAAAAAAAwAAAAAAAAMAAAAAAAB5AAAAAAAAAAAAAAAAAHkAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAHkAAAAAAAB5AAAAAAAAeQAAAAAAAHkAAAAAAAB5AAAAAAAAeQAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAB5AAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAB5AAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAHkAAAAAAAB5AAAAAAAAeQAAAAAAAHkAAAAAAAB5AAAAAAAAeQAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAgAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAADoAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAA==
           version: 7
         0,-1:
           ind: 0,-1
@@ -101,10 +101,10 @@ entities:
     - type: OccluderTree
     - type: SpreaderGrid
       spreadQueues:
-        Smoke: []
         MetalFoam: []
         Puddle: []
         Kudzu: []
+        Smoke: []
     - type: Shuttle
       dampingModifier: 0.25
     - type: GridPathfinding
@@ -461,7 +461,7 @@ entities:
           -1,1:
             0: 56797
           0,2:
-            1: 7999
+            1: 7983
             2: 192
           -1,2:
             1: 63999
@@ -937,6 +937,16 @@ entities:
     components:
     - type: Transform
       pos: -4.5,8.5
+      parent: 1
+  - uid: 780
+    components:
+    - type: Transform
+      pos: -3.5,8.5
+      parent: 1
+  - uid: 846
+    components:
+    - type: Transform
+      pos: 0.5,8.5
       parent: 1
 - proto: AtmosDeviceFanDirectional
   entities:
@@ -2599,6 +2609,11 @@ entities:
     - type: Transform
       pos: -20.5,-3.5
       parent: 1
+  - uid: 1113
+    components:
+    - type: Transform
+      pos: -3.5,8.5
+      parent: 1
 - proto: CableApcStack1
   entities:
   - uid: 559
@@ -3060,6 +3075,51 @@ entities:
     - type: Transform
       pos: -5.5,5.5
       parent: 1
+  - uid: 824
+    components:
+    - type: Transform
+      pos: 0.5,8.5
+      parent: 1
+  - uid: 1107
+    components:
+    - type: Transform
+      pos: -0.5,5.5
+      parent: 1
+  - uid: 1108
+    components:
+    - type: Transform
+      pos: -3.5,5.5
+      parent: 1
+  - uid: 1109
+    components:
+    - type: Transform
+      pos: -2.5,5.5
+      parent: 1
+  - uid: 1110
+    components:
+    - type: Transform
+      pos: 0.5,7.5
+      parent: 1
+  - uid: 1111
+    components:
+    - type: Transform
+      pos: 0.5,6.5
+      parent: 1
+  - uid: 1112
+    components:
+    - type: Transform
+      pos: -3.5,8.5
+      parent: 1
+  - uid: 1114
+    components:
+    - type: Transform
+      pos: 0.5,5.5
+      parent: 1
+  - uid: 1115
+    components:
+    - type: Transform
+      pos: -1.5,5.5
+      parent: 1
 - proto: CableMVStack1
   entities:
   - uid: 547
@@ -3219,6 +3279,25 @@ entities:
     components:
     - type: Transform
       parent: 648
+    - type: GroupExamine
+      group:
+      - hoverMessage: ""
+        contextText: verb-examine-group-other
+        icon: /Textures/Interface/examine-star.png
+        components:
+        - Armor
+        - ClothingSpeedModifier
+        entries:
+        - message: >-
+            It provides the following protection:
+
+            - [color=orange]Explosion[/color] damage [color=white]to contents[/color] reduced by [color=lightblue]75%[/color].
+          priority: 0
+          component: Armor
+        - message: This decreases your running speed by [color=yellow]10%[/color].
+          priority: 0
+          component: ClothingSpeedModifier
+        title: null
     - type: Physics
       canCollide: False
     - type: InsideEntityStorage
@@ -3294,7 +3373,7 @@ entities:
   - uid: 650
     components:
     - type: Transform
-      parent: 648
+      parent: 616
     - type: Physics
       canCollide: False
     - type: GroupExamine
@@ -3362,7 +3441,7 @@ entities:
   - uid: 910
     components:
     - type: Transform
-      pos: 1.476,3.5759797
+      pos: 1.5372324,3.5380068
       parent: 1
 - proto: ComputerTabletopGunneryConsole
   entities:
@@ -3431,10 +3510,13 @@ entities:
     - type: Transform
       pos: -0.5,-6.5
       parent: 1
-- proto: CrateUranium
+- proto: CrateSyndicate
   entities:
-  - uid: 775
+  - uid: 230
     components:
+    - type: MetaData
+      desc: Contains valuable materials for Syndicate use!
+      name: Syndicate materials crate
     - type: Transform
       pos: 1.5,3.5
       parent: 1
@@ -3444,15 +3526,13 @@ entities:
           showEnts: False
           occludes: True
           ents:
-          - 777
+          - 231
+          - 775
           - 696
-          - 688
-          - 596
-          - 595
           - 697
-          - 780
-          - 779
-          - 778
+          - 595
+          - 596
+          - 688
           - 776
         paper_label: !type:ContainerSlot
           showEnts: False
@@ -5321,14 +5401,14 @@ entities:
           showEnts: False
           occludes: True
           ents:
-          - 618
+          - 650
           - 593
-          - 617
-          - 619
-          - 620
-          - 621
           - 622
-          - 824
+          - 621
+          - 620
+          - 619
+          - 617
+          - 618
         paper_label: !type:ContainerSlot
           showEnts: False
           occludes: True
@@ -5344,11 +5424,10 @@ entities:
           showEnts: False
           occludes: True
           ents:
+          - 215
           - 388
-          - 650
           - 649
           - 651
-          - 215
           - 768
         paper_label: !type:ContainerSlot
           showEnts: False
@@ -6079,75 +6158,60 @@ entities:
     - type: Transform
       pos: -7.0988097,6.818386
       parent: 1
+- proto: SheetIridite10
+  entities:
+  - uid: 775
+    components:
+    - type: Transform
+      parent: 230
+    - type: Physics
+      canCollide: False
+    - type: InsideEntityStorage
+- proto: SheetPlastitanium10
+  entities:
+  - uid: 776
+    components:
+    - type: Transform
+      parent: 230
+    - type: Stack
+      count: 20
+    - type: Physics
+      canCollide: False
+    - type: InsideEntityStorage
 - proto: SheetUraniumDepleted
   entities:
   - uid: 595
     components:
     - type: Transform
-      parent: 775
+      parent: 230
     - type: Physics
       canCollide: False
     - type: InsideEntityStorage
   - uid: 596
     components:
     - type: Transform
-      parent: 775
+      parent: 230
     - type: Physics
       canCollide: False
     - type: InsideEntityStorage
   - uid: 688
     components:
     - type: Transform
-      parent: 775
+      parent: 230
     - type: Physics
       canCollide: False
     - type: InsideEntityStorage
   - uid: 696
     components:
     - type: Transform
-      parent: 775
+      parent: 230
     - type: Physics
       canCollide: False
     - type: InsideEntityStorage
   - uid: 697
     components:
     - type: Transform
-      parent: 775
-    - type: Physics
-      canCollide: False
-    - type: InsideEntityStorage
-  - uid: 776
-    components:
-    - type: Transform
-      parent: 775
-    - type: Physics
-      canCollide: False
-    - type: InsideEntityStorage
-  - uid: 777
-    components:
-    - type: Transform
-      parent: 775
-    - type: Physics
-      canCollide: False
-    - type: InsideEntityStorage
-  - uid: 778
-    components:
-    - type: Transform
-      parent: 775
-    - type: Physics
-      canCollide: False
-    - type: InsideEntityStorage
-  - uid: 779
-    components:
-    - type: Transform
-      parent: 775
-    - type: Physics
-      canCollide: False
-    - type: InsideEntityStorage
-  - uid: 780
-    components:
-    - type: Transform
-      parent: 775
+      parent: 230
     - type: Physics
       canCollide: False
     - type: InsideEntityStorage
@@ -6315,17 +6379,17 @@ entities:
     - type: Transform
       pos: -9.5,3.5
       parent: 1
-  - uid: 846
-    components:
-    - type: Transform
-      pos: -6.5,0.5
-      parent: 1
 - proto: SpawnRandomEnergyTurretRangeSyndicate
   entities:
   - uid: 80
     components:
     - type: Transform
       pos: 6.5,6.5
+      parent: 1
+  - uid: 777
+    components:
+    - type: Transform
+      pos: -6.5,0.5
       parent: 1
 - proto: SpawnRandomTurretRangeSyndicate
   entities:
@@ -6421,11 +6485,15 @@ entities:
       rot: 3.141592653589793 rad
       pos: 3.5,3.5
       parent: 1
+    - type: OnUseTimerTrigger
+      delay: 30
   - uid: 837
     components:
     - type: Transform
       pos: 3.5,7.5
       parent: 1
+    - type: OnUseTimerTrigger
+      delay: 30
 - proto: SyndicateJawsOfLife
   entities:
   - uid: 413
@@ -6484,10 +6552,10 @@ entities:
       parent: 1
 - proto: Telecrystal5
   entities:
-  - uid: 824
+  - uid: 231
     components:
     - type: Transform
-      parent: 616
+      parent: 230
     - type: Stack
       count: 15
     - type: Physics
@@ -7188,16 +7256,6 @@ entities:
     - type: Transform
       pos: -3.5,8.5
       parent: 1
-  - uid: 230
-    components:
-    - type: Transform
-      pos: 1.5,9.5
-      parent: 1
-  - uid: 231
-    components:
-    - type: Transform
-      pos: 0.5,9.5
-      parent: 1
   - uid: 242
     components:
     - type: Transform
@@ -7384,6 +7442,16 @@ entities:
     components:
     - type: Transform
       pos: -4.5,-6.5
+      parent: 1
+  - uid: 778
+    components:
+    - type: Transform
+      pos: 1.5,9.5
+      parent: 1
+  - uid: 779
+    components:
+    - type: Transform
+      pos: 0.5,9.5
       parent: 1
   - uid: 802
     components:

--- a/Resources/Prototypes/NPCs/root.yml
+++ b/Resources/Prototypes/NPCs/root.yml
@@ -45,10 +45,8 @@
             - !type:TargetInLOSPrecondition
               targetKey: Target
               rangeKey: RangedRange
-              opaqueKey: true
           operator: !type:GunOperator
             targetKey: Target
-            opaqueKey: true
           services:
             - !type:UtilityService
               id: RangedService


### PR DESCRIPTION
## About the PR
Syndie cache tweaks:
- Changed the uranium crate with 10 stacks of depleted uranium in it to a syndicate crate with depleted uranium, TC, plastitanium, and iridite (people would ignore the uranium crate since they thought it was just normal uranium, not 100k worth of uranium)
- Changed the syndicate bomb time in the cache to 30 seconds. You could easily grab all the loot out of the vault within 2 minutes, making it so stepping on the pressure plates is almost meaningless.

AI Fixes:
- fixed laser turrets not shooting through windows

## Requirements
<!-- Confirm the following by placing an X in the brackets [X]: -->
- [x] I have read relevant guidelines/documentation to this PR found on [our devwiki](https://monolith-station.github.io/mono-docs/).
- [x] I have added media to this PR or it does not require an ingame showcase.
- [x] I can confirm this PR contains either no AI-generated content, or AI-generated content that meets our guidelines.
<!-- You should understand that not following the above may get your PR closed at maintainer’s discretion -->
<!-- When using AI, make sure you are already proficient in creating whatever content you are attempting to generate and that you already have experience contributing to SS14. This means using AI to enhance your preexisting workflow, not vibecoding. -->

**Changelog**
:cl:
- fix: Fixed NPCs (laser turrets) not shooting through windows.
- tweak: Changed the depleted uranium crate in the syndicate cache into a syndicate crate
- tweak: Tweaked the traps in the syndicate cache. Watch your step!
