### PR TITLE
Radio Emotes + Possessive Emotes

### DIFF
--- a/Content.Server/Chat/Managers/ChatSanitizationManager.cs
+++ b/Content.Server/Chat/Managers/ChatSanitizationManager.cs
@@ -91,6 +91,7 @@ public sealed class ChatSanitizationManager : IChatSanitizationManager
         Entry("[':", "chatsan-tearfully-smiles"),
         Entry("('=", "chatsan-tearfully-smiles"),
         Entry("['=", "chatsan-tearfully-smiles"),
+        Entry("?", "chatsan-confused"), //DeltaV
     ];
 
     [Dependency] private readonly IConfigurationManager _configurationManager = default!;

--- a/Content.Server/Chat/Systems/ChatSystem.cs
+++ b/Content.Server/Chat/Systems/ChatSystem.cs
@@ -316,7 +316,7 @@ public sealed partial class ChatSystem : SharedChatSystem
                 var type = ProcessEmoteMessage(source, message, out var modMessage);
                 if (type == EmoteType.Audible || type == EmoteType.AudiblePossessive)
                 {
-                    if (checkRadioPrefix && TryProcessRadioMessage(source, modMessage, out var outputMessage, out var channel, capitalize: false))
+                    if (checkRadioPrefix && TryProccessRadioMessage(source, modMessage, out var outputMessage, out var channel, capitalize: false))
                         SendAudibleEntityEmote(source, outputMessage, range, nameOverride, channel, type, hideLog: hideLog, ignoreActionBlocker: ignoreActionBlocker);
                     else
                         SendAudibleEntityEmote(source, modMessage, range, nameOverride, null, type, hideLog: hideLog, ignoreActionBlocker: ignoreActionBlocker);
@@ -912,7 +912,7 @@ public sealed partial class ChatSystem : SharedChatSystem
             !TryEmoteChatInput(source, action))
             return;
 
-        SendInVoiceRange(ChatChannel.Emotes, action, wrappedMessage, source, range, author);
+        SendInVoiceRange(ChatChannel.Emotes, name, action, wrappedMessage, obfuscated: "", obfuscatedWrappedMessage: "", source, range, author);
 
         var ev = new EntityAudiblyEmotedEvent(source, action, channel, type);
         RaiseLocalEvent(source, ref ev, true);

--- a/Content.Server/Chat/Systems/ChatSystem.cs
+++ b/Content.Server/Chat/Systems/ChatSystem.cs
@@ -40,6 +40,7 @@ using Robust.Shared.Prototypes;
 using Robust.Shared.Random;
 using Robust.Shared.Replays;
 using Robust.Shared.Utility;
+using Content.Shared._DV.Chat; // DeltaV - chat enhancements
 
 namespace Content.Server.Chat.Systems;
 
@@ -248,7 +249,7 @@ public sealed partial class ChatSystem : SharedChatSystem
         // Was there an emote in the message? If so, send it.
         if (player != null && emoteStr != message && emoteStr != null)
         {
-            SendEntityEmote(source, emoteStr, range, nameOverride, ignoreActionBlocker);
+            SendEntityEmote(source, emoteStr, range, nameOverride, null, ignoreActionBlocker); // DeltaV - Had to change up for SendEntityEmote
         }
 
         // This can happen if the entire string is sanitized out.
@@ -311,9 +312,18 @@ public sealed partial class ChatSystem : SharedChatSystem
             case InGameICChatType.Whisper:
                 SendEntityWhisper(source, message, range, null, nameOverride, language, hideLog, ignoreActionBlocker);
                 break;
-            case InGameICChatType.Emote:
-                SendEntityEmote(source, message, range, nameOverride, hideLog, ignoreActionBlocker: ignoreActionBlocker);
-                break;
+            case InGameICChatType.Emote: // DeltaV - Emote now has different types of emotes.
+                var type = ProcessEmoteMessage(source, message, out var modMessage);
+                if (type == EmoteType.Audible || type == EmoteType.AudiblePossessive)
+                {
+                    if (checkRadioPrefix && TryProcessRadioMessage(source, modMessage, out var outputMessage, out var channel, capitalize: false))
+                        SendAudibleEntityEmote(source, outputMessage, range, nameOverride, channel, type, hideLog: hideLog, ignoreActionBlocker: ignoreActionBlocker);
+                    else
+                        SendAudibleEntityEmote(source, modMessage, range, nameOverride, null, type, hideLog: hideLog, ignoreActionBlocker: ignoreActionBlocker);
+                }
+                else
+                    SendEntityEmote(source, modMessage, range, nameOverride, type, hideLog, ignoreActionBlocker: ignoreActionBlocker);
+                break; // DeltaV - End
             // Floofstation section
             case InGameICChatType.Subtle:
                 SendEntitySubtle(source, message, range, nameOverride, hideLog: hideLog, ignoreActionBlocker);
@@ -819,6 +829,7 @@ public sealed partial class ChatSystem : SharedChatSystem
         string action,
         ChatTransmitRange range,
         string? nameOverride,
+        EmoteType? emoteType, // DeltaV
         bool hideLog = false,
         bool checkEmote = true,
         bool ignoreActionBlocker = false,
@@ -832,11 +843,21 @@ public sealed partial class ChatSystem : SharedChatSystem
         var ent = Identity.Entity(source, EntityManager);
         string name = FormattedMessage.EscapeText(nameOverride ?? Name(ent));
 
+        // Begin DeltaV
+        string wrappedMessage;
+
         // Emotes use Identity.Name, since it doesn't actually involve your voice at all.
