### PR TITLE
Fix Sleeping Drone Brains Piloting Across the Sector After a Target F…

### DIFF
--- a/Content.Server/_Mono/NPC/HTN/ShipSteeringSystem.cs
+++ b/Content.Server/_Mono/NPC/HTN/ShipSteeringSystem.cs
@@ -752,6 +752,20 @@ public sealed partial class ShipSteeringSystem : EntitySystem
             return;
 
         RemComp<ShipSteererComponent>(ent);
+
+        // Triad: steering leaves dampening Off while thrusting, so a teardown mid-flight
+        // (target FTL'd away, brain slept, operator failed) left NPC hulls ballistic at combat
+        // speed, migrating across the sector. Restore Dampen so they bleed off velocity and
+        // park for grid cleanup. Consoles keep the pilot's Drive/Cruise/Park selection (#4064).
+        if (TerminatingOrDeleted(ent)
+            || _consoleQuery.HasComp(ent)
+            || Transform(ent).GridUid is not { } grid
+            || TerminatingOrDeleted(grid)
+            || !_physQuery.TryComp(grid, out var body)
+            || !_shuttleQuery.TryComp(grid, out var shuttle))
+            return;
+
+        _shuttle.SetInertiaDampening(grid, body, shuttle, Transform(grid), InertiaDampeningMode.Dampen);
     }
 
     private ref struct SteeringContext

--- a/Content.Server/_Triad/NPC/ShipNpcSleepSystem.cs
+++ b/Content.Server/_Triad/NPC/ShipNpcSleepSystem.cs
@@ -1,0 +1,62 @@
+using Content.Server._Mono.NPC.HTN;
+using Content.Server.NPC.HTN;
+using Content.Server.Shuttles.Components;
+using Content.Shared.NPC;
+using Robust.Shared.Map;
+
+namespace Content.Server._Triad.NPC;
+
+/// <summary>
+/// Tears down an NPC ship brain's helm and guns when the brain is put to sleep.
+///
+/// Sleeping only removes <see cref="ActiveNPCComponent"/>; it never shuts the HTN plan down,
+/// so <see cref="ShipSteererComponent"/> survived and kept piloting per-tick via the mover,
+/// chasing blackboard coordinates anchored to the target entity. A drone whose target FTL'd
+/// away would sleep mid-chase and then autopilot itself across the sector (typically into the
+/// core) the moment the target's map matched again. Killing the plan and the steering/targeting
+/// components here leaves the hull decelerating in place, where grid cleanup despawns it.
+/// </summary>
+public sealed class ShipNpcSleepSystem : EntitySystem
+{
+    [Dependency] private readonly HTNSystem _htn = default!;
+    [Dependency] private readonly ShipSteeringSystem _steering = default!;
+    [Dependency] private readonly ShipTargetingSystem _targeting = default!;
+
+    public override void Initialize()
+    {
+        base.Initialize();
+
+        SubscribeLocalEvent<ActiveNPCComponent, ComponentShutdown>(OnActiveNpcShutdown);
+    }
+
+    private void OnActiveNpcShutdown(EntityUid uid, ActiveNPCComponent comp, ComponentShutdown args)
+    {
+        if (TerminatingOrDeleted(uid))
+            return;
+
+        // Ship brains only. Mob NPCs never carry these components, and player autopilot
+        // consoles (which share the HTN + steering stack) must keep flying while "asleep".
+        if (HasComp<ShuttleConsoleComponent>(uid)
+            || !HasComp<ShipSteererComponent>(uid) && !HasComp<ShipTargetingComponent>(uid))
+            return;
+
+        // Kill the plan first: runs ConditionalShutdown on background (PlanFinished) operators
+        // and nulls the plan, so waking replans from the root instead of resuming a stale chase.
+        if (TryComp<HTNComponent>(uid, out var htn))
+        {
+            _htn.ShutdownPlan(htn);
+
+            // The combat compounds set removeKeyOnFinish: false, so the target keys outlive the
+            // plan. Scrub them, or a KeyExistsPrecondition branch can re-plan onto the escaped
+            // target on wake. Key names are the _Mono/NPCs/Shuttle YAML convention.
+            htn.Blackboard.Remove<EntityUid>("Target");
+            htn.Blackboard.Remove<EntityCoordinates>("TargetCoordinates");
+        }
+
+        // ShutdownPlan only conditionally shuts down PlanFinished-flagged operators; the default
+        // TaskFinished operators never get their teardown from it, so stop both directly.
+        // Steering's Stop also restores inertia dampening so the hull parks for grid cleanup.
+        _steering.Stop(uid);
+        _targeting.Stop(uid);
+    }
+}


### PR DESCRIPTION
## About the PR
Sleeping an NPC only removes `ActiveNPCComponent`; it never tears the HTN plan down, and ship steering runs off the mover rather than the NPC update loop. So a drone that fell asleep mid-chase kept its `ShipSteererComponent` alive, quietly piloting toward blackboard coordinates anchored to a ship that had FTL'd away, then following it across the whole sector once it dropped out of FTL and waking up hot wherever it landed.

This adds `ShipNpcSleepSystem`, which tears ship brains down when they sleep: shuts the plan down, scrubs the `Target`/`TargetCoordinates` keys, and stops steering and targeting. `ShipSteeringSystem.Stop` now also restores inertia dampening for NPC cores, since steering leaves dampening Off while thrusting; a torn-down hull now brakes and parks instead of coasting ballistic at combat speed, which puts it in reach of the normal grid cleanup cycle. Autopilot consoles are excluded from both paths and keep the pilot's dampening selection.

## Why / Balance
FTLing away from a drone fight should actually end the fight. Before this, drones from the outer rings could end up in the core regions chasing their escaped target, then re-acquire whoever was nearest. Side effect worth knowing: a depowered or EMP'd drone now brakes to a stop instead of drifting off, which reads as "disabled" rather than "runaway".

## Media
N/A, server-side fix.

## Requirements
- [x] I have read relevant guidelines/documentation to this PR found on [our devwiki](https://monolith-station.github.io/mono-docs/).
- [x] I have added media to this PR or it does not require an ingame showcase.
- [x] I can confirm this PR contains either no AI-generated content, or AI-generated content that meets our guidelines.

## How to test
Spawn a combat drone (a rammer or `quake`), aggro it with a ship, then FTL away with nobody else nearby. VV the drone's AI core: `ActiveNPCComponent` and `ShipSteererComponent` should both be gone, the drone grid's dampening should read Dampen with velocity bleeding off, and `GridCleanupGridComponent`'s accumulator should start climbing. It should not follow you to your destination. Builds clean and the teardown paths are verifiable via VV; this still wants a live two-ship shakedown before merge.

## Breaking changes
None.

**Changelog**
:cl:
- fix: Combat drones no longer chase ships across the sector after they FTL away, and disabled drones brake to a stop instead of drifting forever.
