### PR TITLE
Fix Supermatter Delamination Never Firing, Add Resonance Cascade

### DIFF
--- a/Content.Server/_EE/Systems/SupermatterSystem.Processing.cs
+++ b/Content.Server/_EE/Systems/SupermatterSystem.Processing.cs
@@ -46,12 +46,19 @@ using Content.Shared.DeviceLinking;
 using Robust.Shared.Timing;
 using System.ComponentModel;
 using Content.Server.GameTicking; // Coyote
+using Content.Server._Triad.Supermatter; // Triad
+using Robust.Shared.Prototypes; // Triad
 
 namespace Content.Server._EE.Supermatter.Systems;
 
 public sealed partial class SupermatterSystem
 {
-    [Dependency] private readonly GameTicker _gameTicker = default!; // Coyote
+    // Triad: removed — the only StartGameRule call went through SupermatterHallucinationRuleSystem
+    // instead, which needs to seed the target map between AddGameRule and StartGameRule.
+    // [Dependency] private readonly GameTicker _gameTicker = default!; // Coyote
+    // End Triad
+    [Dependency] private readonly SupermatterHallucinationRuleSystem _hallucinationRule = default!; // Triad
+    [Dependency] private readonly IPrototypeManager _prototype = default!; // Triad
     /// <summary>
     /// Handle power and radiation output depending on atmospheric things.
     /// </summary>
@@ -657,23 +664,32 @@ public sealed partial class SupermatterSystem
 
         var mix = _atmosphere.GetContainingMixture(uid, true, true);
 
-        if (mix is { })
-        {
-            // Triad: was mix.Remove(...) to measure the absorbed share, which permanently deleted
-            // 15% of the chamber gas per call; this runs every atmos tick while damage is past the
-            // delam point, so a 60s countdown vacuumed the chamber. Same value, no mutation.
-            var moles = mix.TotalMoles * sm.GasEfficiency;
+        // Triad: was mix.Remove(...) to measure the absorbed share, which permanently deleted
+        // 15% of the chamber gas per call; this runs every atmos tick while damage is past the
+        // delam point, so a 60s countdown vacuumed the chamber. Same value, no mutation.
+        var moles = mix is { } ? mix.TotalMoles * sm.GasEfficiency : 0f;
 
-            if (_config.GetCVar(ECCVars.SupermatterDoSingulooseDelam)
-                && moles >= _config.GetCVar(ECCVars.SupermatterMolePenaltyThreshold) * _config.GetCVar(ECCVars.SupermatterSingulooseMolesModifier))
-                return DelamType.Singulo;
-        }
+        var molePenalty = _config.GetCVar(ECCVars.SupermatterMolePenaltyThreshold);
+        var powerPenalty = _config.GetCVar(ECCVars.SupermatterPowerPenaltyThreshold);
+
+        // Triad: resonance cascade. This is the old "crazy conditions" TODO: the crystal is
+        // simultaneously over-pressured and over-powered, i.e. you managed to set up both a
+        // singuloose and a tesloose at once. Checked first because it outranks both.
+        var cascadeModifier = _config.GetCVar(ECCVars.SupermatterCascadeThresholdModifier);
+
+        if (_config.GetCVar(ECCVars.SupermatterDoCascadeDelam)
+            && moles >= molePenalty * cascadeModifier
+            && sm.Power >= powerPenalty * cascadeModifier)
+            return DelamType.Cascade;
+        // End Triad
+
+        if (_config.GetCVar(ECCVars.SupermatterDoSingulooseDelam)
+            && moles >= molePenalty * _config.GetCVar(ECCVars.SupermatterSingulooseMolesModifier))
+            return DelamType.Singulo;
 
         if (_config.GetCVar(ECCVars.SupermatterDoTeslooseDelam)
-            && sm.Power >= _config.GetCVar(ECCVars.SupermatterPowerPenaltyThreshold) * _config.GetCVar(ECCVars.SupermatterTesloosePowerModifier))
+            && sm.Power >= powerPenalty * _config.GetCVar(ECCVars.SupermatterTesloosePowerModifier))
             return DelamType.Tesla;