-        var wrappedMessage = Loc.GetString("chat-manager-entity-me-wrap-message",
-            ("entityName", name),
-            ("entity", ent),
-            ("message", FormattedMessage.RemoveMarkupOrThrow(action)));
+        if (emoteType == EmoteType.Possessive) // DeltaV - Emote types now get checked.
+            wrappedMessage = Loc.GetString("chat-manager-entity-me-possessive-wrap-message",
+                ("entityName", name),
+                ("entity", ent),
+                ("message", FormattedMessage.RemoveMarkupOrThrow(action)));
+        else
+            wrappedMessage = Loc.GetString("chat-manager-entity-me-wrap-message",
+                ("entityName", name),
+                ("entity", ent),
+                ("message", FormattedMessage.RemoveMarkupOrThrow(action)));
+        // End DeltaV
 
         if (checkEmote &&
             !TryEmoteChatInput(source, action))
@@ -849,6 +870,59 @@ public sealed partial class ChatSystem : SharedChatSystem
             else
                 _adminLogger.Add(LogType.Chat, LogImpact.Low, $"Emote from {source}: {action}");
     }
+
+    // DeltaV - Added this to differentiate between emotes that can be heard over radio and those which can't.
+    protected override void SendAudibleEntityEmote(
+       EntityUid source,
+       string action,
+       ChatTransmitRange range,
+       string? nameOverride,
+       RadioChannelPrototype? channel,
+       EmoteType? emoteType,
+       bool hideLog = false,
+       bool checkEmote = true,
+       bool ignoreActionBlocker = false,
+       NetUserId? author = null
+       )
+    {
+        if (!_actionBlocker.CanSpeak(source) && !ignoreActionBlocker)
+            return;
+
+        EmoteType type = emoteType ?? EmoteType.Audible;
+
+        // get the entity's apparent name (if no override provided).
+        var ent = Identity.Entity(source, EntityManager);
+        string name = FormattedMessage.EscapeText(nameOverride ?? Name(ent));
+
+        string wrappedMessage;
+
+        // Audible emotes use Identity.Name, since that is the status quo. Emotes like scream doesn't currently reveal identities so this won't either. [This may be changed with feedback as you can audibly emote over radios]
+        if (emoteType == EmoteType.AudiblePossessive)
+            wrappedMessage = Loc.GetString("chat-manager-entity-me-audible-possessive-wrap-message",
+                ("entityName", name),
+                ("entity", ent),
+                ("message", FormattedMessage.RemoveMarkupOrThrow(action)));
+        else
+            wrappedMessage = Loc.GetString("chat-manager-entity-me-audible-wrap-message",
+                ("entityName", name),
+                ("entity", ent),
+                ("message", FormattedMessage.RemoveMarkupOrThrow(action)));
+
+        if (checkEmote &&
+            !TryEmoteChatInput(source, action))
+            return;
+
+        SendInVoiceRange(ChatChannel.Emotes, action, wrappedMessage, source, range, author);
+
+        var ev = new EntityAudiblyEmotedEvent(source, action, channel, type);
+        RaiseLocalEvent(source, ref ev, true);
+        if (!hideLog)
+            if (name != Name(source))
+                _adminLogger.Add(LogType.Chat, LogImpact.Low, $"Emote from {source} as {name}: {action}");
+            else
+                _adminLogger.Add(LogType.Chat, LogImpact.Low, $"Emote from {source}: {action}");
+    }
+    // DeltaV - End
 
     // ReSharper disable once InconsistentNaming
     private void SendLOOC(EntityUid source, ICommonSession player, string message, bool hideChat)

--- a/Content.Server/Radio/EntitySystems/HeadsetSystem.cs
+++ b/Content.Server/Radio/EntitySystems/HeadsetSystem.cs
@@ -62,13 +62,6 @@ public sealed class HeadsetSystem : SharedHeadsetSystem
             && TryComp(headset.Headset, out EncryptionKeyHolderComponent? keys)
             && keys.Channels.Contains(channel.ID))
         {
-            // if (!TryComp<HandsComponent>(uid, out var hands) || hands.Count < 1 ||
-            //     TryComp<CuffableComponent>(uid, out var cuffable) && _cuffable.IsCuffed((uid, cuffable)))
-            // {
-            //     _popup.PopupEntity(Loc.GetString("headset-cant-reach"), uid, uid, PopupType.SmallCaution);
-            //     return false;
-            // }
-
             return true;
         }
 

--- a/Content.Server/Radio/EntitySystems/HeadsetSystem.cs
+++ b/Content.Server/Radio/EntitySystems/HeadsetSystem.cs
@@ -68,7 +68,7 @@ public sealed class HeadsetSystem : SharedHeadsetSystem
         return false;
     }
 
