### PR TITLE
Fix Tesla Escaping Containment via ChaoticJump

### DIFF
--- a/Content.Server/Physics/Components/ChaoticJumpComponent.cs
+++ b/Content.Server/Physics/Components/ChaoticJumpComponent.cs
@@ -51,4 +51,17 @@ public sealed partial class ChaoticJumpComponent : Component
     /// </summary>
     [DataField, ViewVariables(VVAccess.ReadWrite)]
     public EntProtoId Effect = "EffectEmpPulse";
+
+    /// <summary>
+    /// Triad: radius of the footprint swept along the jump path. The jump cannot land the entity past a
+    /// gap narrower than this, which is what stops it teleporting through containment-field corner slots.
+    /// </summary>
+    [DataField, ViewVariables(VVAccess.ReadWrite)]
+    public float SweepRadius = 0.35f;
+
+    /// <summary>
+    /// Triad: how far short of a swept contact the entity lands, so it does not end up flush against the obstacle.
+    /// </summary>
+    [DataField, ViewVariables(VVAccess.ReadWrite)]
+    public float SweepSkin = 0.1f;
 }

--- a/Content.Server/Physics/Controllers/ChaoticJumpSystem.cs
+++ b/Content.Server/Physics/Controllers/ChaoticJumpSystem.cs
@@ -5,7 +5,7 @@ using Robust.Shared.Physics.Systems;
 using Robust.Shared.Physics;
 using System.Numerics;
 using Robust.Shared.Physics.Controllers;
-using Robust.Shared.Utility;
+using Robust.Shared.Physics.Collision.Shapes;
 
 namespace Content.Server.Physics.Controllers;
 
@@ -18,6 +18,7 @@ public sealed class ChaoticJumpSystem : VirtualController
     [Dependency] private readonly SharedTransformSystem _transform = default!;
     [Dependency] private readonly IRobustRandom _random = default!;
     [Dependency] private readonly SharedPhysicsSystem _physics = default!;
+    [Dependency] private readonly RayCastSystem _rayCast = default!;
 
     public override void Initialize()
     {
@@ -50,27 +51,53 @@ public sealed class ChaoticJumpSystem : VirtualController
 
     private void Jump(EntityUid uid, ChaoticJumpComponent component)
     {
-        var transform = Transform(uid);
-
-        var startPos = _transform.GetWorldPosition(uid);
-        Vector2 targetPos;
+        var xform = Transform(uid);
+        var origin = _physics.GetPhysicsTransform(uid);
+        var startPos = origin.Position;
 
         var direction = _random.NextAngle();
+        var dir = direction.ToVec();
         var range = _random.NextFloat(component.RangeMin, component.RangeMax);
-        var ray = new CollisionRay(startPos, direction.ToVec(), component.CollisionMask);
-        var rayCastResults = _physics.IntersectRay(transform.MapID, ray, range, uid, returnOnFirstHit: false).FirstOrNull();
+        var translation = dir * range;
 
-        if (rayCastResults != null)
+        // Triad: replaced the zero-width raycast + 1-tile offset below with a footprint shape-sweep.
+        // The zero-width ray could thread sub-tile gaps (containment-field corner slots) and the teleport
+        // ignored physics entirely, so the tesla could escape a correctly-built cage. Sweeping the body's
+        // own circle stops it on anything it could not physically pass through. A circle is rotation-
+        // invariant, so the origin transform's rotation is irrelevant. Old logic preserved:
+        // var ray = new CollisionRay(startPos, direction.ToVec(), component.CollisionMask);
+        // var rayCastResults = _physics.IntersectRay(xform.MapID, ray, range, uid, returnOnFirstHit: false).FirstOrNull();
+        // if (rayCastResults != null)
+        // {
+        //     targetPos = rayCastResults.Value.HitPos;
+        //     targetPos = new Vector2(targetPos.X - (float) Math.Cos(direction), targetPos.Y - (float) Math.Sin(direction));
+        // }
+        // else
+        // {
+        //     targetPos = new Vector2(startPos.X + range * (float) Math.Cos(direction), startPos.Y + range * (float) Math.Sin(direction));
+        // }
+        var shape = new PhysShapeCircle(component.SweepRadius);
+        var filter = new QueryFilter
         {
-            targetPos = rayCastResults.Value.HitPos;
-            targetPos = new Vector2(targetPos.X - (float) Math.Cos(direction), targetPos.Y - (float) Math.Sin(direction)); //offset so that the teleport does not take place directly inside the target
+            MaskBits = component.CollisionMask,
+            IsIgnored = entity => entity == uid,
+        };
+
+        var result = _rayCast.CastShape(xform.MapID, shape, origin, translation, filter, RayCastSystem.RayCastClosestCallback);
+
+        Vector2 targetPos;
+        if (result.Hit)
+        {
+            // Land just short of the first solid contact along the sweep.
+            var stopDistance = MathF.Max(0f, range * result.Results[0].Fraction - component.SweepSkin);
+            targetPos = startPos + dir * stopDistance;
         }
         else
         {
-            targetPos = new Vector2(startPos.X + range * (float) Math.Cos(direction), startPos.Y + range * (float) Math.Sin(direction));
+            targetPos = startPos + translation;
         }
 
-        Spawn(component.Effect, transform.Coordinates);
+        Spawn(component.Effect, xform.Coordinates);
 
         _transform.SetWorldPosition(uid, targetPos);
     }

--- a/Resources/Prototypes/Entities/Structures/Power/Generation/Tesla/energyball.yml
+++ b/Resources/Prototypes/Entities/Structures/Power/Generation/Tesla/energyball.yml
@@ -90,6 +90,7 @@
   - type: ChaoticJump
     jumpMinInterval: 8
     jumpMaxInterval: 15
+    sweepRadius: 0.55 # Triad: match the ball's collider so the jump can't teleport where the ball couldn't fit
   - type: WarpPoint
     follow: true
     location: tesla ball


### PR DESCRIPTION
## About the PR
The tesla's chaotic jump could teleport the ball out of a correctly-built containment cage. This changes the jump from a zero-width raycast to a shape-sweep of the ball's own collider, so it can no longer land anywhere the ball couldn't physically fit.

## Why / Balance
`ChaoticJumpSystem` picked a random point along a raycast and `SetWorldPosition`'d the ball there. The zero-width ray could thread the sub-tile gap at a field-cage corner (field generators are 0.4-radius circles, not full-tile blockers), and the teleport ignored physics entirely, so an intact cage didn't reliably hold the ball. Sweeping the ball's collider via `RayCastSystem.CastShape` stops it on anything it couldn't physically pass through, while a clear sweep still teleports the full range so the ball stays just as lively inside the cage. No balance numbers change; this only closes the escape.

## Media
Small behavior fix, no new ingame assets. A before/after of a caged tesla can be attached if wanted.

## Requirements
- [x] I have read relevant guidelines/documentation to this PR found on our devwiki.
- [x] I have added media to this PR or it does not require an ingame showcase.
- [x] I can confirm this PR contains either no AI-generated content, or AI-generated content that meets our guidelines.

## How to test
Set up a tesla inside a containment-field cage and let it run through many chaotic-jump cycles (jumps fire every 8-15s). It should stay inside the cage. Before this fix it could eventually slip through a field corner and escape.

## Breaking changes
None. `ChaoticJumpComponent` gains two additive DataFields (`SweepRadius`, `SweepSkin`) with defaults; no renames or removed API.

**Changelog**
:cl:
- fix: The tesla can no longer chaotic-jump its way out of an intact containment cage.