-
-        //TODO: Add resonance cascade when there's crazy conditions or a destabilizing crystal
 
         return DelamType.Explosion;
     }
@@ -734,38 +750,25 @@ public sealed partial class SupermatterSystem
         // Add hallucinations to every player on the map
         // TODO: change this from paracusia to actual hallucinations whenever those are real
         // Coyote: Removes checks, instead starts a hallucination gamerule, which theoretically ensures the comp is deleted once it's over.
-        _gameTicker.StartGameRule("CSSupermatterHallucination");
-        /*
-        var mobLookup = new HashSet<Entity<MobStateComponent>>();
-        _entityLookup.GetEntitiesOnMap<MobStateComponent>(mapId, mobLookup);
-
-        // These values match the paracusia disability, since we can't double up on paracusia
-        var paracusiaSounds = new SoundCollectionSpecifier("Paracusia");
-        var paracusiaMinTime = 0.1f;
-        var paracusiaMaxTime = 300f;
-        var paracusiaDistance = 7f;
-
-        foreach (var mob in mobLookup)
-        {
-            // Ignore silicons
-            if (HasComp<SiliconLawBoundComponent>(uid))
-                continue;
-
-            if (!EnsureComp<ParacusiaComponent>(mob, out var paracusia))
-            {
-                _paracusia.SetSounds(mob, paracusiaSounds, paracusia);
-                _paracusia.SetTime(mob, paracusiaMinTime, paracusiaMaxTime, paracusia);
-                _paracusia.SetDistance(mob, paracusiaDistance, paracusia);
-            }
-        }*/
+        // Triad: the rule id is data-driven and existence-checked. The Coyote code hardcoded
+        // "CSSupermatterHallucination", a prototype that was never ported into this fork, so
+        // StartGameRule threw here and the delamination payload below never ran at all.
+        // Also removed the ~20 line paracusia loop that used to sit here. It was already commented
+        // out upstream when Coyote swapped this to a game rule, so it was dead twice over; its
+        // behaviour now lives in SupermatterHallucinationRuleSystem, map-scoped and self-cleaning.
+        StartHallucinations(sm, mapId);
+        // End Triad
         // Coyote End.
 
         switch (sm.PreferredDelamType)
         {
+            // Triad: resonance cascade. The crystal collapses into a spreading crystalline growth
+            // instead of leaving a singularity or a tesla behind. Was an empty "one day..." stub.
             case DelamType.Cascade:
-                // one day...
-                // Spawn(sm.KudzuSpawnPrototype, xform.Coordinates);
+                Spawn(sm.KudzuSpawnPrototype, xform.Coordinates);
+                QueueDel(uid);
                 break;
+            // End Triad
 
             case DelamType.Singulo:
                 Spawn(sm.SingularitySpawnPrototype, Transform(uid).Coordinates);
@@ -782,6 +785,37 @@ public sealed partial class SupermatterSystem
             default:
                 _explosion.TriggerExplosive(uid);
                 break;
+        }
+    }
+
+    /// <summary>
+    /// Triad: starts the crystal's hallucination game rule, scoped to the map it delaminated on.
+    /// </summary>
+    /// <remarks>
+    /// This must not throw, ever. It runs immediately before the delamination payload, and the
+    /// payload only gets one shot at firing - <see cref="SupermatterComponent.Delaminated"/> is
+    /// already set by this point. Anything that escapes here silently disarms the crystal, which
+    /// is exactly what the missing "CSSupermatterHallucination" prototype did. Hallucinations are
+    /// flavor; the delamination is the point, so it wins any argument between the two.
+    /// </remarks>
+    private void StartHallucinations(SupermatterComponent sm, MapId mapId)
+    {
+        if (sm.HallucinationRulePrototype is not { } ruleId)
+            return;
+
+        if (!_prototype.HasIndex<EntityPrototype>(ruleId))
+        {
+            Log.Error($"Supermatter hallucination rule prototype '{ruleId}' does not exist; skipping hallucinations.");
+            return;
+        }
+
+        try
+        {
+            _hallucinationRule.StartOnMap(ruleId, mapId);
+        }
+        catch (Exception e)
+        {
+            Log.Error($"Failed to start supermatter hallucination rule '{ruleId}': {e}");
         }
     }
 

