### PR TITLE
Vulp and Kitsune Markings. Yuh

### DIFF
--- a/Resources/Prototypes/_DV/Entities/Mobs/Customization/Markings/kitsune.yml
+++ b/Resources/Prototypes/_DV/Entities/Mobs/Customization/Markings/kitsune.yml
@@ -5,7 +5,7 @@
   id: KitsuneTailDefault
   bodyPart: Tail
   markingCategory: Tail
-  speciesRestriction: [Human, Vulpkanin, Felinid] #triad
+  speciesRestriction: [Human, Vulpkanin, Felinid, IPC] #triad
   coloring:
     default:
       type: !type:CategoryColoring
@@ -23,7 +23,7 @@
   id: KitsuneTailsNine
   bodyPart: Tail
   markingCategory: Tail
-  speciesRestriction: [Human, Vulpkanin, Felinid] # triad
+  speciesRestriction: [Human, Vulpkanin, Felinid, IPC] # triad
   coloring:
     default:
       type: !type:CategoryColoring
@@ -41,7 +41,7 @@
   id: KitsuneTailsThree
   bodyPart: Tail
   markingCategory: Tail
-  speciesRestriction: [Human, Vulpkanin, Felinid] #triad
+  speciesRestriction: [Human, Vulpkanin, Felinid, IPC] #triad
   coloring:
     default:
       type: !type:CategoryColoring
@@ -59,7 +59,7 @@
   id: KitsuneTailsTwo
   bodyPart: Tail
   markingCategory: Tail
-  speciesRestriction: [Human, Vulpkanin, Felinid] #triad
+  speciesRestriction: [Human, Vulpkanin, Felinid, IPC] #triad
   coloring:
     default:
       type: !type:CategoryColoring
@@ -79,7 +79,7 @@
   id: KitsuneEarsDefault
   bodyPart: Head
   markingCategory: HeadTop
-  speciesRestriction: [Human, Vulpkanin, Felinid] #triad
+  speciesRestriction: [Human, Vulpkanin, Felinid, IPC] #triad
   coloring:
     default:
       type: !type:CategoryColoring
@@ -97,7 +97,7 @@
   id: KitsuneEarsFox
   bodyPart: Head
   markingCategory: HeadTop
-  speciesRestriction: [Human, Vulpkanin, Felinid] #triad
+  speciesRestriction: [Human, Vulpkanin, Felinid, IPC] #triad
   coloring:
     default:
       type: !type:CategoryColoring

--- a/Resources/Prototypes/_DV/Entities/Mobs/Customization/Markings/vulpkanin.yml
+++ b/Resources/Prototypes/_DV/Entities/Mobs/Customization/Markings/vulpkanin.yml
@@ -5,7 +5,7 @@
   id: VulpEar
   bodyPart: HeadTop
   markingCategory: HeadTop
-  speciesRestriction: [Vulpkanin, Felinid, SlimePerson] # Triad
+  speciesRestriction: [Vulpkanin, Felinid, SlimePerson, IPC] # Triad
   sprites:
     - sprite: _DV/Mobs/Customization/Vulpkanin/ear_markings.rsi
       state: vulp
@@ -16,7 +16,7 @@
   id: VulpEarFade
   bodyPart: HeadTop
   markingCategory: HeadTop
-  speciesRestriction: [Vulpkanin, Felinid, SlimePerson] # Triad
+  speciesRestriction: [Vulpkanin, Felinid, SlimePerson, IPC] # Triad
   sprites:
     - sprite: _DV/Mobs/Customization/Vulpkanin/ear_markings.rsi
       state: vulp
@@ -27,7 +27,7 @@
   id: VulpEarSharp
   bodyPart: HeadTop
   markingCategory: HeadTop
-  speciesRestriction: [Vulpkanin, Felinid, SlimePerson] # Triad
+  speciesRestriction: [Vulpkanin, Felinid, SlimePerson, IPC] # Triad
   sprites:
     - sprite: _DV/Mobs/Customization/Vulpkanin/ear_markings.rsi
       state: vulp
@@ -38,7 +38,7 @@
   id: VulpEarJackal
   bodyPart: HeadTop
   markingCategory: HeadTop
