### PR TITLE
The Great Felinid Unbaldening (Add RGB Skintones)

### DIFF
--- a/Resources/Prototypes/Nyanotrasen/Species/felinid.yml
+++ b/Resources/Prototypes/Nyanotrasen/Species/felinid.yml
@@ -6,7 +6,7 @@
   sprites: MobHumanSprites
   markingLimits: MobFelinidMarkingLimits
   dollPrototype: MobFelinidDummy
-  skinColoration: HumanToned
+  skinColoration: Hues
 
 - type: markingPoints
   id: MobFelinidMarkingLimits


### PR DESCRIPTION
## About the PR
Gave felinids Hues skintone selection instead of their previous substantially restrictive HumanTones skintone selection.

## Why / Balance
Some people enjoy their felinids being covered in fur, pretty much only improves the experience for the people who want it and doesn't affect people that don't necessarily care.

## Media
<img width="1239" height="699" alt="image" src="https://github.com/user-attachments/assets/540e4fd5-f9d4-4c36-ac6e-6bab8e59a465" />

## Requirements
- [X] I have read relevant guidelines/documentation to this PR found on [our devwiki](https://monolith-station.github.io/mono-docs/).
- [X] I have added media to this PR or it does not require an ingame showcase.
- [X] I can confirm this PR contains either no AI-generated content, or AI-generated content that meets our guidelines.

## How to test
Load in, make a felinid or select your felinid character, the Skin Color section has a full RGB/HSV skintone selection.

## Breaking changes
<!-- List any breaking changes, including namespaces, public class/method/field changes, prototype renames; and provide instructions for fixing them. -->

**Changelog**
:cl:
- tweak: Felinid skintone selection changed from HumanTones to Hues (full RGB control)