--- a/Content.Server/_Triad/Supermatter/SupermatterHallucinationRuleComponent.cs
+++ b/Content.Server/_Triad/Supermatter/SupermatterHallucinationRuleComponent.cs
@@ -1,0 +1,64 @@
+using Robust.Shared.Audio;
+using Robust.Shared.Map;
+
+namespace Content.Server._Triad.Supermatter;
+
+/// <summary>
+/// Gives every mob on one map paracusia for a fixed duration, then takes it back off them.
+/// Started by the supermatter crystal when it delaminates.
+/// </summary>
+/// <remarks>
+/// This is deliberately not a <c>StationEvent</c>. It is only ever started by the crystal, so it
+/// has no business sitting in the random event pool, and it needs a map to scope itself to, which
+/// the scheduler has no way to supply.
+/// </remarks>
+[RegisterComponent]
+public sealed partial class SupermatterHallucinationRuleComponent : Component
+{
+    /// <summary>
+    /// How long the hallucinations last before the rule ends and cleans up after itself.
+    /// </summary>
+    [DataField]
+    public TimeSpan Duration = TimeSpan.FromMinutes(5);
+
+    /// <summary>
+    /// Minimum time in seconds between paracusia incidents.
+    /// </summary>
+    [DataField]
+    public float MinTimeBetweenIncidents = 0.1f;
+
+    /// <summary>
+    /// Maximum time in seconds between paracusia incidents.
+    /// </summary>
+    [DataField]
+    public float MaxTimeBetweenIncidents = 300f;
+
+    /// <summary>
+    /// How far away a paracusia sound can be placed from the listener.
+    /// </summary>
+    [DataField]
+    public float MaxSoundDistance = 7f;
+
+    [DataField]
+    public SoundSpecifier Sounds = new SoundCollectionSpecifier("Paracusia");
+
+    /// <summary>
+    /// Only mobs on this map are affected. The starting code is expected to set this before the
+    /// rule starts; a null map affects every mob in the round, which is almost never wanted.
+    /// </summary>
+    [ViewVariables]
+    public MapId? TargetMap;
+
+    /// <summary>
+    /// When <see cref="Duration"/> runs out. Set on start.
+    /// </summary>
+    [ViewVariables]
+    public TimeSpan EndTime;
+
+    /// <summary>
+    /// Mobs this rule added paracusia to, and only those. Mobs that already had paracusia when the
+    /// rule started are excluded so ending the rule can't strip someone's paracusia trait.
+    /// </summary>
+    [ViewVariables]
+    public List<EntityUid> AffectedEntities = new();
+}

