### PR TITLE
Tesla Revamp

### DIFF
--- a/Content.Server/Lightning/Components/LightningTargetComponent.cs
+++ b/Content.Server/Lightning/Components/LightningTargetComponent.cs
@@ -69,4 +69,26 @@ public sealed partial class LightningTargetComponent : Component
     /// </summary>
     [DataField]
     public FixedPoint2 DamageFromLightning = 1;
+
+    // Triad: electrocution path. The Structural damage above no-ops on Biological damage containers,
+    // so mobs on the strike table took nothing. These make a strike electrocute the target instead;
+    // insulated gloves apply through the normal electrocution attempt.
+
+    /// <summary>
+    /// Triad: whether a lightning strike electrocutes this target (stun + shock damage).
+    /// </summary>
+    [DataField, ViewVariables(VVAccess.ReadWrite)]
+    public bool ElectrocuteOnStrike;
+
+    /// <summary>
+    /// Triad: shock damage dealt by the electrocution.
+    /// </summary>
+    [DataField, ViewVariables(VVAccess.ReadWrite)]
+    public int ElectrocutionShockDamage = 15;
+
+    /// <summary>
+    /// Triad: how long the electrocution lasts.
+    /// </summary>
+    [DataField, ViewVariables(VVAccess.ReadWrite)]
+    public TimeSpan ElectrocutionTime = TimeSpan.FromSeconds(5);
 }

--- a/Content.Server/Lightning/LightningSystem.cs
+++ b/Content.Server/Lightning/LightningSystem.cs
@@ -106,8 +106,20 @@ public sealed class LightningSystem : SharedLightningSystem
         // several hashsets every time
 
         var targets = _lookup.GetEntitiesInRange<LightningTargetComponent>(_transform.GetMapCoordinates(user), range).ToList();
-        _random.Shuffle(targets);
-        targets.Sort((x, y) => y.Comp.Priority.CompareTo(x.Comp.Priority));
+        // Triad: strike-attempt hook. Each candidate may adjust its effective priority and hit chance
+        // from live state (tesla coils bid by charge headroom) before the volley is sorted and rolled.
+        // Targets with no subscriber keep their static values, so behavior is unchanged for them.
+        // _random.Shuffle(targets);
+        // targets.Sort((x, y) => y.Comp.Priority.CompareTo(x.Comp.Priority));
+        var candidates = new List<(Entity<LightningTargetComponent> Target, int Priority, float HitProbability)>(targets.Count);
+        foreach (var target in targets)
+        {
+            var attempt = new LightningStrikeAttemptEvent(user, target.Comp.Priority, target.Comp.HitProbability);
+            RaiseLocalEvent(target, ref attempt);
+            candidates.Add((target, attempt.Priority, Math.Clamp(attempt.HitProbability, 0f, 1f)));
+        }
+        _random.Shuffle(candidates);
+        candidates.Sort((x, y) => y.Priority.CompareTo(x.Priority));
 
         int shootedCount = 0;
         int count = -1;
@@ -115,16 +127,16 @@ public sealed class LightningSystem : SharedLightningSystem
         {
             count++;
 
-            if (count >= targets.Count) { break; }
+            if (count >= candidates.Count) { break; }
 
-            var curTarget = targets[count];
-            if (!_random.Prob(curTarget.Comp.HitProbability)) //Chance to ignore target
+            var curTarget = candidates[count];
+            if (!_random.Prob(curTarget.HitProbability)) //Chance to ignore target
                 continue;
 
-            ShootLightning(user, targets[count].Owner, spawnOnHit, lightningPrototype, triggerLightningEvents);
-            if (arcDepth - targets[count].Comp.LightningResistance > 0)
+            ShootLightning(user, curTarget.Target.Owner, spawnOnHit, lightningPrototype, triggerLightningEvents);
+            if (arcDepth - curTarget.Target.Comp.LightningResistance > 0)
             {
-                ShootRandomLightnings(targets[count].Owner, range, 1, spawnOnHit, lightningPrototype, arcDepth - targets[count].Comp.LightningResistance, triggerLightningEvents);
+                ShootRandomLightnings(curTarget.Target.Owner, range, 1, spawnOnHit, lightningPrototype, arcDepth - curTarget.Target.Comp.LightningResistance, triggerLightningEvents);
             }
             shootedCount++;
         }
@@ -138,3 +150,15 @@ public sealed class LightningSystem : SharedLightningSystem
 /// <param name="Target">The entity that was struck by lightning.</param>
 [ByRefEvent]
 public readonly record struct HitByLightningEvent(EntityUid Source, EntityUid Target);
+
+/// <summary>
+/// Triad: raised directed on each candidate target before a lightning volley is sorted and rolled.
+/// Subscribers may adjust <see cref="Priority"/> and <see cref="HitProbability"/> from live state
+/// (e.g. a tesla coil bidding by charge headroom). Both start at the target's static
+/// LightningTargetComponent values; HitProbability is clamped to [0, 1] after the event.
+/// </summary>
+/// <param name="Source">The entity shooting the lightning volley</param>
+/// <param name="Priority">Effective sort priority for this volley; higher is struck first</param>
+/// <param name="HitProbability">Effective chance this target is not skipped by the roll</param>
+[ByRefEvent]
+public record struct LightningStrikeAttemptEvent(EntityUid Source, int Priority, float HitProbability);

--- a/Content.Server/Lightning/LightningTargetSystem.cs
+++ b/Content.Server/Lightning/LightningTargetSystem.cs
@@ -1,3 +1,4 @@
+using Content.Server.Electrocution; // Triad
 using Content.Server.Explosion.EntitySystems;
 using Content.Server.Lightning;
 using Content.Server.Lightning.Components;
