### PR TITLE
Radiation Damage Origin Fixes

### DIFF
--- a/Content.Server/Radiation/Systems/RadiationSystem.cs
+++ b/Content.Server/Radiation/Systems/RadiationSystem.cs
@@ -49,9 +49,9 @@ public sealed partial class RadiationSystem : EntitySystem
         _accumulator = 0f;
     }
 
-    public void IrradiateEntity(EntityUid uid, float radsPerSecond, float time) // Triad: no origin arg - our OnIrradiatedEvent predates wizden's origin field
+    public void IrradiateEntity(EntityUid uid, float radsPerSecond, float time, EntityUid? origin = null)
     {
-        var msg = new OnIrradiatedEvent(time, radsPerSecond);
+        var msg = new OnIrradiatedEvent(time, radsPerSecond, origin);
         RaiseLocalEvent(uid, msg);
     }
 

--- a/Content.Shared/Damage/Systems/DamageableSystem.cs
+++ b/Content.Shared/Damage/Systems/DamageableSystem.cs
@@ -168,7 +168,8 @@ namespace Content.Shared.Damage
         public enum DamageOriginFlag
         {
             Explosion, // flag set by ExplosionSystem.Processing
-            Barotrauma // flag set by BarotraumaSystem
+            Barotrauma, // flag set by BarotraumaSystem
+            Radiation // Triad, flag set by DamageableSystem.OnIrradiated
         }
 
         /// <summary>
@@ -392,18 +393,18 @@ namespace Content.Shared.Damage
             }
         }
 
-        private void OnIrradiated(EntityUid uid, DamageableComponent component, OnIrradiatedEvent args)
+        private void OnIrradiated(Entity<DamageableComponent> ent, ref OnIrradiatedEvent args)
         {
             var damageValue = FixedPoint2.New(args.TotalRads);
 
             // Radiation should really just be a damage group instead of a list of types.
             DamageSpecifier damage = new();
-            foreach (var typeId in component.RadiationDamageTypeIDs)
+            foreach (var typeId in ent.Comp.RadiationDamageTypeIDs)
             {
                 damage.DamageDict.Add(typeId, damageValue);
             }
 
-            TryChangeDamage(uid, damage, interruptsDoAfters: false);
+            TryChangeDamage(ent.Owner, damage, interruptsDoAfters: false, origin: args.Origin, originFlag: DamageOriginFlag.Radiation); // Triad - origin flag
         }
 
         private void OnRejuvenate(EntityUid uid, DamageableComponent component, RejuvenateEvent args)
@@ -460,7 +461,7 @@ namespace Content.Shared.Damage
         }
     }
 
-    
+
     /// <summary>
     ///     Raised before damage is done, so stuff can cancel it if necessary.
     /// </summary>

--- a/Content.Shared/Radiation/Events/OnIrradiatedEvent.cs
+++ b/Content.Shared/Radiation/Events/OnIrradiatedEvent.cs
@@ -4,11 +4,13 @@
 ///     Raised on entity when it was irradiated
 ///     by some radiation source.
 /// </summary>
-public readonly record struct OnIrradiatedEvent(float FrameTime, float RadsPerSecond)
+public readonly record struct OnIrradiatedEvent(float FrameTime, float RadsPerSecond, EntityUid? Origin)
 {
     public readonly float FrameTime = FrameTime;
 
     public readonly float RadsPerSecond = RadsPerSecond;
+
+    public readonly EntityUid? Origin = Origin;
 
     public float TotalRads => RadsPerSecond * FrameTime;
 }

--- a/Content.Shared/_Mono/ArmorPlate/SharedArmorPlateSystem.cs
+++ b/Content.Shared/_Mono/ArmorPlate/SharedArmorPlateSystem.cs
@@ -5,6 +5,7 @@ using Content.Shared.Examine;
 using Content.Shared.FixedPoint;
 using Content.Shared.Inventory;
 using Content.Shared.Inventory.Events;
+using Content.Shared.Mobs;
 using Content.Shared.Movement.Systems;
 using Content.Shared.Popups;
 using Content.Shared.Storage;
@@ -56,7 +57,9 @@ public sealed class SharedArmorPlateSystem : EntitySystem
         if (!_inventory.TryGetSlots(ent, out var slots))
             return;
 
-        if (args.Origin == null && args.OriginFlag != DamageableSystem.DamageOriginFlag.Explosion)
+        // Triad - conditional for radiation damage
+        if (args.Origin == null && args.OriginFlag is not DamageableSystem.DamageOriginFlag.Explosion
+                and not DamageableSystem.DamageOriginFlag.Radiation)
             return;
 
         foreach (var slot in slots)


### PR DESCRIPTION
## About the PR
Non-player facing change which adds a damage flag to irradiation damage. 

This is needed so armor plates can take rad damage and any other damage type without an origin, because radiation damage has no 'origin' in the damageable event

This PR ports some wizden changes to add a nullable origin to the irradiation event and ``DamageOriginFlag.Radiation``