--- a/Content.Server/_Triad/Supermatter/SupermatterHallucinationRuleSystem.cs
+++ b/Content.Server/_Triad/Supermatter/SupermatterHallucinationRuleSystem.cs
@@ -1,0 +1,92 @@
+using Content.Server.GameTicking.Rules;
+using Content.Server.Traits.Assorted;
+using Content.Shared._EE.Supermatter.Components;
+using Content.Shared.GameTicking.Components;
+using Content.Shared.Humanoid;
+using Content.Shared.Mind.Components;
+using Content.Shared.Silicons.Laws.Components;
+using Content.Shared.Traits.Assorted;
+using Robust.Shared.Map;
+
+namespace Content.Server._Triad.Supermatter;
+
+/// <summary>
+/// Runs <see cref="SupermatterHallucinationRuleComponent"/>: paracusia for everyone on the
+/// crystal's map, cleaned up when the rule's duration expires.
+/// </summary>
+public sealed class SupermatterHallucinationRuleSystem : GameRuleSystem<SupermatterHallucinationRuleComponent>
+{
+    [Dependency] private readonly ParacusiaSystem _paracusia = default!;
+
+    /// <summary>
+    /// Starts the rule scoped to <paramref name="map"/>. Use this rather than
+    /// <c>GameTicker.StartGameRule</c> directly, since the map has to be seeded between the rule
+    /// entity being spawned and the rule starting.
+    /// </summary>
+    /// <returns>False if the prototype is missing or isn't a hallucination rule.</returns>
+    public bool StartOnMap(string ruleId, MapId map)
+    {
+        var ruleEntity = GameTicker.AddGameRule(ruleId);
+
+        if (!TryComp<SupermatterHallucinationRuleComponent>(ruleEntity, out var rule))
+        {
+            Log.Error($"Tried to start {ruleId} as a supermatter hallucination rule, but it has no {nameof(SupermatterHallucinationRuleComponent)}.");
+            Del(ruleEntity);
+            return false;
+        }
+
+        rule.TargetMap = map;
+        return GameTicker.StartGameRule(ruleEntity);
+    }
+
+    protected override void Started(EntityUid uid, SupermatterHallucinationRuleComponent component, GameRuleComponent gameRule, GameRuleStartedEvent args)
+    {
+        base.Started(uid, component, gameRule, args);
+
+        component.EndTime = Timing.CurTime + component.Duration;
+
+        var query = EntityQueryEnumerator<MindContainerComponent, HumanoidAppearanceComponent, TransformComponent>();
+        while (query.MoveNext(out var mob, out _, out _, out var xform))
+        {
+            if (component.TargetMap is { } map && xform.MapID != map)
+                continue;
+
+            // Silicons and anything explicitly immune don't hear the crystal
+            if (HasComp<SiliconLawBoundComponent>(mob) || HasComp<SupermatterHallucinationImmuneComponent>(mob))
+                continue;
+
+            // EnsureComp returns true when the mob already had paracusia. Skip those, so that
+            // ending the rule can't strip paracusia off someone who has it as a trait.
+            if (EnsureComp<ParacusiaComponent>(mob, out var paracusia))
+                continue;
+
+            _paracusia.SetSounds(mob, component.Sounds, paracusia);
+            _paracusia.SetTime(mob, component.MinTimeBetweenIncidents, component.MaxTimeBetweenIncidents, paracusia);
+            _paracusia.SetDistance(mob, component.MaxSoundDistance, paracusia);
+
+            component.AffectedEntities.Add(mob);
+        }
+    }
+
+    protected override void Ended(EntityUid uid, SupermatterHallucinationRuleComponent component, GameRuleComponent gameRule, GameRuleEndedEvent args)
+    {
+        base.Ended(uid, component, gameRule, args);
+
+        foreach (var mob in component.AffectedEntities)
+        {
+            RemComp<ParacusiaComponent>(mob);
+        }
+
+        component.AffectedEntities.Clear();
+    }
+
+    protected override void ActiveTick(EntityUid uid, SupermatterHallucinationRuleComponent component, GameRuleComponent gameRule, float frameTime)
+    {
+        base.ActiveTick(uid, component, gameRule, frameTime);
+
+        if (Timing.CurTime < component.EndTime)
+            return;
+
+        ForceEndSelf(uid, gameRule);
+    }
+}

--- a/Content.Shared/_EE/CCVars/ECCVars.Supermatter.cs
+++ b/Content.Shared/_EE/CCVars/ECCVars.Supermatter.cs
@@ -84,6 +84,24 @@ public sealed partial class ECCVars
     public static readonly CVarDef<float> SupermatterAmmoniaPowerGain =
         CVarDef.Create("supermatter.ammonia_power_gain", 10f, CVar.SERVER);
 
