### PR TITLE
Reverts #3552 as Discussed in Z-Pinch on Discord (AME Nerf Revert) and Adds a Hardcap of 20 to Core Count

### DIFF
--- a/Content.Server/Ame/AmeNodeGroup.cs
+++ b/Content.Server/Ame/AmeNodeGroup.cs
@@ -180,7 +180,7 @@ public sealed class AmeNodeGroup : BaseNodeGroup
         // return MathF.Max(200000f * MathF.Log10(2 * fuel * MathF.Pow(cores, (float)-0.5)), 0); // Frontier: preferring old calculation for now
         // return 200000f * MathF.Log10(fuel * fuel) * MathF.Pow(0.75f, cores - 1); // Frontier: preferring old calculation for now
         if (cores > 0 && fuel > 0) // Mono - default zero power unless conditions are met
-            return 200000f * MathF.Log10(fuel * fuel) * MathF.Pow( 1.11111f, cores - 1); // Triad - Reverted Mono nerfs to AME as datafarms are a non-issue here
+            return 200000f * MathF.Log10(fuel * fuel) * MathF.Pow(1.11111f, Math.Clamp(cores, 0, 20) - 1); // Triad - Reverted Mono nerfs to AMEs and adds a hard cap of 20 after which no additional power is yielded
         return 0;
     }
 

--- a/Content.Server/Ame/AmeNodeGroup.cs
+++ b/Content.Server/Ame/AmeNodeGroup.cs
@@ -180,7 +180,7 @@ public sealed class AmeNodeGroup : BaseNodeGroup
         // return MathF.Max(200000f * MathF.Log10(2 * fuel * MathF.Pow(cores, (float)-0.5)), 0); // Frontier: preferring old calculation for now
         // return 200000f * MathF.Log10(fuel * fuel) * MathF.Pow(0.75f, cores - 1); // Frontier: preferring old calculation for now
         if (cores > 0 && fuel > 0) // Mono - default zero power unless conditions are met
-            return 200000f * MathF.Log10(fuel * fuel) * MathF.Pow( 1.11111f, fuel / 2f - 1); // Mono - Exponential scaling at high injection
+            return 200000f * MathF.Log10(fuel * fuel) * MathF.Pow( 1.11111f, cores - 1); // Triad - Reverted Mono nerfs to AME as datafarms are a non-issue here
         return 0;
     }
 

--- a/Content.Server/Ame/AmeNodeGroup.cs
+++ b/Content.Server/Ame/AmeNodeGroup.cs
@@ -180,7 +180,7 @@ public sealed class AmeNodeGroup : BaseNodeGroup
         // return MathF.Max(200000f * MathF.Log10(2 * fuel * MathF.Pow(cores, (float)-0.5)), 0); // Frontier: preferring old calculation for now
         // return 200000f * MathF.Log10(fuel * fuel) * MathF.Pow(0.75f, cores - 1); // Frontier: preferring old calculation for now
         if (cores > 0 && fuel > 0) // Mono - default zero power unless conditions are met
-            return 200000f * MathF.Log10(fuel * fuel) * MathF.Pow(1.11111f, Math.Clamp(cores, 0, 20) - 1); // Triad - Reverted Mono nerfs to AMEs and adds a hard cap of 20 after which no additional power is yielded
+            return 200000f * MathF.Log10(fuel * fuel) * MathF.Pow( 1.11111f, Math.Clamp(cores, 0, 20) - 1); // Triad - Reverted Mono nerfs to AMEs and adds a hard cap of 20 after which no additional power is yielded
         return 0;
     }
 


### PR DESCRIPTION
## About the PR
AMEs are currently sad and people cant make huge datafarms here so infinite money cryptoexploits are a none-issue

## Why / Balance
Ddrakov asked for it. 

## Media
n/A

## Requirements
<!-- Confirm the following by placing an X in the brackets [X]: -->
- [X] I have read relevant guidelines/documentation to this PR found on [our devwiki](https://monolith-station.github.io/mono-docs/).
- [X] I have added media to this PR or it does not require an ingame showcase.
- [X] I can confirm this PR contains either no AI-generated content, or AI-generated content that meets our guidelines.
<!-- You should understand that not following the above may get your PR closed at maintainer’s discretion -->
<!-- When using AI, make sure you are already proficient in creating whatever content you are attempting to generate and that you already have experience contributing to SS14. This means using AI to enhance your preexisting workflow, not vibecoding. Yeah yeah we dont want the caseless case that can be wielded to shoot caseless rounds that drop a casing that you can wield to shoot caseless rounds. -->

## How to test
Boot up. AME with multiple cores. Its better now.

## Breaking changes
n/A

**Changelog**
<!-- Add a Changelog entry to make players aware of new features or changes that could affect gameplay.
Make sure to read the guidelines and take this Changelog template out of the comment block in order for it to show up.
Changelog must have a :cl: symbol, so the bot recognizes the changes and adds them to the game's changelog.
Remove this symbol for non-player facing PRs.-->
:cl:
- tweak: AME is now more efficient at multiple cores like it used to be. However a maximum power output of 20 cores is implemented to prevent antimatter tumors at Edison
- tweak: DDrakov Marr Pass retained (For now)