### PR TITLE
Adds Maintenance Jacks to the Engineering Techfab(s)

### DIFF
--- a/Resources/Prototypes/_NF/Recipes/Lathes/Packs/Deprecated/engineering_techfab.yml
+++ b/Resources/Prototypes/_NF/Recipes/Lathes/Packs/Deprecated/engineering_techfab.yml
@@ -12,6 +12,7 @@
     - Wrench
     - CrowbarGreen
     - Multitool
+    - MaintenanceJack # Triad. Parity with ToolsStatic.
     - FlashlightLantern
     - AppraisalTool
     - HandLabeler


### PR DESCRIPTION
## About the PR
This PR adds maintenance jacks to the Engineering techfab, also indirectly adding it to the Edison techfab.

## Why / Balance
ToolsStatic has it. Why not Engineering techfabs?

## Media
<img width="782" height="598" alt="image" src="https://github.com/user-attachments/assets/773f743b-b775-4db5-a55a-74266717a164" />

## Requirements
<!-- Confirm the following by placing an X in the brackets [X]: -->
- [X] I have read relevant guidelines/documentation to this PR found on [our devwiki](https://monolith-station.github.io/mono-docs/).
- [X] I have added media to this PR or it does not require an ingame showcase.
- [X] I can confirm this PR contains either no AI-generated content, or AI-generated content that meets our guidelines.
<!-- You should understand that not following the above may get your PR closed at maintainer’s discretion -->
<!-- When using AI, make sure you are already proficient in creating whatever content you are attempting to generate and that you already have experience contributing to SS14. This means using AI to enhance your preexisting workflow, not vibecoding. -->

## How to test
1. Spawn in any of the Engineering techfabs
2. They have the maintenance jack

**Changelog**
:cl: Minerva
- tweak: The Engineering techfab(s) can now print maintenance jacks.