@@ -12,6 +13,7 @@ namespace Content.Server.Tesla.EntitySystems;
 public sealed class LightningTargetSystem : EntitySystem
 {
     [Dependency] private readonly DamageableSystem _damageable = default!;
+    [Dependency] private readonly ElectrocutionSystem _electrocution = default!; // Triad
     [Dependency] private readonly ExplosionSystem _explosionSystem = default!;
     [Dependency] private readonly TransformSystem _transform = default!;
 
@@ -24,6 +26,10 @@ public sealed class LightningTargetSystem : EntitySystem
 
     private void OnHitByLightning(Entity<LightningTargetComponent> uid, ref HitByLightningEvent args)
     {
+        // Triad: electrocution path for biological targets, which the Structural damage below no-ops on.
+        if (uid.Comp.ElectrocuteOnStrike)
+            _electrocution.TryDoElectrocution(uid, args.Source, uid.Comp.ElectrocutionShockDamage, uid.Comp.ElectrocutionTime, refresh: true);
+
         DamageSpecifier damage = new();
         damage.DamageDict.Add("Structural", uid.Comp.DamageFromLightning);
         _damageable.TryChangeDamage(uid, damage, true);

--- a/Content.Server/Tesla/Components/TeslaCoilComponent.cs
+++ b/Content.Server/Tesla/Components/TeslaCoilComponent.cs
@@ -14,4 +14,21 @@ public sealed partial class TeslaCoilComponent : Component
     // To Do: Different lightning bolts have different powers and generate different amounts of energy
     [DataField, ViewVariables(VVAccess.ReadWrite)]
     public float ChargeFromLightning = 50000f;
+
+    /// <summary>
+    /// Triad: strike-chance floor once the battery is full. Lightning favors the biggest potential
+    /// difference, so the coil's effective hit chance scales with charge headroom: empty = 1.0
+    /// (plus a priority bump above every static target), full = this floor. A floored coil still
+    /// outranks grounding rods in the sort but gets skipped on almost every roll, so overflow
+    /// falls through to the rods.
+    /// </summary>
+    [DataField, ViewVariables(VVAccess.ReadWrite)]
+    public float SaturatedHitProbability = 0.05f;
+
+    /// <summary>
+    /// Triad: priority added on top of the coil's static LightningTarget priority while the battery
+    /// is completely empty, so a fresh coil catches the next bolt ahead of every charged coil.
+    /// </summary>
+    [DataField, ViewVariables(VVAccess.ReadWrite)]
+    public int EmptyPriorityBonus = 1;
 }

--- a/Content.Server/Tesla/Components/TeslaEnergyBallComponent.cs
+++ b/Content.Server/Tesla/Components/TeslaEnergyBallComponent.cs
@@ -36,8 +36,8 @@ public sealed partial class TeslaEnergyBallComponent : Component
 
     /// <summary>
     /// Triad: energy bled passively per second while the ball exists. 0 disables decay (upstream
-    /// behavior, the default). The tesla prototype pins this to the Level-1 PA feed rate so Level 1
-    /// is break-even: alive, no motes. See energyball.yml.
+    /// behavior, the default). The tesla prototype pins this to the effective Level-1 PA feed rate
+    /// so Level 1 idles the ball: alive, essentially no motes. See energyball.yml for the tuning.
     /// </summary>
     [DataField, ViewVariables(VVAccess.ReadWrite)]
     public float PassiveEnergyDecay;

--- a/Content.Server/Tesla/Components/TeslaEnergyBallComponent.cs
+++ b/Content.Server/Tesla/Components/TeslaEnergyBallComponent.cs
@@ -35,6 +35,14 @@ public sealed partial class TeslaEnergyBallComponent : Component
     public float EnergyToDespawn = -100f;
 
     /// <summary>
+    /// Triad: energy bled passively per second while the ball exists. 0 disables decay (upstream
+    /// behavior, the default). The tesla prototype pins this to the Level-1 PA feed rate so Level 1
+    /// is break-even: alive, no motes. See energyball.yml.
+    /// </summary>
+    [DataField, ViewVariables(VVAccess.ReadWrite)]
+    public float PassiveEnergyDecay;
+
+    /// <summary>
     /// Played when energy reaches the lower limit (and entity destroyed)
     /// </summary>
     [DataField]

--- a/Content.Server/Tesla/EntitySystem/TeslaCoilSystem.cs
+++ b/Content.Server/Tesla/EntitySystem/TeslaCoilSystem.cs
@@ -2,6 +2,7 @@ using Content.Server.Power.Components;
 using Content.Server.Power.EntitySystems;
 using Content.Server.Tesla.Components;
 using Content.Server.Lightning;
+using Content.Shared.Power; // Triad
 
 namespace Content.Server.Tesla.EntitySystems;
 
@@ -11,6 +12,7 @@ namespace Content.Server.Tesla.EntitySystems;
 public sealed class TeslaCoilSystem : EntitySystem
 {
     [Dependency] private readonly BatterySystem _battery = default!;
+    [Dependency] private readonly SharedAppearanceSystem _appearance = default!; // Triad
 
     public override void Initialize()
     {
@@ -18,6 +20,7 @@ public sealed class TeslaCoilSystem : EntitySystem
 
         SubscribeLocalEvent<TeslaCoilComponent, HitByLightningEvent>(OnHitByLightning);
         SubscribeLocalEvent<TeslaCoilComponent, LightningStrikeAttemptEvent>(OnLightningStrikeAttempt); // Triad
+        SubscribeLocalEvent<TeslaCoilComponent, ChargeChangedEvent>(OnChargeChanged); // Triad
     }
 
     //When struck by lightning, charge the internal battery
@@ -46,5 +49,13 @@ public sealed class TeslaCoilSystem : EntitySystem
 
         var headroom = 1f - battery.CurrentCharge / battery.MaxCharge;
         args.HitProbability = MathHelper.Lerp(coil.Comp.SaturatedHitProbability, 1f, headroom);
+    }
+
+    // Triad: hold the arcing indicator while the coil can't bank a full strike, so engineers can see
+    // saturation at a glance. Drains through the power net raise ChargeChangedEvent too, so the
+    // indicator clears on its own as the coil pushes charge into the grid.
+    private void OnChargeChanged(Entity<TeslaCoilComponent> coil, ref ChargeChangedEvent args)
+    {
+        _appearance.SetData(coil, TeslaCoilVisuals.Charged, args.Charge + coil.Comp.ChargeFromLightning > args.MaxCharge);
     }
 }