-  speciesRestriction: [Vulpkanin, Felinid, SlimePerson] # Triad
+  speciesRestriction: [Vulpkanin, Felinid, SlimePerson, IPC] # Triad
   sprites:
     - sprite: _DV/Mobs/Customization/Vulpkanin/ear_markings.rsi
       state: jackal
@@ -49,7 +49,7 @@
   id: VulpEarTerrier
   bodyPart: HeadTop
   markingCategory: HeadTop
-  speciesRestriction: [Vulpkanin, Felinid, SlimePerson] # Triad
+  speciesRestriction: [Vulpkanin, Felinid, SlimePerson, IPC] # Triad
   sprites:
     - sprite: _DV/Mobs/Customization/Vulpkanin/ear_markings.rsi
       state: terrier
@@ -60,7 +60,7 @@
   id: VulpEarWolf
   bodyPart: HeadTop
   markingCategory: HeadTop
-  speciesRestriction: [Vulpkanin, Felinid, SlimePerson] # Triad
+  speciesRestriction: [Vulpkanin, Felinid, SlimePerson, IPC] # Triad
   sprites:
     - sprite: _DV/Mobs/Customization/Vulpkanin/ear_markings.rsi
       state: wolf
@@ -71,7 +71,7 @@
   id: VulpEarFennec
   bodyPart: HeadTop
   markingCategory: HeadTop
-  speciesRestriction: [Vulpkanin, Felinid, SlimePerson] # Triad
+  speciesRestriction: [Vulpkanin, Felinid, SlimePerson, IPC] # Triad
   sprites:
     - sprite: _DV/Mobs/Customization/Vulpkanin/ear_markings.rsi
       state: fennec
@@ -82,7 +82,7 @@
   id: VulpEarFox
   bodyPart: HeadTop
   markingCategory: HeadTop
-  speciesRestriction: [Vulpkanin, Felinid, SlimePerson] # Triad
+  speciesRestriction: [Vulpkanin, Felinid, SlimePerson, IPC] # Triad
   sprites:
     - sprite: _DV/Mobs/Customization/Vulpkanin/ear_markings.rsi
       state: fox
@@ -91,7 +91,7 @@
   id: VulpEarOtie
   bodyPart: HeadTop
   markingCategory: HeadTop
-  speciesRestriction: [Vulpkanin, SlimePerson] # Triad
+  speciesRestriction: [Vulpkanin, SlimePerson, IPC] # Triad
   sprites:
     - sprite: _DV/Mobs/Customization/Vulpkanin/ear_markings.rsi
       state: otie
@@ -102,7 +102,7 @@
   id: VulpEarTajaran
   bodyPart: HeadTop
   markingCategory: HeadTop
-  speciesRestriction: [Vulpkanin, SlimePerson] # Triad
+  speciesRestriction: [Vulpkanin, SlimePerson, IPC] # Triad
   sprites:
     - sprite: _DV/Mobs/Customization/Vulpkanin/ear_markings.rsi
       state: msai
@@ -113,7 +113,7 @@
   id: VulpEarShock
   bodyPart: HeadTop
   markingCategory: HeadTop
-  speciesRestriction: [Vulpkanin, Felinid, SlimePerson] # Triad
+  speciesRestriction: [Vulpkanin, Felinid, SlimePerson, IPC] # Triad
   sprites:
     - sprite: _DV/Mobs/Customization/Vulpkanin/ear_markings.rsi
       state: shock
@@ -122,7 +122,7 @@
   id: VulpEarCoyote
   bodyPart: HeadTop
   markingCategory: HeadTop
-  speciesRestriction: [Vulpkanin, SlimePerson] # Triad
+  speciesRestriction: [Vulpkanin, SlimePerson, IPC] # Triad
   sprites:
     - sprite: _DV/Mobs/Customization/Vulpkanin/ear_markings.rsi
       state: coyote
@@ -131,7 +131,7 @@
   id: VulpEarDalmatian
   bodyPart: HeadTop
   markingCategory: HeadTop