+    // Triad: resonance cascade delamination.
+    /// <summary>
+    ///     Toggles whether or not Cascade delaminations can occur. A cascade outranks both Singuloose and Tesloose,
+    ///     and needs the conditions for both to be met at once: the chamber is over the mole penalty threshold
+    ///     AND the core is over the power penalty threshold. Instead of a singularity or a tesla, the crystal
+    ///     collapses into a spreading crystalline growth.
+    /// </summary>
+    public static readonly CVarDef<bool> SupermatterDoCascadeDelam =
+        CVarDef.Create("supermatter.do_cascade", true, CVar.SERVER);
+
+    /// <summary>
+    ///     Multiplies both the mole and power thresholds for the purpose of determining if a delam is a Cascade.
+    ///     Above 1 makes cascades rarer than the singuloose/tesloose they would otherwise outrank.
+    /// </summary>
+    public static readonly CVarDef<float> SupermatterCascadeThresholdModifier =
+        CVarDef.Create("supermatter.cascade_threshold_modifier", 1.25f, CVar.SERVER);
+    // End Triad
+
     /// <summary>
     ///     When true, bypass the normal checks to determine delam type, and instead use the type chosen by supermatter.forced_delam_type
     /// </summary>

--- a/Content.Shared/_EE/Supermatter/Components/SupermatterComponent.cs
+++ b/Content.Shared/_EE/Supermatter/Components/SupermatterComponent.cs
@@ -66,9 +66,22 @@ public sealed partial class SupermatterComponent : Component
     [DataField]
     public EntProtoId TeslaSpawnPrototype = "TeslaEnergyBall";
 
-    // one day...
-    // [DataField]
-    // public EntProtoId KudzuSpawnPrototype = "SupermatterKudzu";
+    // Triad: cascade delamination is real now, see ChooseDelamType.
+    [DataField]
+    public EntProtoId KudzuSpawnPrototype = "SupermatterKudzu";
+
+    /// <summary>
+    /// Game rule started on delamination to give everyone on the crystal's map hallucinations.
+    /// Null skips it.
+    /// </summary>
+    /// <remarks>
+    /// Triad: this used to be a hardcoded "CSSupermatterHallucination" that was never ported
+    /// alongside the code referencing it, so starting it threw and ate the delamination payload
+    /// below it. Data-driven and existence-checked now.
+    /// </remarks>
+    [DataField]
+    public EntProtoId? HallucinationRulePrototype = "SupermatterHallucination";
+    // End Triad
 
     [DataField]
     public EntProtoId AnomalyBluespaceSpawnPrototype = "AnomalyBluespace";