--- a/Content.Server/Tesla/EntitySystem/TeslaCoilSystem.cs
+++ b/Content.Server/Tesla/EntitySystem/TeslaCoilSystem.cs
@@ -17,6 +17,7 @@ public sealed class TeslaCoilSystem : EntitySystem
         base.Initialize();
 
         SubscribeLocalEvent<TeslaCoilComponent, HitByLightningEvent>(OnHitByLightning);
+        SubscribeLocalEvent<TeslaCoilComponent, LightningStrikeAttemptEvent>(OnLightningStrikeAttempt); // Triad
     }
 
     //When struck by lightning, charge the internal battery
@@ -26,5 +27,24 @@ public sealed class TeslaCoilSystem : EntitySystem
         {
             _battery.SetCharge(coil, batteryComponent.CurrentCharge + coil.Comp.ChargeFromLightning);
         }
+    }
+
+    // Triad: bid for the strike by charge headroom. An empty coil is a guaranteed catch and outbids
+    // every static target; a full coil floors at SaturatedHitProbability so bolts fall through to
+    // the grounding rods. At half charge the effective chance is ~0.52, close to the old static 0.5.
+    private void OnLightningStrikeAttempt(Entity<TeslaCoilComponent> coil, ref LightningStrikeAttemptEvent args)
+    {
+        if (!TryComp<BatteryComponent>(coil, out var battery) || battery.MaxCharge <= 0f)
+            return;
+
+        if (battery.CurrentCharge <= 0f)
+        {
+            args.Priority += coil.Comp.EmptyPriorityBonus;
+            args.HitProbability = 1f;
+            return;
+        }
+
+        var headroom = 1f - battery.CurrentCharge / battery.MaxCharge;
+        args.HitProbability = MathHelper.Lerp(coil.Comp.SaturatedHitProbability, 1f, headroom);
     }
 }

--- a/Content.Server/Tesla/EntitySystem/TeslaEnergyBallSystem.cs
+++ b/Content.Server/Tesla/EntitySystem/TeslaEnergyBallSystem.cs
@@ -26,6 +26,22 @@ public sealed class TeslaEnergyBallSystem : EntitySystem
         SubscribeLocalEvent<TeslaEnergyBallComponent, EntityConsumedByEventHorizonEvent>(OnConsumed);
     }
 