-  speciesRestriction: [Vulpkanin, Felinid, SlimePerson] # Triad
+  speciesRestriction: [Vulpkanin, Felinid, SlimePerson, IPC] # Triad
   sprites:
     - sprite: _DV/Mobs/Customization/Vulpkanin/ear_markings.rsi
       state: dalmatian
@@ -141,7 +141,7 @@
   id: VulpSnoutAlt
   bodyPart: Snout
   markingCategory: Snout
-  speciesRestriction: [Vulpkanin, SlimePerson] # Triad
+  speciesRestriction: [Vulpkanin, SlimePerson, IPC] # Triad
   sprites:
     - sprite: _DV/Mobs/Customization/Vulpkanin/head_markings.rsi
       state: muzzle_alt
@@ -152,7 +152,7 @@
   id: VulpSnout
   bodyPart: Snout
   markingCategory: Snout
-  speciesRestriction: [Vulpkanin, SlimePerson] # Triad
+  speciesRestriction: [Vulpkanin, SlimePerson, IPC] # Triad
   sprites:
     - sprite: _DV/Mobs/Customization/Vulpkanin/head_markings.rsi
       state: muzzle
@@ -163,7 +163,7 @@
   id: VulpSnoutSharp
   bodyPart: Snout
   markingCategory: Snout
-  speciesRestriction: [Vulpkanin, SlimePerson] # Triad
+  speciesRestriction: [Vulpkanin, SlimePerson, IPC] # Triad
   sprites:
     - sprite: _DV/Mobs/Customization/Vulpkanin/head_markings.rsi
       state: muzzle_sharp
@@ -174,7 +174,7 @@
   id: VulpSnoutFade
   bodyPart: Snout
   markingCategory: Snout
-  speciesRestriction: [Vulpkanin, SlimePerson] # Triad
+  speciesRestriction: [Vulpkanin, SlimePerson, IPC] # Triad
   sprites:
     - sprite: _DV/Mobs/Customization/Vulpkanin/head_markings.rsi
       state: muzzle_fade
@@ -185,7 +185,7 @@
   id: VulpSnoutNose
   bodyPart: Snout
   markingCategory: Snout
-  speciesRestriction: [Vulpkanin, SlimePerson] # Triad
+  speciesRestriction: [Vulpkanin, SlimePerson, IPC] # Triad
   sprites:
     - sprite: _DV/Mobs/Customization/Vulpkanin/head_markings.rsi
       state: nose
@@ -194,7 +194,7 @@
   id: VulpSnoutMask
   bodyPart: Snout
   markingCategory: Snout
-  speciesRestriction: [Vulpkanin, SlimePerson] # Triad
+  speciesRestriction: [Vulpkanin, SlimePerson, IPC] # Triad
   sprites:
     - sprite: _DV/Mobs/Customization/Vulpkanin/head_markings.rsi
       state: mask
@@ -205,7 +205,7 @@
   id: VulpSnoutVulpine
   bodyPart: Snout
   markingCategory: Snout
-  speciesRestriction: [Vulpkanin, SlimePerson] # Triad
+  speciesRestriction: [Vulpkanin, SlimePerson, IPC] # Triad
   sprites:
     - sprite: _DV/Mobs/Customization/Vulpkanin/head_markings.rsi
       state: vulpine
@@ -216,7 +216,7 @@
   id: VulpSnoutSwift
   bodyPart: Snout
   markingCategory: Snout
-  speciesRestriction: [Vulpkanin, SlimePerson] # Triad
+  speciesRestriction: [Vulpkanin, SlimePerson, IPC] # Triad
   sprites:
     - sprite: _DV/Mobs/Customization/Vulpkanin/head_markings.rsi
       state: vulpine-lines
@@ -225,7 +225,7 @@
   id: VulpSnoutBlaze
   bodyPart: Snout
   markingCategory: Snout
-  speciesRestriction: [Vulpkanin, SlimePerson] # Triad
+  speciesRestriction: [Vulpkanin, SlimePerson, IPC] # Triad
   sprites:
     - sprite: _DV/Mobs/Customization/Vulpkanin/head_markings.rsi
       state: blaze
@@ -234,7 +234,7 @@
   id: VulpSnoutPatch
   bodyPart: Snout
   markingCategory: Snout