--- a/Resources/Prototypes/_Triad/supermatter_delamination.yml
+++ b/Resources/Prototypes/_Triad/supermatter_delamination.yml
@@ -1,0 +1,84 @@
+# Delamination payloads for the supermatter crystal.
+# Started/spawned from Content.Server/_EE/Systems/SupermatterSystem.Processing.cs.
+
+# Everyone on the crystal's map hears things for a while after it goes.
+- type: entity
+  id: SupermatterHallucination
+  parent: BaseGameRule
+  components:
+  - type: SupermatterHallucinationRule
+    duration: 300
+    minTimeBetweenIncidents: 0.1
+    maxTimeBetweenIncidents: 300
+    maxSoundDistance: 7
+    sounds:
+      collection: Paracusia
+
+# Resonance cascade payload. Parented off BaseKudzu rather than Kudzu so it doesn't inherit the
+# edible/flammable/weedkiller surface - prototypes can add components but never remove them.
+# Keeps the Kudzu edge-spreader group on purpose: KudzuSystem.OnKudzuSpread asserts on it in debug.
+- type: entity
+  id: SupermatterKudzu
+  parent: BaseKudzu
+  name: crystalline growth
+  description: Jagged shards of resonating crystal, still spreading. It hums against your teeth.
+  placement:
+    mode: SnapgridCenter
+    snap:
+    - Wall
+  components:
+  - type: Sprite
+    sprite: Objects/Misc/kudzu.rsi
+    state: kudzu_11
+    drawdepth: Overdoors
+    color: "#ffe838"
+  - type: KudzuVisuals
+  - type: Clickable
+  - type: MeleeSound
+    soundGroups:
+      Brute:
+        path:
+          "/Audio/Weapons/slash.ogg"
+  - type: Fixtures
+    fixtures:
+      fix1:
+        hard: false
+        density: 7
+        shape:
+          !type:PhysShapeAabb
+          bounds: "-0.5,-0.5,0.5,0.5"
+        layer:
+        - MidImpassable
+  - type: Damageable
+    damageModifierSet: Metallic
+  - type: Destructible
+    thresholds:
+    - trigger:
+        !type:DamageTrigger
+        damage: 60
+      behaviors:
+      - !type:DoActsBehavior
+        acts: [ "Destruction" ]
+  - type: Kudzu
+    growthTickChance: 0.4
+    spreadChance: 0.5
+  - type: DamageContacts
+    damage:
+      types:
+        Piercing: 2
+        Radiation: 1
+  - type: RadiationSource
+    intensity: 0.4
+    slope: 0.8
+  - type: SpeedModifierContacts
+    walkSpeedModifier: 0.3
+    sprintSpeedModifier: 0.3
+    ignoreWhitelist:
+      components:
+      - IgnoreKudzu
+  - type: PointLight
+    enabled: true
+    radius: 2
+    energy: 1
+    color: "#ffe838"
+  - type: AtmosExposed


### PR DESCRIPTION
## About the PR

The supermatter has not been delaminating. It announces the countdown, then does nothing.
This fixes it and implements the resonance cascade that has been stubbed out since #339.

`HandleDelamination` calls `StartGameRule("CSSupermatterHallucination")`, a prototype that
came across with the code in #339 but was never ported alongside it. Unknown prototype, so
it throws, four lines above the switch that spawns the singularity, tesla or explosion.
`sm.Delaminated` is already set by then, so it throws once and the crystal sits inert for
the rest of the round. The rule id is now a `DataField` with an existence check.

## Why / Balance

Existing delam thresholds are untouched.

`SupermatterHallucination` replaces the missing prototype, scoped to the crystal's map
rather than the whole round. Not a `StationEvent`, since it should not be in the random
event pool and the scheduler cannot supply the map.

`DelamType.Cascade` needs the mole *and* power penalty thresholds tripped at once, both
scaled by `supermatter.cascade_threshold_modifier` (1.25) so it stays rarer than the two
it outranks. Crystal collapses into a spreading crystalline growth. Both behind cvars if
the numbers want tuning.

## Requirements

- [x] I have read relevant guidelines/documentation to this PR found on [our devwiki](https://monolith-station.github.io/mono-docs/).
- [x] I have added media to this PR or it does not require an ingame showcase.
- [x] I can confirm this PR contains either no AI-generated content, or AI-generated content that meets our guidelines.

## How to test

`supermatter.do_force_delam true` and `supermatter.forced_delam_type Cascade` (or
`Singulo` / `Tesla` / `Explosion`), then damage the crystal and wait out the 60s. Before
this PR all four do nothing.

## Breaking changes

None. Two new cvars, two new `DataField`s, all defaulted.

**Changelog**

:cl:
- fix: The supermatter crystal now actually delaminates. It has been announcing the countdown and then doing nothing.
- add: Supermatter delaminations cause hallucinations for everyone on the crystal's map.
- add: A supermatter that is both over-pressured and over-powered now suffers a resonance cascade, collapsing into a spreading crystalline growth.
