### PR TITLE
Desk Bell and Other Portable Atmos Device Persistence

### DIFF
--- a/Resources/Prototypes/Entities/Objects/Misc/desk_bell.yml
+++ b/Resources/Prototypes/Entities/Objects/Misc/desk_bell.yml
@@ -50,3 +50,4 @@
         Blunt: 4
   - type: StaticPrice # Frontier
     price: 10
+  - type: HLPersistOnShipSave # Triad

--- a/Resources/Prototypes/Entities/Structures/Piping/Atmospherics/portable.yml
+++ b/Resources/Prototypes/Entities/Structures/Piping/Atmospherics/portable.yml
@@ -98,6 +98,7 @@
   - type: GuideHelp
     guides:
     - PortableScrubber
+  - type: HLPersistOnShipSave # Triad
 
 - type: entity
   id: SpaceHeater
@@ -186,6 +187,7 @@
   - type: GuideHelp
     guides:
     - Thermomachines
+  - type: HLPersistOnShipSave # Triad
 
 - type: entity
   parent: SpaceHeater


### PR DESCRIPTION
## About the PR
This PR makes desk bells and portable scrubbers/space heaters save with ships
1. Desk bells go on desks and are fun flavor things
2. Portable scrubbers/space heaters are portable devices that can use power when anchored, and should just persist like other portable devices

## Media
<img width="691" height="530" alt="image" src="https://github.com/user-attachments/assets/24b03af1-bc47-4376-be82-9d6defd8e43b" />

## Requirements
<!-- Confirm the following by placing an X in the brackets [X]: -->
- [X] I have read relevant guidelines/documentation to this PR found on [our devwiki](https://monolith-station.github.io/mono-docs/).
- [X] I have added media to this PR or it does not require an ingame showcase.
- [X] I can confirm this PR contains either no AI-generated content, or AI-generated content that meets our guidelines.
<!-- You should understand that not following the above may get your PR closed at maintainer’s discretion -->
<!-- When using AI, make sure you are already proficient in creating whatever content you are attempting to generate and that you already have experience contributing to SS14. This means using AI to enhance your preexisting workflow, not vibecoding. -->

## How to test
1. Look at the things I changed
2. They persist

## Breaking changes
<!-- List any breaking changes, including namespaces, public class/method/field changes, prototype renames; and provide instructions for fixing them. -->

**Changelog**
:cl: Minerva
- tweak: Portable scrubbers and space heaters now persist through ship saves even when unanchored.
- tweak: Desk bells now persist through ship saves.