-  speciesRestriction: [Vulpkanin, SlimePerson] # Triad
+  speciesRestriction: [Vulpkanin, SlimePerson, IPC] # Triad
   sprites:
     - sprite: _DV/Mobs/Customization/Vulpkanin/head_markings.rsi
       state: patch
@@ -272,7 +272,7 @@
   id: VulpTail
   bodyPart: Tail
   markingCategory: Tail
-  speciesRestriction: [Vulpkanin, Felinid, SlimePerson] # Triad
+  speciesRestriction: [Vulpkanin, Felinid, SlimePerson, IPC] # Triad
   sprites:
     - sprite: _DV/Mobs/Customization/Vulpkanin/tail_markings.rsi
       state: vulp
@@ -283,7 +283,7 @@
   id: VulpTailTip
   bodyPart: Tail
   markingCategory: Tail
-  speciesRestriction: [Vulpkanin, Felinid, SlimePerson] # Triad
+  speciesRestriction: [Vulpkanin, Felinid, SlimePerson, IPC] # Triad
   sprites:
     - sprite: _DV/Mobs/Customization/Vulpkanin/tail_markings.rsi
       state: vulp
@@ -294,7 +294,7 @@
   id: VulpTailWag
   bodyPart: Tail
   markingCategory: Tail
-  speciesRestriction: [Vulpkanin, Felinid, SlimePerson] # Triad
+  speciesRestriction: [Vulpkanin, Felinid, SlimePerson, IPC] # Triad
   sprites:
     - sprite: _DV/Mobs/Customization/Vulpkanin/tail_markings.rsi
       state: vulp_wag
@@ -305,7 +305,7 @@
   id: VulpTailWagTip
   bodyPart: Tail
   markingCategory: Tail
-  speciesRestriction: [Vulpkanin, Felinid, SlimePerson] # Triad
+  speciesRestriction: [Vulpkanin, Felinid, SlimePerson, IPC] # Triad
   sprites:
     - sprite: _DV/Mobs/Customization/Vulpkanin/tail_markings.rsi
       state: vulp_wag
@@ -316,7 +316,7 @@
   id: VulpTailAlt
   bodyPart: Tail
   markingCategory: Tail
-  speciesRestriction: [Vulpkanin, Felinid, SlimePerson] # Triad
+  speciesRestriction: [Vulpkanin, Felinid, SlimePerson, IPC] # Triad
   sprites:
     - sprite: _DV/Mobs/Customization/Vulpkanin/tail_markings.rsi
       state: vulp_alt
@@ -327,7 +327,7 @@
   id: VulpTailAltTip
   bodyPart: Tail
   markingCategory: Tail
-  speciesRestriction: [Vulpkanin, Felinid, SlimePerson] # Triad
+  speciesRestriction: [Vulpkanin, Felinid, SlimePerson, IPC] # Triad
   sprites:
     - sprite: _DV/Mobs/Customization/Vulpkanin/tail_markings.rsi
       state: vulp_alt
@@ -338,7 +338,7 @@
   id: VulpTailLong
   bodyPart: Tail
   markingCategory: Tail
-  speciesRestriction: [Vulpkanin, Felinid, SlimePerson] # Triad
+  speciesRestriction: [Vulpkanin, Felinid, SlimePerson, IPC] # Triad
   sprites:
     - sprite: _DV/Mobs/Customization/Vulpkanin/tail_markings.rsi
       state: long
@@ -349,7 +349,7 @@
   id: VulpTailFox
   bodyPart: Tail
   markingCategory: Tail
-  speciesRestriction: [Vulpkanin, Felinid, SlimePerson] # Triad
+  speciesRestriction: [Vulpkanin, Felinid, SlimePerson, IPC] # Triad
   sprites:
     - sprite: _DV/Mobs/Customization/Vulpkanin/tail_markings.rsi
       state: fox
@@ -360,7 +360,7 @@
   id: VulpTailFoxTip
   bodyPart: Tail
   markingCategory: Tail
