### PR TITLE
Cherrypick: Full Radiation Immunity Tweak

### DIFF
--- a/Resources/Prototypes/Entities/Clothing/OuterClothing/hardsuits.yml
+++ b/Resources/Prototypes/Entities/Clothing/OuterClothing/hardsuits.yml
@@ -470,7 +470,7 @@
         Slash: 0.8
         Piercing: 0.85
         Heat: 0.35
-        Radiation: 0.0
+        Radiation: 0.01 # Mono 0.0 -> 0.01
         Caustic: 0.7
   - type: ClothingSpeedModifier
     walkModifier: 0.8
@@ -545,7 +545,7 @@
         Slash: 0.65 # Mono 0.65 < 0.8
         Piercing: 0.65 # Mono 0.65 < 0.9
         Heat: 0.3
-        Radiation: 0 # Mono 0 < 0.1
+        Radiation: 0.01 # Mono 0.1 -> 0.0 -> 0.01
         Caustic: 0.2
   - type: ExplosionResistance
     damageCoefficient: 0.1

--- a/Resources/Prototypes/_Goobstation/Entities/Clothing/OuterClothing/modsuit.yml
+++ b/Resources/Prototypes/_Goobstation/Entities/Clothing/OuterClothing/modsuit.yml
@@ -243,7 +243,7 @@
         Heat: 0.7
         Shock: 0.4 # Mono
         Caustic: 0.4 # Mono
-        Radiation: 0 # Mono
+        Radiation: 0.01 # Mono
   - type: StaminaDamageResistance
     coefficient: 0.7 # Mono
 

--- a/Resources/Prototypes/_Mono/Entities/Clothing/OuterClothing/modsuit.yml
+++ b/Resources/Prototypes/_Mono/Entities/Clothing/OuterClothing/modsuit.yml
@@ -114,7 +114,7 @@
         Piercing: 0.65
         Heat: 0.5
         Shock: 0.9
-        Radiation: 0.0
+        Radiation: 0.01
   - type: StaminaDamageResistance
     coefficient: 0.9
   - type: FireProtection


### PR DESCRIPTION
## About the PR
<!-- What did you change? -->
<!-- If this is a code change, summarize at high level how your new code works. This makes it easier to review. -->
tweaked all sort of full immunity regarding radiation, no more absolute immunity for some stuff, this one is bandaid till later balancing
## Why / Balance
<!-- Discuss how this would affect game balance or explain why it was changed. Link any relevant discussions or issues. -->
abuse prevention before it happens similar to other server, also full immunity is always bad in the long run
## Media
<!-- Attach media if the PR makes ingame changes (clothing, items, features, etc). 
Small fixes/refactors are exempt. Media may be used in SS14 progress reports with credit. -->

## Requirements
<!-- Confirm the following by placing an X in the brackets [X]: -->
- [x] I have read relevant guidelines/documentation to this PR found on [our devwiki](https://monolith-station.github.io/mono-docs/).
- [x] I have added media to this PR or it does not require an ingame showcase.
- [x] I can confirm this PR contains either no AI-generated content, or AI-generated content that meets our guidelines.
<!-- You should understand that not following the above may get your PR closed at maintainer’s discretion -->
<!-- When using AI, make sure you are already proficient in creating whatever content you are attempting to generate and that you already have experience contributing to SS14. This means using AI to enhance your preexisting workflow, not vibecoding. -->

## How to test
<!-- Describe the way it can be tested -->
check on all updated suits
should show 99% rad resistance
## Breaking changes
<!-- List any breaking changes, including namespaces, public class/method/field changes, prototype renames; and provide instructions for fixing them. -->

**Changelog**
<!-- Add a Changelog entry to make players aware of new features or changes that could affect gameplay.
Make sure to read the guidelines and take this Changelog template out of the comment block in order for it to show up.
Changelog must have a :cl: symbol, so the bot recognizes the changes and adds them to the game's changelog.
Remove this symbol for non-player facing PRs.-->
🆑 
- tweak: Most suits with 100% rad immunity is at most 99% now