### PR TITLE
Feat(medical-Alert): Do Not Make Recurring Alert Inside Morgue

### DIFF
--- a/Content.Server/_Triad/Explosion/EntitySystems/TriggerSystem.Triad.cs
+++ b/Content.Server/_Triad/Explosion/EntitySystems/TriggerSystem.Triad.cs
@@ -1,6 +1,7 @@
 using Content.Shared.Implants.Components;
 using Content.Shared.Mobs;
 using Content.Shared.Mobs.Components;
+using Content.Shared.Morgue.Components;
 
 namespace Content.Server.Explosion.EntitySystems;
 
@@ -10,7 +11,7 @@ public sealed partial class TriggerSystem : EntitySystem
     {
         var query = EntityQueryEnumerator<ImplantedComponent, MobStateComponent>();
 
-        while (query.MoveNext(out var implantedComponent, out var mobState))
+        while (query.MoveNext(out var uid, out var implantedComponent, out var mobState))
         {
             foreach (var entityUid in implantedComponent.ImplantContainer.ContainedEntities)
             {
@@ -27,7 +28,14 @@ public sealed partial class TriggerSystem : EntitySystem
 
                 if (component.NextTrigger != TimeSpan.Zero && _timing.CurTime >= component.NextTrigger)
                 {
-                    Trigger(entityUid);
+                    if (!_container.TryGetContainingContainer(uid, out var container) || !HasComp<MorgueComponent>(container.Owner))
+                    {
+                        Trigger(entityUid);
+                    }
+                    else
+                    {
+                        component.NextTrigger = _timing.CurTime + component.RetriggerDelay;
+                    }
                 }
             }
         }

--- a/Content.Server/_Triad/Explosion/EntitySystems/TriggerSystem.Triad.cs
+++ b/Content.Server/_Triad/Explosion/EntitySystems/TriggerSystem.Triad.cs
@@ -11,11 +11,11 @@ public sealed partial class TriggerSystem : EntitySystem
     {
         var query = EntityQueryEnumerator<ImplantedComponent, MobStateComponent>();
 
-        while (query.MoveNext(out var uid, out var implantedComponent, out var mobState))
+        while (query.MoveNext(out var entityUid, out var implantedComponent, out var mobState))
         {
-            foreach (var entityUid in implantedComponent.ImplantContainer.ContainedEntities)
+            foreach (var containerUid in implantedComponent.ImplantContainer.ContainedEntities)
             {
-                if (!TryComp<RattleComponent>(entityUid, out var component))
+                if (!TryComp<RattleComponent>(containerUid, out var component))
                     continue;
 
                 // This is our reset state
@@ -28,9 +28,9 @@ public sealed partial class TriggerSystem : EntitySystem
 
                 if (component.NextTrigger != TimeSpan.Zero && _timing.CurTime >= component.NextTrigger)
                 {
-                    if (!_container.TryGetContainingContainer(uid, out var container) || !HasComp<MorgueComponent>(container.Owner))
+                    if (!_container.TryGetContainingContainer(entityUid, out var container) || !HasComp<MorgueComponent>(container.Owner))
                     {
-                        Trigger(entityUid);
+                        Trigger(containerUid);
                     }
                     else
                     {


### PR DESCRIPTION
## About the PR
Make it so the recurring medical alert only alert while not in a morgue

## Why / Balance
So there won't be an alert yelling at you for someone who is unrecoverable and acknowledged by putting inside a morgue

## Media

https://github.com/user-attachments/assets/9a42e286-ebd6-4252-98cc-e5cd6159746d



## Requirements
<!-- Confirm the following by placing an X in the brackets [X]: -->
- [x] I have read relevant guidelines/documentation to this PR found on [our devwiki](https://monolith-station.github.io/mono-docs/).
- [x] I have added media to this PR or it does not require an ingame showcase.
- [x] I can confirm this PR contains either no AI-generated content, or AI-generated content that meets our guidelines.
<!-- You should understand that not following the above may get your PR closed at maintainer’s discretion -->
<!-- When using AI, make sure you are already proficient in creating whatever content you are attempting to generate and that you already have experience contributing to SS14. This means using AI to enhance your preexisting workflow, not vibecoding. -->

**Changelog**
:cl:
- tweak: Changed the recurring medical alert to only alert while outside the morgue