-    private void OnAudibleEmote(EntityUid uid, WearingHeadsetComponent component, EntityAudiblyEmotedEvent args)
+    private void OnAudibleEmote(EntityUid uid, WearingHeadsetComponent component, ref EntityAudiblyEmotedEvent args)
     {
         if (CheckRadioCapable(uid, component, args.Channel))
         {

--- a/Content.Server/Radio/EntitySystems/HeadsetSystem.cs
+++ b/Content.Server/Radio/EntitySystems/HeadsetSystem.cs
@@ -62,12 +62,12 @@ public sealed class HeadsetSystem : SharedHeadsetSystem
             && TryComp(headset.Headset, out EncryptionKeyHolderComponent? keys)
             && keys.Channels.Contains(channel.ID))
         {
-            if (!TryComp<HandsComponent>(uid, out var hands) || hands.Count < 1 ||
-                TryComp<CuffableComponent>(uid, out var cuffable) && _cuffable.IsCuffed((uid, cuffable)))
-            {
-                _popup.PopupEntity(Loc.GetString("headset-cant-reach"), uid, uid, PopupType.SmallCaution);
-                return false;
-            }
+            // if (!TryComp<HandsComponent>(uid, out var hands) || hands.Count < 1 ||
+            //     TryComp<CuffableComponent>(uid, out var cuffable) && _cuffable.IsCuffed((uid, cuffable)))
+            // {
+            //     _popup.PopupEntity(Loc.GetString("headset-cant-reach"), uid, uid, PopupType.SmallCaution);
+            //     return false;
+            // }
 
             return true;
         }

--- a/Content.Server/Radio/EntitySystems/HeadsetSystem.cs
+++ b/Content.Server/Radio/EntitySystems/HeadsetSystem.cs
@@ -10,6 +10,7 @@ using Content.Shared.Chat;
 using Content.Shared.Radio.EntitySystems;
 using Robust.Shared.Network;
 using Robust.Shared.Player;
+using Content.Shared._DV.Chat;
 
 namespace Content.Server.Radio.EntitySystems;
 
@@ -27,6 +28,7 @@ public sealed class HeadsetSystem : SharedHeadsetSystem
         SubscribeLocalEvent<HeadsetComponent, EncryptionChannelsChangedEvent>(OnKeysChanged);
 
         SubscribeLocalEvent<WearingHeadsetComponent, EntitySpokeEvent>(OnSpeak);
+        SubscribeLocalEvent<WearingHeadsetComponent, EntityAudiblyEmotedEvent>(OnAudibleEmote); // DeltaV
 
         SubscribeLocalEvent<HeadsetComponent, EmpPulseEvent>(OnEmpPulse);
     }
@@ -51,13 +53,43 @@ public sealed class HeadsetSystem : SharedHeadsetSystem
             EnsureComp<ActiveRadioComponent>(uid).Channels = new(keyHolder.Channels);
     }
 
+    // DeltaV
+    // WARNING - Be very careful when modifying this method.
+    // The implementation right now has null forgiving operatiors in OnSpeak() and OnAudibleEmote() since this only returns true if channel is not null
+    private bool CheckRadioCapable(EntityUid uid, WearingHeadsetComponent headset, RadioChannelPrototype? channel)
+    {
+        if (channel != null
+            && TryComp(headset.Headset, out EncryptionKeyHolderComponent? keys)
+            && keys.Channels.Contains(channel.ID))
+        {
+            if (!TryComp<HandsComponent>(uid, out var hands) || hands.Count < 1 ||
+                TryComp<CuffableComponent>(uid, out var cuffable) && _cuffable.IsCuffed((uid, cuffable)))
+            {
+                _popup.PopupEntity(Loc.GetString("headset-cant-reach"), uid, uid, PopupType.SmallCaution);
+                return false;
+            }
+
+            return true;
+        }
+
+        return false;
+    }
+
+    private void OnAudibleEmote(EntityUid uid, WearingHeadsetComponent component, EntityAudiblyEmotedEvent args)
+    {
+        if (CheckRadioCapable(uid, component, args.Channel))
+        {
+            _radio.SendRadioMessage(uid, args.Message, args.Channel!, component.Headset, emType: args.Type);
+            args.Channel = null;
+        }
+    }
+    // DeltaV - End
+
     private void OnSpeak(EntityUid uid, WearingHeadsetComponent component, EntitySpokeEvent args)
     {
-        if (args.Channel != null
-            && TryComp(component.Headset, out EncryptionKeyHolderComponent? keys)
-            && keys.Channels.Contains(args.Channel.ID))
+        if (CheckRadioCapable(uid, component, args.Channel)) // DeltaV - Put all the radio checks into the CheckRadioCapable() method.
         {
-            _radio.SendRadioMessage(uid, args.Message, args.Channel, component.Headset);
+            _radio.SendRadioMessage(uid, args.Message, args.Channel!, component.Headset); // DeltaV - Made the args.Channel null ignorant as CheckRadioCapable() guarantees it not null.
             args.Channel = null; // prevent duplicate messages from other listeners.
         }
     }

--- a/Content.Server/Radio/EntitySystems/RadioDeviceSystem.cs
+++ b/Content.Server/Radio/EntitySystems/RadioDeviceSystem.cs
@@ -209,7 +209,7 @@ public sealed class RadioDeviceSystem : SharedRadioDeviceSystem
         // log to chat so people can identity the speaker/source, but avoid clogging ghost chat if there are many radios
         var message = args.OriginalChatMsg.Message; // The chat system will handle the rest and re-obfuscate if needed.
 