-  speciesRestriction: [Vulpkanin, Felinid, SlimePerson] # Triad
+  speciesRestriction: [Vulpkanin, Felinid, SlimePerson, IPC] # Triad
   sprites:
     - sprite: _DV/Mobs/Customization/Vulpkanin/tail_markings.rsi
       state: fox
@@ -371,7 +371,7 @@
   id: VulpTailFoxWag
   bodyPart: Tail
   markingCategory: Tail
-  speciesRestriction: [Vulpkanin, Felinid, SlimePerson] # Triad
+  speciesRestriction: [Vulpkanin, Felinid, SlimePerson, IPC] # Triad
   sprites:
     - sprite: _DV/Mobs/Customization/Vulpkanin/tail_markings.rsi
       state: fox_wag
@@ -382,7 +382,7 @@
   id: VulpTailFoxWagTip
   bodyPart: Tail
   markingCategory: Tail
-  speciesRestriction: [Vulpkanin, Felinid, SlimePerson] # Triad
+  speciesRestriction: [Vulpkanin, Felinid, SlimePerson, IPC] # Triad
   sprites:
     - sprite: _DV/Mobs/Customization/Vulpkanin/tail_markings.rsi
       state: fox_wag
@@ -393,7 +393,7 @@
   id: VulpTailBushy
   bodyPart: Tail
   markingCategory: Tail
-  speciesRestriction: [Vulpkanin, SlimePerson] # Triad
+  speciesRestriction: [Vulpkanin, SlimePerson, IPC] # Triad
   sprites:
     - sprite: _DV/Mobs/Customization/Vulpkanin/tail_markings.rsi
       state: bushfluff
@@ -402,7 +402,7 @@
   id: VulpTailBushyWag
   bodyPart: Tail
   markingCategory: Tail
-  speciesRestriction: [Vulpkanin, SlimePerson] # Triad
+  speciesRestriction: [Vulpkanin, SlimePerson, IPC] # Triad
   sprites:
     - sprite: _DV/Mobs/Customization/Vulpkanin/tail_markings.rsi
       state: bushfluff_wag
@@ -411,7 +411,7 @@
   id: VulpTailCoyote
   bodyPart: Tail
   markingCategory: Tail
-  speciesRestriction: [Vulpkanin, Felinid, SlimePerson] # Triad
+  speciesRestriction: [Vulpkanin, Felinid, SlimePerson, IPC] # Triad
   sprites:
     - sprite: _DV/Mobs/Customization/Vulpkanin/tail_markings.rsi
       state: coyote
@@ -420,7 +420,7 @@
   id: VulpTailCoyoteWag
   bodyPart: Tail
   markingCategory: Tail
-  speciesRestriction: [Vulpkanin, Felinid, SlimePerson] # Triad
+  speciesRestriction: [Vulpkanin, Felinid, SlimePerson, IPC] # Triad
   sprites:
     - sprite: _DV/Mobs/Customization/Vulpkanin/tail_markings.rsi
       state: coyote_wag
@@ -429,7 +429,7 @@
   id: VulpTailCorgiWag
   bodyPart: Tail
   markingCategory: Tail
-  speciesRestriction: [Vulpkanin, SlimePerson] # Triad
+  speciesRestriction: [Vulpkanin, SlimePerson, IPC] # Triad
   sprites:
     - sprite: _DV/Mobs/Customization/Vulpkanin/tail_markings.rsi
       state: corgi_wag
@@ -438,7 +438,7 @@
   id: VulpTailHusky
   bodyPart: Tail
   markingCategory: Tail
-  speciesRestriction: [Vulpkanin, Felinid, SlimePerson] # Triad
+  speciesRestriction: [Vulpkanin, Felinid, SlimePerson, IPC] # Triad
   sprites:
     - sprite: _DV/Mobs/Customization/Vulpkanin/tail_markings.rsi
       state: husky-inner
@@ -449,7 +449,7 @@
   id: VulpTailHuskyAlt
   bodyPart: Tail
   markingCategory: Tail
-  speciesRestriction: [Vulpkanin, Felinid, SlimePerson] # Triad
+  speciesRestriction: [Vulpkanin, Felinid, SlimePerson, IPC] # Triad
   sprites:
     - sprite: _DV/Mobs/Customization/Vulpkanin/tail_markings.rsi
       state: husky
