### PR TITLE
Updates the Description of the Bastion to Not Be Civilian Grade 12 Gauge Db

### DIFF
--- a/Resources/Prototypes/_Triad/Entities/Objects/Weapons/Guns/Shotgun/shotgun.yml
+++ b/Resources/Prototypes/_Triad/Entities/Objects/Weapons/Guns/Shotgun/shotgun.yml
@@ -2,7 +2,7 @@
   name: Bastion double-barreled shotgun (4 gauge)
   parent: [BaseWeaponShotgun, BaseGunWieldable, BaseClass2AShipContraband]
   id: WeaponShotgunDoubleBarreledTdfBastion
-  description: An immortal classic. A civilian grade shotgun. Uses 12 gauge shotgun shells.
+  description: A doom-slaying classic. A military grade double barrel shotgun chambered in 4 gauge. Not attachments, no crutches, all skill. Suitable for breaching.
   components:
   - type: Sprite
     sprite: _Triad/Objects/Weapons/Guns/Shotgun/tdf_doublebarrel.rsi

--- a/Resources/Prototypes/_Triad/Entities/Objects/Weapons/Guns/Shotgun/shotgun.yml
+++ b/Resources/Prototypes/_Triad/Entities/Objects/Weapons/Guns/Shotgun/shotgun.yml
@@ -2,7 +2,7 @@
   name: Bastion double-barreled shotgun (4 gauge)
   parent: [BaseWeaponShotgun, BaseGunWieldable, BaseClass2AShipContraband]
   id: WeaponShotgunDoubleBarreledTdfBastion
-  description: A doom-slaying classic. A military grade double barrel shotgun chambered in 4 gauge. Not attachments, no crutches, all skill. Suitable for breaching.
+  description: A doom-slaying classic. A military grade double barrel shotgun chambered in 4 gauge. No attachments, no crutches, all skill. Suitable for breaching.
   components:
   - type: Sprite
     sprite: _Triad/Objects/Weapons/Guns/Shotgun/tdf_doublebarrel.rsi


### PR DESCRIPTION

## About the PR
This PR makes the description more flavorful and fixes the wrongly pasted description for the bastion. What Hydrakin do to a person..

## Why / Balance
It makes the gun sound more badass, so badass that people might start complaining its OP

## Media
:)

## Requirements
<!-- Confirm the following by placing an X in the brackets [X]: -->
- [X] I have read relevant guidelines/documentation to this PR found on [our devwiki](https://monolith-station.github.io/mono-docs/).
- [X] I have added media to this PR or it does not require an ingame showcase.
- [X] I can confirm this PR contains either no AI-generated content, or AI-generated content that meets our guidelines. WHO THE FUCK USES AI OUTSIDE OF BEING A TOOL?!?!?
<!-- You should understand that not following the above may get your PR closed at maintainer’s discretion -->
<!-- When using AI, make sure you are already proficient in creating whatever content you are attempting to generate and that you already have experience contributing to SS14. This means using AI to enhance your preexisting workflow, not vibecoding. -->

## How to test
Get Bastion. Feel badass.

## Breaking changes
None

**Changelog**
:cl:
- fix: Bastion Description more badass and now correctly lists that its 4 gauge.
