### PR TITLE
Resomi Temperature Hotfix

### DIFF
--- a/Resources/Prototypes/_Moffstation/Entities/Mobs/Species/resomi.yml
+++ b/Resources/Prototypes/_Moffstation/Entities/Mobs/Species/resomi.yml
@@ -50,7 +50,7 @@
     prototype: Resomi
     requiredLegs: 2
   # Monolith - Start - MEAT
-  - type: Butcherable 
+  - type: Butcherable
     butcheringType: Spike
     spawned:
     - id: FoodMeatResomi
@@ -84,12 +84,21 @@
   - type: Temperature
     coldDamageThreshold: 195.4 # Freezing point of ammonia is -77.75°C
     heatDamageThreshold: 320.15 # Space chickens can't tolerate reasonable temperatures, but requiring them to stay icy would be cringe, so instead make their heat damage threshold dangerously close to standard atmos, at 47°C
+    currentTemperature: 285 # Triad - lowered base body temp as a quick fix to prevent chickens cooking themselves
     coldDamage:
       types:
         Cold : 0.05 #per second, scales with temperature & other constants
     heatDamage:
       types:
         Heat : 3 #per second, scales with temperature & other constants
+  - type: ThermalRegulator
+    metabolismHeat: 800
+    radiatedHeat: 100
+    implicitHeatRegulation: 500
+    sweatHeatRegulation: 2000
+    shiveringHeatRegulation: 2000
+    normalBodyTemperature: 285 # Triad - lowered base body temp as a quick fix to prevent chickens cooking themselves
+    thermalRegulationTemperatureThreshold: 20
   - type: TemperatureSpeed # You're supposed to be used to the cold why are you so slow
     thresholds: # Calculated based on UI alert thresholds, rounded up
       272: 0.8


### PR DESCRIPTION
## About the PR
<!-- What did you change? -->
<!-- If this is a code change, summarize at high level how your new code works. This makes it easier to review. -->
Lowers the Resomi's body temperature to 285k(12c) so that they do not incur the "too hot" speed penalty for existing.

## Why / Balance
<!-- Discuss how this would affect game balance or explain why it was changed. Link any relevant discussions or issues. -->
Resomi was adjusted to become slower at or above 30c, but Resomi uses the default body temperature heat of 36c. This made them always at the highest slow down due to being "too hot".

## Requirements
<!-- Confirm the following by placing an X in the brackets [X]: -->
- [x] I have read relevant guidelines/documentation to this PR found on [our devwiki](https://monolith-station.github.io/mono-docs/).
- [x] I have added media to this PR or it does not require an ingame showcase.
- [x] I can confirm this PR contains either no AI-generated content, or AI-generated content that meets our guidelines.
<!-- You should understand that not following the above may get your PR closed at maintainer’s discretion -->
<!-- When using AI, make sure you are already proficient in creating whatever content you are attempting to generate and that you already have experience contributing to SS14. This means using AI to enhance your preexisting workflow, not vibecoding. -->

## How to test
<!-- Describe the way it can be tested -->
Spawn as space chikem

## Breaking changes
<!-- List any breaking changes, including namespaces, public class/method/field changes, prototype renames; and provide instructions for fixing them. -->
God I hope not

**Changelog**
<!-- Add a Changelog entry to make players aware of new features or changes that could affect gameplay.
Make sure to read the guidelines and take this Changelog template out of the comment block in order for it to show up.
Changelog must have a :cl: symbol, so the bot recognizes the changes and adds them to the game's changelog.
Remove this symbol for non-player facing PRs.-->
:cl:
- tweak: Resomi base temp is now 285k