-        // Triad please dont speak emotes thanks
+        // Triad - Prevent speaking emotes
         if (args.emType == EmoteType.Audible || args.emType == EmoteType.AudiblePossessive)
             {_chat.TrySendInGameICMessage(uid, message, InGameICChatType.Emote, ChatTransmitRange.GhostRangeLimitNoAdminCheck,
             nameOverride: name, checkRadioPrefix: false, languageOverride: args.Language);

--- a/Content.Server/Radio/EntitySystems/RadioDeviceSystem.cs
+++ b/Content.Server/Radio/EntitySystems/RadioDeviceSystem.cs
@@ -210,10 +210,12 @@ public sealed class RadioDeviceSystem : SharedRadioDeviceSystem
         var message = args.OriginalChatMsg.Message; // The chat system will handle the rest and re-obfuscate if needed.
 
         // Triad - Prevent speaking emotes
-        if (args.emType == EmoteType.Audible || args.emType == EmoteType.AudiblePossessive)
-            {_chat.TrySendInGameICMessage(uid, message, InGameICChatType.Emote, ChatTransmitRange.GhostRangeLimitNoAdminCheck,
-            nameOverride: name, checkRadioPrefix: false, languageOverride: args.Language);
-            return;}
+        if (args.EmType == EmoteType.Audible || args.EmType == EmoteType.AudiblePossessive)
+            {
+                _chat.TrySendInGameICMessage(uid, message, InGameICChatType.Emote, ChatTransmitRange.GhostRangeLimitNoAdminCheck,
+                nameOverride: name, checkRadioPrefix: false, languageOverride: args.Language);
+                return;
+            }
 
         _chat.TrySendInGameICMessage(uid, message, component.OutputChatType, ChatTransmitRange.GhostRangeLimitNoAdminCheck,
             nameOverride: name, checkRadioPrefix: false, languageOverride: args.Language); // Einstein Engines - Languages  / Frontier: GhostRangeLimit<GhostRangeLimitNoAdminCheck, InGameICChatType.Whisper<component.OutputChatType

--- a/Content.Server/Radio/EntitySystems/RadioDeviceSystem.cs
+++ b/Content.Server/Radio/EntitySystems/RadioDeviceSystem.cs
@@ -13,6 +13,7 @@ using Content.Server._EinsteinEngines.Language;
 using Content.Shared.Power;
 using Content.Shared.Radio;
 using Content.Shared.Chat;
+using Content.Shared._DV.Chat; //Delta-V
 using Content.Shared.UserInterface; // Nuclear-14
 using Content.Shared._NC.Radio; // Nuclear-14
 using Robust.Server.GameObjects; // Nuclear-14
@@ -207,6 +208,13 @@ public sealed class RadioDeviceSystem : SharedRadioDeviceSystem
 
         // log to chat so people can identity the speaker/source, but avoid clogging ghost chat if there are many radios
         var message = args.OriginalChatMsg.Message; // The chat system will handle the rest and re-obfuscate if needed.
+
+        // Triad please dont speak emotes thanks
+        if (args.emType == EmoteType.Audible || args.emType == EmoteType.AudiblePossessive)
+            {_chat.TrySendInGameICMessage(uid, message, InGameICChatType.Emote, ChatTransmitRange.GhostRangeLimitNoAdminCheck,
+            nameOverride: name, checkRadioPrefix: false, languageOverride: args.Language);
+            return;}
+
         _chat.TrySendInGameICMessage(uid, message, component.OutputChatType, ChatTransmitRange.GhostRangeLimitNoAdminCheck,
             nameOverride: name, checkRadioPrefix: false, languageOverride: args.Language); // Einstein Engines - Languages  / Frontier: GhostRangeLimit<GhostRangeLimitNoAdminCheck, InGameICChatType.Whisper<component.OutputChatType
     }

--- a/Content.Server/Radio/EntitySystems/RadioSystem.cs
+++ b/Content.Server/Radio/EntitySystems/RadioSystem.cs
@@ -290,7 +290,7 @@ public sealed class RadioSystem : EntitySystem
             ? Loc.GetString("chat-manager-language-prefix", ("language", language.ChatName))
             : "";
 
-        // Triad Moved from SendRadioMessage
+        // Triad - Integrated from SendRadioMessage
         if (emType == EmoteType.Audible)
             return Loc.GetString("chat-radio-message-audible-emote-wrap",
                 ("color", channel.Color),
@@ -314,6 +314,7 @@ public sealed class RadioSystem : EntitySystem
                 ("name", name),
                 ("message", message),
                 ("language", languageDisplay));
+        // Traid - End
     }
     // Einstein Engines - Language end
 

--- a/Content.Server/Radio/EntitySystems/RadioSystem.cs
+++ b/Content.Server/Radio/EntitySystems/RadioSystem.cs
@@ -93,7 +93,7 @@ public sealed class RadioSystem : EntitySystem
     }
 
     // DeltaV
-    private void OnIntrinsicAudibleEmote(EntityUid uid, IntrinsicRadioTransmitterComponent component, EntityAudiblyEmotedEvent args)
+    private void OnIntrinsicAudibleEmote(EntityUid uid, IntrinsicRadioTransmitterComponent component, ref EntityAudiblyEmotedEvent args)
     {
         if (args.Channel != null && component.Channels.Contains(args.Channel.ID))
         {

--- a/Content.Server/Radio/EntitySystems/RadioSystem.cs
+++ b/Content.Server/Radio/EntitySystems/RadioSystem.cs
@@ -314,7 +314,7 @@ public sealed class RadioSystem : EntitySystem
                 ("name", name),
                 ("message", message),
                 ("language", languageDisplay));
-        // Traid - End
+        // Triad - End
     }
     // Einstein Engines - Language end
 

--- a/Content.Server/Radio/EntitySystems/RadioSystem.cs
+++ b/Content.Server/Radio/EntitySystems/RadioSystem.cs
@@ -4,6 +4,7 @@ using Content.Server.Chat.Systems;
 using Content.Server._EinsteinEngines.Language;
 using Content.Server.Power.Components;
 using Content.Shared._Mono.Radio;
+using Content.Shared._DV.Chat;
 using Content.Shared.Chat;
 using Content.Shared.Database;
 using Content.Shared._EinsteinEngines.Language;
@@ -45,6 +46,7 @@ public sealed class RadioSystem : EntitySystem
         base.Initialize();
         SubscribeLocalEvent<IntrinsicRadioReceiverComponent, RadioReceiveEvent>(OnIntrinsicReceive);
         SubscribeLocalEvent<IntrinsicRadioTransmitterComponent, EntitySpokeEvent>(OnIntrinsicSpeak);
+        SubscribeLocalEvent<IntrinsicRadioTransmitterComponent, EntityAudiblyEmotedEvent>(OnIntrinsicAudibleEmote); // DeltaV - Robots should be allowed to emote over radio.
 
         _exemptQuery = GetEntityQuery<TelecomExemptComponent>();
     }
@@ -90,6 +92,16 @@ public sealed class RadioSystem : EntitySystem
         }
     }
 