+    // Triad: passive energy decay. The ball bleeds energy continuously so it needs a running PA to
+    // sustain it; with no feed it drains to EnergyToDespawn and collapses.
+    public override void Update(float frameTime)
+    {
+        base.Update(frameTime);
+
+        var query = EntityQueryEnumerator<TeslaEnergyBallComponent>();
+        while (query.MoveNext(out var uid, out var teslaEnergyBall))
+        {
+            if (teslaEnergyBall.PassiveEnergyDecay <= 0f)
+                continue;
+
+            AdjustEnergy(uid, teslaEnergyBall, -teslaEnergyBall.PassiveEnergyDecay * frameTime);
+        }
+    }
+
     private void OnConsumed(Entity<TeslaEnergyBallComponent> tesla, ref EntityConsumedByEventHorizonEvent args)
     {
         Spawn(tesla.Comp.ConsumeEffectProto, Transform(args.Entity).Coordinates);

--- a/Content.Shared/Power/TeslaCoilVisuals.cs
+++ b/Content.Shared/Power/TeslaCoilVisuals.cs
@@ -6,5 +6,6 @@ namespace Content.Shared.Power;
 public enum TeslaCoilVisuals : byte
 {
     Enabled,
-    Lightning
+    Lightning,
+    Charged // Triad: coil battery too full to accept a full strike; shows the persistent arcing indicator
 }

--- a/Resources/Maps/_NF/POI/edison.yml
+++ b/Resources/Maps/_NF/POI/edison.yml
@@ -36438,23 +36438,6 @@ entities:
     - type: Transform
       pos: 33.5,-24.5
       parent: 1
-- proto: CrateEngineeringTeslaCoil
-  entities:
-  - uid: 6050
-    components:
-    - type: Transform
-      pos: 43.5,-23.5
-      parent: 1
-  - uid: 6051
-    components:
-    - type: Transform
-      pos: 42.5,-23.5
-      parent: 1
-  - uid: 6052
-    components:
-    - type: Transform
-      pos: 44.5,-23.5
-      parent: 1
 - proto: CrateEngineeringTeslaCoilBulk
   entities:
   - uid: 6053
@@ -80497,28 +80480,6 @@ entities:
     components:
     - type: Transform
       pos: 25.5,17.5
-      parent: 1
-- proto: TeslaCoilFlatpack
-  entities:
-  - uid: 12219
-    components:
-    - type: Transform
-      pos: 46.438305,-23.349659
-      parent: 1
-  - uid: 12220
-    components:
-    - type: Transform
-      pos: 46.713493,-23.386375
-      parent: 1
-  - uid: 12221
-    components:
-    - type: Transform
-      pos: 46.493343,-23.569962
-      parent: 1
-  - uid: 12222
-    components:
-    - type: Transform
-      pos: 46.823566,-23.569962
       parent: 1
 - proto: TeslaGenerator
   entities:

--- a/Resources/Prototypes/Entities/Mobs/base.yml
+++ b/Resources/Prototypes/Entities/Mobs/base.yml
@@ -123,6 +123,9 @@
   - type: LightningTarget
     priority: 1 # Mono
     lightningExplode: false
+    # Triad: bolts that overflow the coils and rods electrocute whoever they land on.
+    # Insulated gloves apply; lightningResistance stays 1 so the bolt can arc once more onward.
+    electrocuteOnStrike: true
 
 # Used for mobs that can enter combat mode and can attack.
 - type: entity

--- a/Resources/Prototypes/Entities/Structures/Power/Generation/Tesla/coil.yml
+++ b/Resources/Prototypes/Entities/Structures/Power/Generation/Tesla/coil.yml
@@ -63,7 +63,7 @@
     chargeFromLightning: 2000000
   - type: LightningTarget
     priority: 4
-    hitProbability: 0.5
+    hitProbability: 0.5 # Triad: fallback only; with a working battery the coil bids by charge headroom (see TeslaCoilSystem)
     lightningResistance: 10
     lightningExplode: false
   - type: PowerNetworkBattery

--- a/Resources/Prototypes/Entities/Structures/Power/Generation/Tesla/coil.yml
+++ b/Resources/Prototypes/Entities/Structures/Power/Generation/Tesla/coil.yml
@@ -66,8 +66,8 @@
     # Triad: wild-tesla economy, capacitor model. One strike fills the bank; the full coil's strike
     # bid floors (see TeslaCoilSystem) so the next bolt round-robins to a drained coil, and the bank
     # trickles out through the throttled supply below. Tower count is therefore the throughput knob:
-    # Monte Carlo at a hacked Level-3 PA gives ~3.5 MW with 12 towers, ~6 MW with 24, ~7 MW asymptote
-    # (~2.5 MW at stock Level 2 with 12).
+    # Monte Carlo at a hacked Level-3 PA: ~5.3 MW with 12 towers, peaking at ~7 MW with 24; towers
+    # beyond 24 add no output, only spread wear (~2.6 MW at stock Level 2 with 12).
     maxCharge: 2000000
     startingCharge: 0
   - type: BatteryDischarger
@@ -78,16 +78,16 @@
     hitProbability: 0.5 # Triad: fallback only; with a working battery the coil bids by charge headroom (see TeslaCoilSystem)
     lightningResistance: 10
     lightningExplode: false
-    # Triad: durability for 9-hour rounds under the mote-heavy strike economy: 4500 strikes to
-    # destruction. Simulated with a 12-coil ring: first coil death ~11h at PA Level 2, ~4h at a
-    # hacked Level 3. Stretch service intervals by welding (Repairable) or adding coils.
-    damageFromLightning: 0.05
+    # Triad: 1500 strikes to destruction. Simulated: first tower death ~2h on a max-output 24-tower
+    # array at a hacked Level 3, ~3.4h at stock Level 2 with 12 towers. Weld (Repairable) on a
+    # service rotation, or add towers beyond 24 to spread wear.
+    damageFromLightning: 0.15
   - type: PowerNetworkBattery
     # Triad: throttled discharge is what makes tower count matter — each tower trickles its bank at
-    # 300 kW, so full harvest at a hacked Level-3 PA needs a ~24-tower array. The ~7s per-tower
-    # buffer also smooths the strike lumps into near-constant grid supply.
-    maxSupply: 300000
-    supplyRampTolerance: 300000
+    # 500 kW (4s recovery), sized so harvest at a hacked Level-3 PA peaks at a 24-tower array. The
+    # per-tower buffer also smooths the strike lumps into near-constant grid supply.
+    maxSupply: 500000
+    supplyRampTolerance: 500000
   - type: Anchorable
   - type: Rotatable
   - type: Pullable

--- a/Resources/Prototypes/Entities/Structures/Power/Generation/Tesla/coil.yml
+++ b/Resources/Prototypes/Entities/Structures/Power/Generation/Tesla/coil.yml
@@ -30,6 +30,9 @@
       - state: coilhit
         visible: false
         map: ["hit"]
+      - state: coilhit # Triad: persistent arc while saturated; own layer so the strike flash can't clobber it
+        visible: false
+        map: ["charged"]
   - type: Appearance
   - type: GenericVisualizer
     visuals:
@@ -39,6 +42,10 @@
           False: { state: coil }
       enum.TeslaCoilVisuals.Lightning:
         hit:
+          True: { visible: true }
+          False: { visible: false }
+      enum.TeslaCoilVisuals.Charged: # Triad
+        charged:
           True: { visible: true }
           False: { visible: false }
   - type: LightningSparking

--- a/Resources/Prototypes/Entities/Structures/Power/Generation/Tesla/coil.yml
+++ b/Resources/Prototypes/Entities/Structures/Power/Generation/Tesla/coil.yml
@@ -63,16 +63,22 @@
     sprite: Structures/Power/Generation/Tesla/coil.rsi
     state: coil
   - type: Battery
-    maxCharge: 1000000
+    # Triad: wild-tesla economy. A strike banks maxCharge/6, so the charge-headroom routing has a
+    # real gradient instead of one strike pegging the coil (upstream: 2M strike into a 1M bank).
+    maxCharge: 3000000
     startingCharge: 0
   - type: BatteryDischarger
   - type: TeslaCoil
-    chargeFromLightning: 2000000
+    chargeFromLightning: 500000 # Triad: was 2000000, see Battery note
   - type: LightningTarget
     priority: 4
     hitProbability: 0.5 # Triad: fallback only; with a working battery the coil bids by charge headroom (see TeslaCoilSystem)
     lightningResistance: 10
     lightningExplode: false
+    # Triad: durability for 9-hour rounds under the mote-heavy strike economy: ~4500 strikes to
+    # destruction (~7h at a moderate PA level per coil). Stretch service intervals by welding
+    # (Repairable) or spreading load across more coils.
+    damageFromLightning: 0.05
   - type: PowerNetworkBattery
     maxSupply: 1000000
     supplyRampTolerance: 1000000

--- a/Resources/Prototypes/Entities/Structures/Power/Generation/Tesla/coil.yml
+++ b/Resources/Prototypes/Entities/Structures/Power/Generation/Tesla/coil.yml
@@ -63,15 +63,16 @@
     sprite: Structures/Power/Generation/Tesla/coil.rsi
     state: coil
   - type: Battery
-    # Triad: wild-tesla economy. A strike banks maxCharge/6, so the charge-headroom routing has a
-    # real gradient instead of one strike pegging the coil (upstream: 2M strike into a 1M bank).
-    # Sized from Monte Carlo for ~7 MW sustained at a hacked Level-3 PA with a 12-coil ring
-    # (~2.6 MW at stock Level 2).
-    maxCharge: 12000000
+    # Triad: wild-tesla economy, capacitor model. One strike fills the bank; the full coil's strike
+    # bid floors (see TeslaCoilSystem) so the next bolt round-robins to a drained coil, and the bank
+    # trickles out through the throttled supply below. Tower count is therefore the throughput knob:
+    # Monte Carlo at a hacked Level-3 PA gives ~3.5 MW with 12 towers, ~6 MW with 24, ~7 MW asymptote
+    # (~2.5 MW at stock Level 2 with 12).
+    maxCharge: 2000000
     startingCharge: 0
   - type: BatteryDischarger
   - type: TeslaCoil
-    chargeFromLightning: 2000000 # Triad: upstream value, but into a 12M bank instead of 1M — see Battery note
+    chargeFromLightning: 2000000 # Triad: equals maxCharge on purpose — one strike saturates, see Battery note
   - type: LightningTarget
     priority: 4
     hitProbability: 0.5 # Triad: fallback only; with a working battery the coil bids by charge headroom (see TeslaCoilSystem)
@@ -82,8 +83,11 @@
     # hacked Level 3. Stretch service intervals by welding (Repairable) or adding coils.
     damageFromLightning: 0.05
   - type: PowerNetworkBattery
-    maxSupply: 1000000
-    supplyRampTolerance: 1000000
+    # Triad: throttled discharge is what makes tower count matter — each tower trickles its bank at
+    # 300 kW, so full harvest at a hacked Level-3 PA needs a ~24-tower array. The ~7s per-tower
+    # buffer also smooths the strike lumps into near-constant grid supply.
+    maxSupply: 300000
+    supplyRampTolerance: 300000
   - type: Anchorable
   - type: Rotatable
   - type: Pullable

--- a/Resources/Prototypes/Entities/Structures/Power/Generation/Tesla/coil.yml
+++ b/Resources/Prototypes/Entities/Structures/Power/Generation/Tesla/coil.yml
@@ -75,9 +75,9 @@
     hitProbability: 0.5 # Triad: fallback only; with a working battery the coil bids by charge headroom (see TeslaCoilSystem)
     lightningResistance: 10
     lightningExplode: false
-    # Triad: durability for 9-hour rounds under the mote-heavy strike economy: ~4500 strikes to
-    # destruction (~7h at a moderate PA level per coil). Stretch service intervals by welding
-    # (Repairable) or spreading load across more coils.
+    # Triad: durability for 9-hour rounds under the mote-heavy strike economy: 4500 strikes to
+    # destruction. Simulated with a 12-coil ring: first coil death ~11h at PA Level 2, ~4h at a
+    # hacked Level 3. Stretch service intervals by welding (Repairable) or adding coils.
     damageFromLightning: 0.05
   - type: PowerNetworkBattery
     maxSupply: 1000000

--- a/Resources/Prototypes/Entities/Structures/Power/Generation/Tesla/coil.yml
+++ b/Resources/Prototypes/Entities/Structures/Power/Generation/Tesla/coil.yml
@@ -65,11 +65,13 @@
   - type: Battery
     # Triad: wild-tesla economy. A strike banks maxCharge/6, so the charge-headroom routing has a
     # real gradient instead of one strike pegging the coil (upstream: 2M strike into a 1M bank).
-    maxCharge: 3000000
+    # Sized from Monte Carlo for ~7 MW sustained at a hacked Level-3 PA with a 12-coil ring
+    # (~2.6 MW at stock Level 2).
+    maxCharge: 12000000
     startingCharge: 0
   - type: BatteryDischarger
   - type: TeslaCoil
-    chargeFromLightning: 500000 # Triad: was 2000000, see Battery note
+    chargeFromLightning: 2000000 # Triad: upstream value, but into a 12M bank instead of 1M — see Battery note
   - type: LightningTarget
     priority: 4
     hitProbability: 0.5 # Triad: fallback only; with a working battery the coil bids by charge headroom (see TeslaCoilSystem)

--- a/Resources/Prototypes/Entities/Structures/Power/Generation/Tesla/energyball.yml
+++ b/Resources/Prototypes/Entities/Structures/Power/Generation/Tesla/energyball.yml
@@ -73,6 +73,12 @@
     consumeEntities: false
   - type: TeslaEnergyBall
     spawnProto: TeslaMiniEnergyBall
+    # Triad: wild-tesla economy. Decay pinned to the Level-1 PA feed (3 emitters * 20 energy / 6s = 10/s)
+    # so Level 1 is break-even (alive, no motes), Standby/Level 0 starves the ball, Level 2+ makes motes.
+    # The deep despawn floor gives ~60s of grace under full starvation before collapse, since feed lands
+    # in 6-second lumps and the stock -100 floor would kill it after barely two missed waves.
+    passiveEnergyDecay: 10
+    energyToDespawn: -600
     soundCollapse:
       path: /Audio/Effects/tesla_collapse.ogg
       params:

--- a/Resources/Prototypes/Entities/Structures/Power/Generation/Tesla/energyball.yml
+++ b/Resources/Prototypes/Entities/Structures/Power/Generation/Tesla/energyball.yml
@@ -73,15 +73,16 @@
     consumeEntities: false
   - type: TeslaEnergyBall
     spawnProto: TeslaMiniEnergyBall
-    # Triad: wild-tesla economy. Decay pinned to the Level-1 PA feed (3 emitters * 20 energy / 6s = 10/s)
-    # so Level 1 is break-even (alive, no motes), Standby/Level 0 starves the ball, Level 2+ makes motes.
-    # The deep despawn floor gives ~60s of grace under full starvation before collapse, since feed lands
-    # in 6-second lumps and the stock -100 floor would kill it after barely two missed waves.
-    passiveEnergyDecay: 10
+    # Triad: wild-tesla economy. Decay pinned to the EFFECTIVE Level-1 PA feed (~7.3/s from Monte
+    # Carlo, not the ideal 3 lanes * 20 / 6s = 10/s: the ball's wander in a 3-wide cage drops the far
+    # side lane about a third of the time). Level 1 idles the ball (alive, a stray mote every few
+    # minutes), Standby/Level 0 starves it, Level 2+ makes motes. The deep despawn floor gives ~85s
+    # of grace under full starvation, since feed lands in 6-second lumps.
+    passiveEnergyDecay: 7
     energyToDespawn: -600
-    # Mote count self-regulates: spawn rate = net feed / needEnergyToSpawn, motes live 120s, so
-    # Level 3 (net +20/s) sustains 20*120/120 = 20 motes and Level 2 (net +5/s) sustains 5.
-    needEnergyToSpawn: 120
+    # Mote count self-regulates: spawn rate = net feed / needEnergyToSpawn, motes live 120s.
+    # Simulated ladder at these numbers: Level 1 ~0.5 motes, Level 2 ~6, Level 3 ~22 sustained.
+    needEnergyToSpawn: 80
     soundCollapse:
       path: /Audio/Effects/tesla_collapse.ogg
       params:

--- a/Resources/Prototypes/Entities/Structures/Power/Generation/Tesla/energyball.yml
+++ b/Resources/Prototypes/Entities/Structures/Power/Generation/Tesla/energyball.yml
@@ -79,6 +79,9 @@
     # in 6-second lumps and the stock -100 floor would kill it after barely two missed waves.
     passiveEnergyDecay: 10
     energyToDespawn: -600
+    # Mote count self-regulates: spawn rate = net feed / needEnergyToSpawn, motes live 120s, so
+    # Level 3 (net +20/s) sustains 20*120/120 = 20 motes and Level 2 (net +5/s) sustains 5.
+    needEnergyToSpawn: 120
     soundCollapse:
       path: /Audio/Effects/tesla_collapse.ogg
       params:

--- a/Resources/Prototypes/_NF/PointsOfInterest/EdisonPort/entities.yml
+++ b/Resources/Prototypes/_NF/PointsOfInterest/EdisonPort/entities.yml
@@ -196,12 +196,12 @@
   id: CrateEngineeringTeslaCoilBulk
   parent: CrateEngineeringSecure
   name: bulk tesla coil crate
-  description: A collection of six tesla coils. Attracts lightning and generates energy from it.
+  description: A dozen flatpacked tesla coils. Attract lightning and generate energy from it.
   components:
   - type: StorageFill
     contents:
       - id: TeslaCoilFlatpack
-        amount: 6
+        amount: 12 # Triad: one crate = a starter array; two = the 24-tower max-output build
 
 - type: entity
   id: CrateEngineeringSingularityCollectorBulk

--- a/Resources/Prototypes/_Triad/Catalog/Cargo/cargo_engines.yml
+++ b/Resources/Prototypes/_Triad/Catalog/Cargo/cargo_engines.yml
@@ -1,0 +1,12 @@
+# Triad: the upstream single-coil product (EngineTeslaCoil) is abstract via Frontier, so this is
+# the only console path to tesla coils. One bulk crate is a 12-tower starter array; two build the
+# 24-tower max-output ring.
+- type: cargoProduct
+  id: EngineTeslaCoilBulk
+  icon:
+    sprite: Structures/Power/Generation/Tesla/coil.rsi
+    state: coil
+  product: CrateEngineeringTeslaCoilBulk
+  cost: 10000
+  category: cargoproduct-category-name-engineering
+  group: market

--- a/Resources/ServerInfo/Guidebook/Engineering/TeslaEngine.xml
+++ b/Resources/ServerInfo/Guidebook/Engineering/TeslaEngine.xml
@@ -102,9 +102,9 @@
     <GuideEntityEmbed Entity="ClothingHandsGlovesColorYellow"/>
   </Box>
 
-  Remember that the ball starves without its accelerator. Shut the Particle Accelerator down and a loose ball will collapse on its own within a couple of minutes, provided it doesn't find enough to eat along the way. Evacuate its path, cut the feed, and wait it out.
+  Remember that the ball starves without its accelerator. An escaped ball has left the particle stream behind, so it is already dying: expect it to collapse on its own within a few minutes. Evacuate its path and let it burn itself out.
 
-  The tesla can also be destroyed by firing antiparticles at it using a Portable Particle Decelerator, however, the Tesla is much more powerful than the Singularity, and it will take a lot of antiparticles to destroy it.
+  To end it faster, fire antiparticles at it using a Portable Particle Decelerator, however, the Tesla is much more powerful than the Singularity, and it will take a lot of antiparticles to destroy it.
   A group of people using decelerators is recommended to destroy a tesloose.
 
   Portable Particle Decelerators can be either researched and made by the Research Department, or they can be bought from Cargo.

--- a/Resources/ServerInfo/Guidebook/Engineering/TeslaEngine.xml
+++ b/Resources/ServerInfo/Guidebook/Engineering/TeslaEngine.xml
@@ -102,16 +102,6 @@
     <GuideEntityEmbed Entity="ClothingHandsGlovesColorYellow"/>
   </Box>
 
-  Remember that the ball starves without its accelerator. An escaped ball has left the particle stream behind, so it is already dying: expect it to collapse on its own within a few minutes. Evacuate its path and let it burn itself out.
-
-  To end it faster, fire antiparticles at it using a Portable Particle Decelerator, however, the Tesla is much more powerful than the Singularity, and it will take a lot of antiparticles to destroy it.
-  A group of people using decelerators is recommended to destroy a tesloose.
-
-  Portable Particle Decelerators can be either researched and made by the Research Department, or they can be bought from Cargo.
-
-  <Box>
-    <GuideEntityEmbed Entity="WeaponParticleDecelerator"/>
-  </Box>
-
+  Remember that the ball starves without its accelerator. An escaped ball has left the particle stream behind, so it is already dying: expect it to collapse on its own within a few minutes. Evacuate its path, keep your distance, and let it burn itself out.
 
 </Document>

--- a/Resources/ServerInfo/Guidebook/Engineering/TeslaEngine.xml
+++ b/Resources/ServerInfo/Guidebook/Engineering/TeslaEngine.xml
@@ -1,4 +1,4 @@
-﻿<Document>
+<Document>
   # Tesla Engine
   The Tesla Engine is a powerful generator that uses a contained ball of lightning to produce energy for the station.
   <Box>
@@ -10,11 +10,23 @@
 
   It generates power by harnessing the lightning strikes produced by the lightning ball using Tesla Coils.
 
+  ## Feeding the Ball
+  The lightning ball constantly bleeds energy into space. It must be continuously fed by a running Particle Accelerator, or it will starve, shrink, and collapse within a couple of minutes.
+
+  How hard you feed it matters:
+  - At low accelerator power the ball merely survives, producing only its own occasional strikes.
+  - Fed harder, the ball builds surplus energy and sheds it as miniature ball lightning, which orbit the containment field and fire strikes of their own.
+  - The more miniature balls in orbit, the more lightning, and the more power your coils can harvest. A well-fed tesla is dramatically more generous, and dramatically more dangerous.
+
+  <Box>
+    <GuideEntityEmbed Entity="TeslaMiniEnergyBall"/>
+  </Box>
+
   ## Containment Field
   The Tesla Engine requires a containment field to prevent the lightning ball from escaping and destroying the station.
 
   It is suggested to use the minimum size containment field for the lightning ball.
-  Larger containment fields allow the lightning ball to reach closer to sensitive equipment and potentially strike it, ignoring placed grounding rods and tesla coils.
+  A tight cage keeps the ball centered in the accelerator's particle stream, and keeps it away from sensitive equipment beyond the field.
 
   <Box>
     <GuideEntityEmbed Entity="ContainmentFieldGenerator" Caption="" Margin="0"/>
@@ -33,18 +45,16 @@
   </Box>
 
   ## Lightning Strikes
-  When the Tesla Engine is active, the lightning ball will periodically strike objects surrounding it.
+  When the Tesla Engine is active, the lightning ball and its miniature balls will periodically strike objects surrounding them.
 
-  The Tesla prefers to strike some objects more than others, such as Tesla Coils and Grounding Rods.
+  Lightning seeks the largest difference in electrical potential. An empty Tesla Coil is the most attractive target on the station; a fully charged one is nearly ignored. Grounding Rods are always willing targets and sit just below coils in preference.
 
-  If the tesla can't find any Tesla Coils or Grounding Rods to strike first, it will strike almost any station object capable of being powered, such as Substations, APCs, and general machinery.
+  If the tesla can't find any Tesla Coils or Grounding Rods to strike, it will strike almost any station object capable of being powered, such as Substations, APCs, and general machinery.
 
-  Certain objects aren't struck by the tesla, such as batteries, lights, PDAs, and other handheld items.
-
-  It will also strike mobs and crew members, shocking them. Make sure to wear insulated gloves before approaching it.
+  It will also strike mobs and crew members, electrocuting them. Make sure to wear insulated gloves before approaching it, and keep spectators away from a heavily fed engine.
 
   ## Tesla Coils
-  Lightning strikes can be harnessed using Tesla Coils, which convert the lightning strikes into power for the station.
+  Lightning strikes are harnessed using Tesla Coils, which store each strike and feed it to the grid.
 
   <Box>
     <GuideEntityEmbed Entity="TeslaCoil" Caption=""/>
@@ -52,13 +62,13 @@
     <GuideEntityEmbed Entity="TeslaCoil" Caption=""/>
   </Box>
 
-  Tesla Coils should be placed around the lightning ball to capture the energy from lightning strikes, as well as to prevent the lightning from striking sensitive equipment further away.
+  A single strike fully charges a coil's internal bank. While it holds charge the coil arcs visibly and discharges into the grid at a steady rate; lightning avoids it in favor of empty coils, so strikes naturally spread themselves across the array.
 
-  Tesla Coils take damage every time they are struck by lightning, and will eventually break if not repaired.
-  Be sure to monitor the condition of the Tesla Coils and repair them as needed.
+  Ring the containment field with coils. Output grows with every coil you add until each bolt reliably finds an empty coil waiting; beyond that point, additional coils add no output but spread the wear.
 
-  When lightning strikes Tesla Coils, they fill an internal battery, which is rapidly discharged to the grid.
-  It will discharge this power even if there is no consumer to take it, so it's a good idea to have an SMES nearby to store the power and discharge it smoothly.
+  Coils take damage every time they are struck, and a hard-driven array needs regular attention. Watch for cracks and repair coils with a welder before they fail, or stock spares.
+
+  A coil arcing is normal, it is simply holding charge. If the entire array arcs continuously, your grid isn't drawing enough power: add SMES capacity to soak up the surplus, or the engine will waste its strikes.
 
   ## Grounding Rods
   Grounding Rods help protect sensitive equipment from being struck and prevent a loosed tesla (tesloose).
@@ -76,7 +86,7 @@
   </Box>
 
   Grounding rods do not take damage from lightning strikes.
-  This makes them beneficial for forming a saftey net of grounding rods to rely on in case the tesla coils are damaged or destroyed.
+  This makes them beneficial for forming a safety net of grounding rods to rely on in case the tesla coils are damaged or destroyed.
 
   Engineers should use grounding rods to protect sensitive equipment from lightning strikes, such as the Emitters powering the containment field generators.
 
@@ -84,7 +94,7 @@
   If the lightning ball escapes the containment field, it is referred to as a loosed tesla, or tesloose.
 
   An escaped tesla will randomly walk around the station, attracted to objects that can be powered, such as APCs, Substations, and machinery.
-  It will also gladly strike crew members and mobs, shocking them.
+  It will also gladly strike crew members and mobs, electrocuting them.
 
   Wearing insulated gloves will protect you from being shocked by the tesla, but it won't prevent the tesla from striking you.
 
@@ -92,7 +102,9 @@
     <GuideEntityEmbed Entity="ClothingHandsGlovesColorYellow"/>
   </Box>
 
-  The tesla can be destroyed by firing antiparticles at it using a Portable Particle Decelerator, however, the Tesla is much more powerful than the Singularity, and it will take a lot of antiparticles to destroy it.
+  Remember that the ball starves without its accelerator. Shut the Particle Accelerator down and a loose ball will collapse on its own within a couple of minutes, provided it doesn't find enough to eat along the way. Evacuate its path, cut the feed, and wait it out.
+
+  The tesla can also be destroyed by firing antiparticles at it using a Portable Particle Decelerator, however, the Tesla is much more powerful than the Singularity, and it will take a lot of antiparticles to destroy it.
   A group of people using decelerators is recommended to destroy a tesloose.
 
   Portable Particle Decelerators can be either researched and made by the Research Department, or they can be bought from Cargo.


### PR DESCRIPTION
## About the PR
It's time for the Tesla to be good instead of bad.

The ball now has a real energy budget, coils are single-strike capacitors that lightning routes between by charge, and the whole engine scales with how hard you feed it and how many towers you build.

## Why / Balance
The tesla was flat: the ball was immortal once spawned, coils filled on one strike into an undersized bank, the strike table ignored charge state, and durability was tuned for rounds a fraction of our length. There was no reason to push the PA and no reason to buy coils.

Every number in this PR is backed by a Monte Carlo sim of the strike economy (bolt cadences, routing rolls, drain cycles, ball wander vs the PA lanes). The resulting ladder: the ball starves without a running PA (this also makes a tesloose self-resolving in a few minutes, which matters on a server with no obtainable particle decelerators), idles at low power, and sheds miniature ball lightning as feed rises. Coils fill from a single strike, arc visibly while charged, trickle out at 500 kW, and lightning prefers whichever coil has the most headroom, so strikes round-robin the array. Output grows with tower count to a peak at 24 towers (~7 MW fully driven); towers past that only spread wear. First tower death lands ~2h on a max array, so a hard-driven engine needs a weld rotation or spare coils. Bolts that overflow the coils and rods now genuinely electrocute crew (insuls apply, and the arc can chain onward once).

New upstreamable hook: `LightningStrikeAttemptEvent`, raised per candidate before a volley is sorted and rolled so targets can bid from live state. Targets without a subscriber behave exactly as before.

Also: the Edison bulk crate holds 12 flatpacks and gains a cargo listing (Frontier had abstracted the only coil product, so nothing sold coils at all), Edison map stock trims to one bulk crate, and the Tesla Engine guidebook is rewritten for the new mechanics.

## Media
<img width="686" height="386" alt="image" src="https://github.com/user-attachments/assets/70ee6c0d-5613-4ccf-be1f-d38fcc9a198a" />

## Requirements
- [x] I have read relevant guidelines/documentation to this PR found on our devwiki.
- [x] I have added media to this PR or it does not require an ingame showcase.
- [x] I can confirm this PR contains either no AI-generated content, or AI-generated content that meets our guidelines.

## How to test
Build a standard tesla setup (3x3 field cage, coil ring, rods) and run the PA through its power levels. At standby the ball collapses in about a minute; at Level 1 it idles; higher levels shed motes and output climbs. Strike a coil and watch it arc until drained; let the SMES bank fill and the whole array should sit arcing with bolts spilling to the rods. Stand next to it without insuls at your own risk.

I have not verified the arc indicator visuals in-game yet, that's the one piece the sim can't cover.

## Breaking changes
None. New DataFields are all additive with inert defaults (`PassiveEnergyDecay`, `ElectrocuteOnStrike`, coil bid fields); `TeslaCoilVisuals` gains a `Charged` member. Note the electrocution path fires for every `ShootRandomLightnings` source, including the electrical anomaly.

**Changelog**
:cl:
- tweak: The tesla ball now starves without a running particle accelerator, and sheds miniature ball lightning when fed hard. A loose tesla burns itself out in minutes.
- tweak: Tesla coils are now single-strike capacitors: lightning favors empty coils, charged coils arc visibly while discharging, and total output scales with how many towers you build.
- tweak: Tesla coils wear out under sustained load. Weld them on a service rotation or stock spares.
- tweak: Lightning strikes now electrocute crew and mobs. Wear insulated gloves around the engine.
- add: Bulk tesla coil crates (a dozen flatpacks) can be bought from the cargo console.
- tweak: Rewrote the Tesla Engine guidebook entry.