@@ -458,7 +458,7 @@
   id: VulpTailFox2
   bodyPart: Tail
   markingCategory: Tail
-  speciesRestriction: [Vulpkanin, Felinid, SlimePerson] # Triad
+  speciesRestriction: [Vulpkanin, Felinid, SlimePerson, IPC] # Triad
   sprites:
     - sprite: _DV/Mobs/Customization/Vulpkanin/tail_markings.rsi
       state: fox2
@@ -467,7 +467,7 @@
   id: VulpTailFox3
   bodyPart: Tail
   markingCategory: Tail
-  speciesRestriction: [Vulpkanin, Felinid, SlimePerson] # Triad
+  speciesRestriction: [Vulpkanin, Felinid, SlimePerson, IPC] # Triad
   sprites:
     - sprite: _DV/Mobs/Customization/Vulpkanin/tail_markings.rsi
       state: fox3
@@ -478,7 +478,7 @@
   id: VulpTailFennec
   bodyPart: Tail
   markingCategory: Tail
-  speciesRestriction: [Vulpkanin, Felinid, SlimePerson] # Triad
+  speciesRestriction: [Vulpkanin, Felinid, SlimePerson, IPC] # Triad
   sprites:
     - sprite: _DV/Mobs/Customization/Vulpkanin/tail_markings.rsi
       state: fennec
@@ -487,7 +487,7 @@
   id: VulpTailOtie
   bodyPart: Tail
   markingCategory: Tail
-  speciesRestriction: [Vulpkanin, Felinid, SlimePerson] # Triad
+  speciesRestriction: [Vulpkanin, Felinid, SlimePerson, IPC] # Triad
   sprites:
     - sprite: _DV/Mobs/Customization/Vulpkanin/tail_markings.rsi
       state: otie
@@ -496,7 +496,7 @@
   id: VulpTailFluffy
   bodyPart: Tail
   markingCategory: Tail
-  speciesRestriction: [Vulpkanin, Felinid, SlimePerson] # Triad
+  speciesRestriction: [Vulpkanin, Felinid, SlimePerson, IPC] # Triad
   sprites:
     - sprite: _DV/Mobs/Customization/Vulpkanin/tail_markings.rsi
       state: fluffy
@@ -505,7 +505,7 @@
   id: VulpTailDalmatianWag
   bodyPart: Tail
   markingCategory: Tail
-  speciesRestriction: [Vulpkanin, SlimePerson] # Triad
+  speciesRestriction: [Vulpkanin, SlimePerson, IPC] # Triad
   sprites:
     - sprite: _DV/Mobs/Customization/Vulpkanin/tail_markings.rsi
       state: dalmatian_wag


### PR DESCRIPTION
## About the PR
Allows IPCs to use Vulpkanin markings.

## Why / Balance
People like tails and ears of IPCs. I like tails and ears of IPCs. This could theoretically decrease easy visibility for which species is which, but it should not be very much of an issue.

## Media
<img width="233" height="455" alt="image" src="https://github.com/user-attachments/assets/c90f6cb1-2507-4226-bcf6-ec2d9c0b97ef" />

## Requirements
<!-- Confirm the following by placing an X in the brackets [X]: -->
- [x] I have read relevant guidelines/documentation to this PR found on [our devwiki](https://monolith-station.github.io/mono-docs/).
- [x] I have added media to this PR or it does not require an ingame showcase.
- [x] I can confirm this PR contains either no AI-generated content, or AI-generated content that meets our guidelines.
<!-- You should understand that not following the above may get your PR closed at maintainer’s discretion -->
<!-- When using AI, make sure you are already proficient in creating whatever content you are attempting to generate and that you already have experience contributing to SS14. This means using AI to enhance your preexisting workflow, not vibecoding. -->

## How to test
Make an IPC, go to markings. 

## Breaking changes
<!-- List any breaking changes, including namespaces, public class/method/field changes, prototype renames; and provide instructions for fixing them. -->

**Changelog**

:cl:
- add: Gave IPCs the ability to use vulpkanin markings.