+    // DeltaV
+    private void OnIntrinsicAudibleEmote(EntityUid uid, IntrinsicRadioTransmitterComponent component, EntityAudiblyEmotedEvent args)
+    {
+        if (args.Channel != null && component.Channels.Contains(args.Channel.ID))
+        {
+            SendRadioMessage(uid, args.Message, args.Channel, uid, emType: args.Type);
+        }
+    }
+    // DeltaV - End
+
     /// <summary>
     /// Send radio message to all active radio listeners
     /// </summary>
@@ -100,9 +112,10 @@ public sealed class RadioSystem : EntitySystem
         EntityUid radioSource,
         int? frequency = null,
         LanguagePrototype? language = null,
-        bool escapeMarkup = true) // Frontier: added frequency
+        bool escapeMarkup = true,
+        EmoteType? emType = null) // Frontier: added frequency // DeltaV - EmoteType? added.
     {
-        SendRadioMessage(messageSource, message, _prototype.Index(channel), radioSource, frequency: frequency, escapeMarkup: escapeMarkup, language: language); // Frontier: added frequency / Einstein Engines - Language
+        SendRadioMessage(messageSource, message, _prototype.Index(channel), radioSource, frequency: frequency, escapeMarkup: escapeMarkup, language: language, emType: emType); // Frontier: added frequency / Einstein Engines - Language
     }
 
     /// <summary>
@@ -117,7 +130,8 @@ public sealed class RadioSystem : EntitySystem
         EntityUid radioSource,
         int? frequency = null,
         LanguagePrototype? language = null,
-        bool escapeMarkup = true) // Nuclear-14: add frequency
+        bool escapeMarkup = true,
+        EmoteType? emType = null) // DeltaV - EmoteType? added. // Nuclear-14: add frequency
     {
         // Einstein Engines - Language begin
         if (language == null)
@@ -170,7 +184,7 @@ public sealed class RadioSystem : EntitySystem
         //     ("channel", channelText), // Frontier: $"\\[{channel.LocalizedName}\\]"<channelText
         //     ("name", name),
         //     ("message", content));
-        var wrappedMessage = WrapRadioMessage(messageSource, channel, name, content, language); // Einstein Engines - Language
+        var wrappedMessage = WrapRadioMessage(messageSource, channel, name, content, language, emType); // Einstein Engines - Language
 
         // most radios are relayed to chat, so lets parse the chat message beforehand
         // var chat = new ChatMessage(
@@ -262,7 +276,8 @@ public sealed class RadioSystem : EntitySystem
         RadioChannelPrototype channel,
         string name,
         string message,
-        LanguagePrototype language)
+        LanguagePrototype language,
+        EmoteType emType)
     {
         // TODO: code duplication with ChatSystem.WrapMessage
         var speech = _chat.GetSpeechVerb(source, message);
@@ -275,16 +290,30 @@ public sealed class RadioSystem : EntitySystem
             ? Loc.GetString("chat-manager-language-prefix", ("language", language.ChatName))
             : "";
 
-        return Loc.GetString(speech.Bold ? "chat-radio-message-wrap-bold" : "chat-radio-message-wrap",
-            ("color", channel.Color),
-            ("languageColor", languageColor),
-            ("fontType", language.SpeechOverride.FontId ?? speech.FontId),
-            ("fontSize", language.SpeechOverride.FontSize ?? speech.FontSize),
-            ("verb", Loc.GetString(_random.Pick(speech.SpeechVerbStrings))),
-            ("channel", $"\\[{channel.LocalizedName}\\]"),
-            ("name", name),
-            ("message", message),
-            ("language", languageDisplay));
+        //Moved from SendRadioMessage
+        if (emType == EmoteType.Audible)
+            Loc.GetString("chat-radio-message-audible-emote-wrap",
+                ("color", channel.Color),
+                ("channel", $"\\[{channel.LocalizedName}\\]"),
+                ("name", name),
+                ("message", message));
+        else if (emType == EmoteType.AudiblePossessive)
+            Loc.GetString("chat-radio-message-audible-possessive-emote-wrap",
+                ("color", channel.Color),
+                ("channel", $"\\[{channel.LocalizedName}\\]"),
+                ("name", name),
+                ("message", message));
+        else
+            Loc.GetString(speech.Bold ? "chat-radio-message-wrap-bold" : "chat-radio-message-wrap",
+                ("color", channel.Color),
+                ("languageColor", languageColor),
+                ("fontType", language.SpeechOverride.FontId ?? speech.FontId),
+                ("fontSize", language.SpeechOverride.FontSize ?? speech.FontSize),
+                ("verb", Loc.GetString(_random.Pick(speech.SpeechVerbStrings))),
+                ("channel", $"\\[{channel.LocalizedName}\\]"),
+                ("name", name),
+                ("message", message),
+                ("language", languageDisplay));
     }
     // Einstein Engines - Language end
 

--- a/Content.Server/Radio/EntitySystems/RadioSystem.cs
+++ b/Content.Server/Radio/EntitySystems/RadioSystem.cs
@@ -202,7 +202,7 @@ public sealed class RadioSystem : EntitySystem
         var obfuscated = _language.ObfuscateSpeech(content, language);
         var obfuscatedWrapped = WrapRadioMessage(messageSource, channel, name, obfuscated, language, emType);
         var notUdsMsg = new ChatMessage(ChatChannel.Radio, obfuscated, obfuscatedWrapped, NetEntity.Invalid, null);
-        var ev = new RadioReceiveEvent(messageSource, channel, msg, notUdsMsg, language, radioSource);
+        var ev = new RadioReceiveEvent(messageSource, channel, msg, notUdsMsg, language, radioSource, emType);
         // Einstein Engines - Language end
 
         var sendAttemptEv = new RadioSendAttemptEvent(channel, radioSource);
@@ -290,7 +290,7 @@ public sealed class RadioSystem : EntitySystem
             ? Loc.GetString("chat-manager-language-prefix", ("language", language.ChatName))
             : "";
 
-        //Moved from SendRadioMessage
+        // Triad Moved from SendRadioMessage
         if (emType == EmoteType.Audible)
             return Loc.GetString("chat-radio-message-audible-emote-wrap",
                 ("color", channel.Color),

--- a/Content.Server/Radio/EntitySystems/RadioSystem.cs
+++ b/Content.Server/Radio/EntitySystems/RadioSystem.cs
@@ -200,7 +200,7 @@ public sealed class RadioSystem : EntitySystem
 
         // Einstein Engines - Language begin
         var obfuscated = _language.ObfuscateSpeech(content, language);
-        var obfuscatedWrapped = WrapRadioMessage(messageSource, channel, name, obfuscated, language);
+        var obfuscatedWrapped = WrapRadioMessage(messageSource, channel, name, obfuscated, language, emType);
         var notUdsMsg = new ChatMessage(ChatChannel.Radio, obfuscated, obfuscatedWrapped, NetEntity.Invalid, null);
         var ev = new RadioReceiveEvent(messageSource, channel, msg, notUdsMsg, language, radioSource);
         // Einstein Engines - Language end
@@ -277,7 +277,7 @@ public sealed class RadioSystem : EntitySystem
         string name,
         string message,
         LanguagePrototype language,
-        EmoteType emType)
+        EmoteType? emType)
     {
         // TODO: code duplication with ChatSystem.WrapMessage
         var speech = _chat.GetSpeechVerb(source, message);
@@ -292,19 +292,19 @@ public sealed class RadioSystem : EntitySystem
 
         //Moved from SendRadioMessage
         if (emType == EmoteType.Audible)
-            Loc.GetString("chat-radio-message-audible-emote-wrap",
+            return Loc.GetString("chat-radio-message-audible-emote-wrap",
                 ("color", channel.Color),
                 ("channel", $"\\[{channel.LocalizedName}\\]"),
                 ("name", name),
                 ("message", message));
         else if (emType == EmoteType.AudiblePossessive)
-            Loc.GetString("chat-radio-message-audible-possessive-emote-wrap",
+            return Loc.GetString("chat-radio-message-audible-possessive-emote-wrap",
                 ("color", channel.Color),
                 ("channel", $"\\[{channel.LocalizedName}\\]"),
                 ("name", name),
                 ("message", message));
         else
-            Loc.GetString(speech.Bold ? "chat-radio-message-wrap-bold" : "chat-radio-message-wrap",
+            return Loc.GetString(speech.Bold ? "chat-radio-message-wrap-bold" : "chat-radio-message-wrap",
                 ("color", channel.Color),
                 ("languageColor", languageColor),
                 ("fontType", language.SpeechOverride.FontId ?? speech.FontId),

--- a/Content.Server/Radio/RadioEvent.cs
+++ b/Content.Server/Radio/RadioEvent.cs
@@ -18,7 +18,7 @@ public readonly record struct RadioReceiveEvent(
     ChatMessage LanguageObfuscatedChatMsg,
     LanguagePrototype Language,
     EntityUid RadioSource,
-    EmoteType? emType //Triad
+    EmoteType? EmType //Triad
 );
 // Einstein Engines - Language end
 

--- a/Content.Server/Radio/RadioEvent.cs
+++ b/Content.Server/Radio/RadioEvent.cs
@@ -1,4 +1,5 @@
 using Content.Shared.Chat;
+using Content.Shared._DV.Chat; //Triad
 using Content.Shared._EinsteinEngines.Language;
 using Content.Shared.Radio;
 
@@ -16,7 +17,8 @@ public readonly record struct RadioReceiveEvent(
     ChatMessage OriginalChatMsg,
     ChatMessage LanguageObfuscatedChatMsg,
     LanguagePrototype Language,
-    EntityUid RadioSource
+    EntityUid RadioSource,
+    EmoteType? emType //Triad
 );
 // Einstein Engines - Language end
 

--- a/Content.Shared/Chat/SharedChatSystem.Emote.cs
+++ b/Content.Shared/Chat/SharedChatSystem.Emote.cs
@@ -233,7 +233,10 @@ public abstract partial class SharedChatSystem
 
         if (emoteType == AudibleEmotePrefix)
         {
-            emoteType = input[1]; // Check for if we want AudiblePossessiveEmote
+            if (input.Length > 1) // Check for if we want AudiblePossessiveEmote
+            {
+                emoteType = input[1];
+            }
             type = EmoteType.Audible;
         }
 

--- a/Content.Shared/Chat/SharedChatSystem.Emote.cs
+++ b/Content.Shared/Chat/SharedChatSystem.Emote.cs
@@ -1,4 +1,6 @@
 using System.Collections.Frozen;
+using System.Collections.Immutable;
+using Content.Shared._DV.Chat; // DeltaV - chat
 using Content.Shared.Chat.Prototypes;
 using Content.Shared.Speech;
 using Robust.Shared.Audio;
@@ -97,7 +99,7 @@ public abstract partial class SharedChatSystem
         {
             // not all emotes are loc'd, but for the ones that are we pass in entity
             var action = Loc.GetString(_random.Pick(emote.ChatMessages), ("entity", source));
-            SendEntityEmote(source, action, range, nameOverride, hideLog: hideLog, checkEmote: false, ignoreActionBlocker: ignoreActionBlocker);
+            SendEntityEmote(source, action, range, nameOverride, null, hideLog: hideLog, checkEmote: false, ignoreActionBlocker: ignoreActionBlocker); // DeltaV
         }
 
         return didEmote;
@@ -207,6 +209,48 @@ public abstract partial class SharedChatSystem
 
         return true;
     }
+
+    // DeltaV
+    /// <summary>
+    /// Checks which type of emote the message contains and returns the type while outputting the string without the prefixes.
+    /// </summary>
+    public static EmoteType? ProcessEmoteMessage(EntityUid source, string input, out string output)
+    {
+        output = input.Trim();
+        EmoteType? type = null;
+
+        if (input.Length == 0)
+            return type;
+
+        if (!(input.StartsWith(AudibleEmotePrefix) || input.StartsWith(PossessiveEmotePrefix)))
+        {
+            type = EmoteType.Normal;
+            return type;
+        }
+
+        var emoteType = input[0];
+        output = input[1..].TrimStart();
+
+        if (emoteType == AudibleEmotePrefix)
+        {
+            emoteType = input[1]; // Check for if we want AudiblePossessiveEmote
+            type = EmoteType.Audible;
+        }
+
+        if (emoteType == PossessiveEmotePrefix)
+        {
+            if (type == EmoteType.Audible)
+            {
+                type = EmoteType.AudiblePossessive;
+                output = input[2..].TrimStart();
+            }
+            else
+                type = EmoteType.Possessive;
+        }
+
+        return type;
+    }
+    // DeltaV - End
 
     /// <summary>
     /// Creates and raises <see cref="BeforeEmoteEvent"/> and then <see cref="EmoteEvent"/> to let other systems do things like play audio.

--- a/Content.Shared/Chat/SharedChatSystem.cs
+++ b/Content.Shared/Chat/SharedChatSystem.cs
@@ -1,6 +1,7 @@
 using System.Collections.Frozen;
 using Content.Shared._Starlight.CollectiveMind; // Goobstation - Starlight collective mind port
 using System.Text.RegularExpressions;
+using Content.Shared._DV.Chat;
 using Content.Shared.ActionBlocker;
 using Content.Shared.Chat.Prototypes;
 using Content.Shared.Popups;
@@ -26,6 +27,8 @@ public abstract partial class SharedChatSystem : EntitySystem
     public const char OOCPrefix = '[';
     public const char EmotesPrefix = '@';
     public const char EmotesAltPrefix = '*';
+    public const char AudibleEmotePrefix = '!'; // DeltaV - You may now scream audibly!
+    public const char PossessiveEmotePrefix = '\''; // DeltaV - You may now be possessive of things! Whatever that means.
     public const char AdminPrefix = ']';
     public const char WhisperPrefix = ',';
     public const char CollectiveMindPrefix = '+';
@@ -161,6 +164,7 @@ public abstract partial class SharedChatSystem : EntitySystem
         string input,
         out string output,
         out RadioChannelPrototype? channel,
+        bool capitalize = true, // DeltaV - We might not want to capitalize the first letter if we send in emotes.
         bool quiet = false)
     {
         output = input.Trim();
@@ -171,7 +175,7 @@ public abstract partial class SharedChatSystem : EntitySystem
 
         if (input.StartsWith(RadioCommonPrefix))
         {
-            output = SanitizeMessageCapital(input[1..].TrimStart());
+            output = capitalize ? SanitizeMessageCapital(input[1..].TrimStart()) : input[1..].TrimStart(); // DeltaV
             channel = _prototypeManager.Index<RadioChannelPrototype>(CommonChannel);
             return true;
         }
@@ -181,7 +185,7 @@ public abstract partial class SharedChatSystem : EntitySystem
 
         if (input.Length < 2 || char.IsWhiteSpace(input[1]))
         {
-            output = SanitizeMessageCapital(input[1..].TrimStart());
+            output = capitalize ? SanitizeMessageCapital(input[1..].TrimStart()) : input[1..].TrimStart(); // DeltaV
             if (!quiet)
                 _popup.PopupEntity(Loc.GetString("chat-manager-no-radio-key"), source, source);
             return true;
@@ -189,7 +193,7 @@ public abstract partial class SharedChatSystem : EntitySystem
 
         var channelKey = input[1];
         channelKey = char.ToLower(channelKey);
-        output = SanitizeMessageCapital(input[2..].TrimStart());
+        output = capitalize ? SanitizeMessageCapital(input[2..].TrimStart()) : input[2..].TrimStart(); // DeltaV
 
         if (channelKey == DefaultChannelKey)
         {
@@ -376,11 +380,29 @@ public abstract partial class SharedChatSystem : EntitySystem
         return rawmsg.Substring(tagStart, tagEnd - tagStart);
     }
 
+    // DeltaV
+    protected virtual void SendAudibleEntityEmote(
+        EntityUid source,
+        string action,
+        ChatTransmitRange range,
+        string? nameOverride,
+        RadioChannelPrototype? channel,
+        EmoteType? emoteType,
+        bool hideLog = false,
+        bool checkEmote = true,
+        bool ignoreActionBlocker = false,
+        NetUserId? author = null
+    )
+    {
+    }
+    // DeltaV - End
+
     protected virtual void SendEntityEmote(
         EntityUid source,
         string action,
         ChatTransmitRange range,
         string? nameOverride,
+        EmoteType? emoteType,
         bool hideLog = false,
         bool checkEmote = true,
         bool ignoreActionBlocker = false,

--- a/Content.Shared/_DV/Chat/SharedChatEvents.cs
+++ b/Content.Shared/_DV/Chat/SharedChatEvents.cs
@@ -1,0 +1,6 @@
+using Content.Shared.Radio;
+
+namespace Content.Shared._DV.Chat;
+
+[ByRefEvent]
+public record struct EntityAudiblyEmotedEvent(EntityUid Source, string Message, RadioChannelPrototype? Channel, EmoteType? Type);

--- a/Content.Shared/_DV/Chat/SharedChatSystemEnums.cs
+++ b/Content.Shared/_DV/Chat/SharedChatSystemEnums.cs
@@ -1,0 +1,15 @@
+namespace Content.Shared._DV.Chat;
+
+
+// Note for future: If you want to make this more robust to handle more types of emotes while still being able to check off audible as an option for it then it would
+// probably be better to make it a struct and have audible be a flag for it and then the type of emote. This would avoid having to make two different types for audible and visual.
+/// <summary>
+/// Different ways of emoting. For that little extra in RP!
+/// </summary>
+public enum EmoteType : byte
+{
+    Normal, // Character emotes
+    Audible, // Character screams
+    Possessive, // Character's emote
+    AudiblePossessive // Character's scream
+}

--- a/Resources/Locale/en-US/_DV/headset/headset-component.ftl
+++ b/Resources/Locale/en-US/_DV/headset/headset-component.ftl
@@ -1,9 +1,2 @@
 chat-radio-message-audible-emote-wrap = [color={$color}]{$channel} {$name} {$message}[/color]
 chat-radio-message-audible-possessive-emote-wrap = [color={$color}]{$channel} {$name}'s {$message}[/color]
-
-chat-radio-justice = Justice
-chat-radio-prison = Prison
-chat-radio-admeme-1 = Channel 1
-chat-radio-admeme-2 = Channel 2
-chat-radio-admeme-3 = Channel 3
-chat-radio-rootsong = Rootsong

--- a/Resources/Locale/en-US/_DV/headset/headset-component.ftl
+++ b/Resources/Locale/en-US/_DV/headset/headset-component.ftl
@@ -1,0 +1,9 @@
+chat-radio-message-audible-emote-wrap = [color={$color}]{$channel} {$name} {$message}[/color]
+chat-radio-message-audible-possessive-emote-wrap = [color={$color}]{$channel} {$name}'s {$message}[/color]
+
+chat-radio-justice = Justice
+chat-radio-prison = Prison
+chat-radio-admeme-1 = Channel 1
+chat-radio-admeme-2 = Channel 2
+chat-radio-admeme-3 = Channel 3
+chat-radio-rootsong = Rootsong

--- a/Resources/Locale/en-US/_NF/chat/managers/chat_manager.ftl
+++ b/Resources/Locale/en-US/_NF/chat/managers/chat_manager.ftl
@@ -41,3 +41,17 @@ chat-speech-verb-feroxi-1 = blubs
 chat-speech-verb-feroxi-2 = swishes
 chat-speech-verb-feroxi-3 = gnashes
 chat-speech-verb-feroxi-4 = growls
+
+chat-manager-entity-me-possessive-wrap-message = [italic]{ PROPER($entity) ->
+    *[false] The {$entityName}'s {$message}[/italic]
+     [true] {CAPITALIZE($entityName)}'s {$message}[/italic]
+    }
+
+chat-manager-entity-me-audible-wrap-message = [italic]{ PROPER($entity) ->
+    *[false] The {$entityName} {$message}[/italic]
+     [true] {CAPITALIZE($entityName)} {$message}[/italic]
+    }
+chat-manager-entity-me-audible-possessive-wrap-message = [italic]{ PROPER($entity) ->
+    *[false] The {$entityName}'s {$message}[/italic]
+     [true] {CAPITALIZE($entityName)}'s {$message}[/italic]
+    }


### PR DESCRIPTION
## About the PR
<!-- What did you change? -->
<!-- If this is a code change, summarize at high level how your new code works. This makes it easier to review. -->
Cherypicked the ability to send emotes over radio, as well as emoting possessively without being spaced weird, from Delta-V
This also adds "?" as shorthand for "looks confused"

## Why / Balance
<!-- Discuss how this would affect game balance or explain why it was changed. Link any relevant discussions or issues. -->
Must miao on radio,,,

## Media
<!-- Attach media if the PR makes ingame changes (clothing, items, features, etc). 
Small fixes/refactors are exempt. Media may be used in SS14 progress reports with credit. -->
Image from original.
<img width="368" height="185" alt="image" src="https://github.com/user-attachments/assets/5ac9d687-8ef2-4bea-a647-9b52ca20d72a" />
Demonstration video from original.
https://github.com/user-attachments/assets/e070d97f-12c3-4042-8a36-f6bab7d00199


## Requirements
<!-- Confirm the following by placing an X in the brackets [X]: -->
- [X] I have read relevant guidelines/documentation to this PR found on [our devwiki](https://monolith-station.github.io/mono-docs/).
- [X] I have added media to this PR or it does not require an ingame showcase.
- [X] I can confirm this PR contains either no AI-generated content, or AI-generated content that meets our guidelines.
<!-- You should understand that not following the above may get your PR closed at maintainer’s discretion -->
<!-- When using AI, make sure you are already proficient in creating whatever content you are attempting to generate and that you already have experience contributing to SS14. This means using AI to enhance your preexisting workflow, not vibecoding. -->

## How to test
<!-- Describe the way it can be tested -->
Emote over radio using @![radio prefix] ex, @!; or @!:d
Emote possessively using @'    ("s" not needed, or else youll look a fool)

## Breaking changes
<!-- List any breaking changes, including namespaces, public class/method/field changes, prototype renames; and provide instructions for fixing them. -->
I have touched the forbidden chat code..

**Changelog**
<!-- Add a Changelog entry to make players aware of new features or changes that could affect gameplay.
Make sure to read the guidelines and take this Changelog template out of the comment block in order for it to show up.
Changelog must have a :cl: symbol, so the bot recognizes the changes and adds them to the game's changelog.
Remove this symbol for non-player facing PRs.-->
:cl:
- add: ability to emote over radio using @![radio channel]
- add: ability to emote possessively using @'
- add: "?" shorthand emote for "looks confused"