### PR TITLE
Temperature Slowdown Fixes

### DIFF
--- a/Content.Shared/Temperature/Components/TemperatureSpeedComponent.cs
+++ b/Content.Shared/Temperature/Components/TemperatureSpeedComponent.cs
@@ -13,7 +13,7 @@ public sealed partial class TemperatureSpeedComponent : Component
     /// Sets the baseline temperature to compare with thresholds to know when to stop applying a slowdown
     /// </summary>
     [DataField]
-    public float? baseTemperature;
+    public float? BaseTemperature;
 
     /// <summary>
     /// Pairs of temperature thresholds to applied slowdown values.

--- a/Content.Shared/Temperature/Components/TemperatureSpeedComponent.cs
+++ b/Content.Shared/Temperature/Components/TemperatureSpeedComponent.cs
@@ -11,6 +11,7 @@ public sealed partial class TemperatureSpeedComponent : Component
 {
     /// <summary> Triad
     /// Sets the baseline temperature to compare with thresholds to know when to stop applying a slowdown
+    /// TODO: Remove this once base temp is not server only
     /// </summary>
     [DataField]
     public float? BaseTemperature;

--- a/Content.Shared/Temperature/Components/TemperatureSpeedComponent.cs
+++ b/Content.Shared/Temperature/Components/TemperatureSpeedComponent.cs
@@ -9,6 +9,12 @@ namespace Content.Shared.Temperature.Components;
 [RegisterComponent, NetworkedComponent, Access(typeof(SharedTemperatureSystem)), AutoGenerateComponentState, AutoGenerateComponentPause]
 public sealed partial class TemperatureSpeedComponent : Component
 {
+    /// <summary> Triad
+    /// Sets the baseline temperature to compare with thresholds to know when to stop applying a slowdown
+    /// </summary>
+    [DataField]
+    public float? baseTemperature;
+
     /// <summary>
     /// Pairs of temperature thresholds to applied slowdown values.
     /// </summary>

--- a/Content.Shared/Temperature/Systems/SharedTemperatureSystem.cs
+++ b/Content.Shared/Temperature/Systems/SharedTemperatureSystem.cs
@@ -41,7 +41,12 @@ public sealed class SharedTemperatureSystem : EntitySystem
                 break;
             }
         }
+
         // Triad - Adjusted to allow too hot speed modifiers.
+
+        //var maxThreshold = ent.Comp.Thresholds.Max(p => p.Key);
+        //if (args.CurrentTemperature > maxThreshold && args.LastTemperature < maxThreshold)
+
         float maxColdThreshold = 0;
         float minHotThreshold = 0;
         foreach (var (threshold, modifier) in ent.Comp.Thresholds) // Find the thresholds that are closest to the normal body temperature se we can detect when to stop applying slowdowns
@@ -62,13 +67,14 @@ public sealed class SharedTemperatureSystem : EntitySystem
             ent.Comp.CurrentSpeedModifier = null;
             Dirty(ent);
         }
+        // Triad - End
         if (args.CurrentTemperature < minHotThreshold && args.LastTemperature > minHotThreshold) // We cooled down beyond the lowest heat threshold
         {
             ent.Comp.NextSlowdownUpdate = _timing.CurTime + SlowdownApplicationDelay;
             ent.Comp.CurrentSpeedModifier = null;
             Dirty(ent);
         }
-        // Triad - End
+
     }
 
     private void OnRefreshMovementSpeedModifiers(Entity<TemperatureSpeedComponent> ent, ref RefreshMovementSpeedModifiersEvent args)

--- a/Content.Shared/Temperature/Systems/SharedTemperatureSystem.cs
+++ b/Content.Shared/Temperature/Systems/SharedTemperatureSystem.cs
@@ -46,7 +46,7 @@ public sealed class SharedTemperatureSystem : EntitySystem
         float minHotThreshold = 0;
         foreach (var (threshold, modifier) in ent.Comp.Thresholds) // Find the thresholds that are closest to the normal body temperature se we can detect when to stop applying slowdowns
         {
-            var difference = threshold - ent.Comp.baseTemperature; // Hot thresholds are pos, cold thresholds are neg
+            var difference = threshold - ent.Comp.BaseTemperature; // Hot thresholds are pos, cold thresholds are neg
             if ((maxColdThreshold == 0 || threshold > maxColdThreshold) &&  difference < 0) //Set cold modifier
             {
                 maxColdThreshold = threshold;

--- a/Content.Shared/Temperature/Systems/SharedTemperatureSystem.cs
+++ b/Content.Shared/Temperature/Systems/SharedTemperatureSystem.cs
@@ -29,6 +29,7 @@ public sealed class SharedTemperatureSystem : EntitySystem
 
     private void OnTemperatureChanged(Entity<TemperatureSpeedComponent> ent, ref OnTemperatureChangeEvent args)
     {
+
         foreach (var (threshold, modifier) in ent.Comp.Thresholds)
         {
             if (args.CurrentTemperature < threshold && args.LastTemperature > threshold ||
@@ -40,14 +41,34 @@ public sealed class SharedTemperatureSystem : EntitySystem
                 break;
             }
         }
-
-        var maxThreshold = ent.Comp.Thresholds.Max(p => p.Key);
-        if (args.CurrentTemperature > maxThreshold && args.LastTemperature < maxThreshold)
+        // Triad - Adjusted to allow too hot speed modifiers.
+        float maxColdThreshold = 0;
+        float minHotThreshold = 0;
+        foreach (var (threshold, modifier) in ent.Comp.Thresholds) // Find the thresholds that are closest to the normal body temperature se we can detect when to stop applying slowdowns
+        {
+            var difference = threshold - ent.Comp.baseTemperature; // Hot thresholds are pos, cold thresholds are neg
+            if ((maxColdThreshold == 0 || threshold > maxColdThreshold) &&  difference < 0) //Set cold modifier
+            {
+                maxColdThreshold = threshold;
+            }
+            else if ((minHotThreshold == 0 || threshold < minHotThreshold) &&  difference > 0) //Set hot modifier
+            {
+                minHotThreshold = threshold;
+            }
+        }
+        if (args.CurrentTemperature > maxColdThreshold && args.LastTemperature < maxColdThreshold) // We warmed up beyond the highest cold threshold
         {
             ent.Comp.NextSlowdownUpdate = _timing.CurTime + SlowdownApplicationDelay;
             ent.Comp.CurrentSpeedModifier = null;
             Dirty(ent);
         }
+        if (args.CurrentTemperature < minHotThreshold && args.LastTemperature > minHotThreshold) // We cooled down beyond the lowest heat threshold
+        {
+            ent.Comp.NextSlowdownUpdate = _timing.CurTime + SlowdownApplicationDelay;
+            ent.Comp.CurrentSpeedModifier = null;
+            Dirty(ent);
+        }
+        // Triad - End
     }
 
     private void OnRefreshMovementSpeedModifiers(Entity<TemperatureSpeedComponent> ent, ref RefreshMovementSpeedModifiersEvent args)

--- a/Content.Shared/Temperature/Systems/SharedTemperatureSystem.cs
+++ b/Content.Shared/Temperature/Systems/SharedTemperatureSystem.cs
@@ -29,7 +29,6 @@ public sealed class SharedTemperatureSystem : EntitySystem
 
     private void OnTemperatureChanged(Entity<TemperatureSpeedComponent> ent, ref OnTemperatureChangeEvent args)
     {
-
         foreach (var (threshold, modifier) in ent.Comp.Thresholds)
         {
             if (args.CurrentTemperature < threshold && args.LastTemperature > threshold ||

--- a/Content.Shared/Temperature/Systems/SharedTemperatureSystem.cs
+++ b/Content.Shared/Temperature/Systems/SharedTemperatureSystem.cs
@@ -67,8 +67,8 @@ public sealed class SharedTemperatureSystem : EntitySystem
             ent.Comp.CurrentSpeedModifier = null;
             Dirty(ent);
         }
-        // Triad - End
         if (args.CurrentTemperature < minHotThreshold && args.LastTemperature > minHotThreshold) // We cooled down beyond the lowest heat threshold
+        // Triad - End
         {
             ent.Comp.NextSlowdownUpdate = _timing.CurTime + SlowdownApplicationDelay;
             ent.Comp.CurrentSpeedModifier = null;

--- a/Resources/Prototypes/Entities/Mobs/Species/base.yml
+++ b/Resources/Prototypes/Entities/Mobs/Species/base.yml
@@ -278,6 +278,7 @@
       types:
         Heat: 1.5 #per second, scales with temperature & other constants
   - type: TemperatureSpeed
+    baseTemperature: 310.15 # Triad- Added to allow "too hot" slowdown thresholds. Should be set to a speices' normalBodyTemperature
     thresholds:
       293: 0.8
       280: 0.6

--- a/Resources/Prototypes/_Goobstation/Entities/Mobs/Species/tajaran.yml
+++ b/Resources/Prototypes/_Goobstation/Entities/Mobs/Species/tajaran.yml
@@ -117,6 +117,8 @@
       - !type:Emote
         emote: Scream
         probability: 0.2
+  - type: TemperatureSpeed # Triad
+    baseTemperature: 311.76
 
 - type: entity
   save: false

--- a/Resources/Prototypes/_Moffstation/Entities/Mobs/Species/resomi.yml
+++ b/Resources/Prototypes/_Moffstation/Entities/Mobs/Species/resomi.yml
@@ -100,6 +100,7 @@
     normalBodyTemperature: 285 # Triad - lowered base body temp as a quick fix to prevent chickens cooking themselves
     thermalRegulationTemperatureThreshold: 20
   - type: TemperatureSpeed # You're supposed to be used to the cold why are you so slow
+    baseTemperature: 285
     thresholds: # Calculated based on UI alert thresholds, rounded up
       253: 0.8
       231: 0.6

--- a/Resources/Prototypes/_Moffstation/Entities/Mobs/Species/resomi.yml
+++ b/Resources/Prototypes/_Moffstation/Entities/Mobs/Species/resomi.yml
@@ -98,14 +98,14 @@
     sweatHeatRegulation: 2000
     shiveringHeatRegulation: 2000
     normalBodyTemperature: 285 # Triad - lowered base body temp as a quick fix to prevent chickens cooking themselves
-    thermalRegulationTemperatureThreshold: 20
+    thermalRegulationTemperatureThreshold: 2
   - type: TemperatureSpeed # You're supposed to be used to the cold why are you so slow
     baseTemperature: 285
     thresholds: # Calculated based on UI alert thresholds, rounded up
       253: 0.8
       231: 0.6
       196: 0.4
-      300: 0.8   # Triad - ~30C, heat-side slowdown
+      303: 0.8   # Triad - ~30C, heat-side slowdown
       310: 0.6   # Triad - ~37C, deeper heat slowdown before damage threshold at 320.15
   - type: MovementSpeedModifier
     weightlessAcceleration: 2.5 # Birb move fast in zero-g

--- a/Resources/Prototypes/_Moffstation/Entities/Mobs/Species/resomi.yml
+++ b/Resources/Prototypes/_Moffstation/Entities/Mobs/Species/resomi.yml
@@ -100,7 +100,7 @@
     normalBodyTemperature: 285 # Triad - lowered base body temp as a quick fix to prevent chickens cooking themselves
     thermalRegulationTemperatureThreshold: 20
   - type: TemperatureSpeed # You're supposed to be used to the cold why are you so slow
-    baseTemperature: 285
+    baseTemperature: 285 # Triad
     thresholds: # Calculated based on UI alert thresholds, rounded up
       272: 0.8
       242: 0.6

--- a/Resources/Prototypes/_Moffstation/Entities/Mobs/Species/resomi.yml
+++ b/Resources/Prototypes/_Moffstation/Entities/Mobs/Species/resomi.yml
@@ -91,19 +91,19 @@
     heatDamage:
       types:
         Heat : 3 #per second, scales with temperature & other constants
-  - type: ThermalRegulator # Triad
+  - type: ThermalRegulator
     metabolismHeat: 800
     radiatedHeat: 100
     implicitHeatRegulation: 500
     sweatHeatRegulation: 2000
     shiveringHeatRegulation: 2000
     normalBodyTemperature: 285 # Triad - lowered base body temp as a quick fix to prevent chickens cooking themselves
-    thermalRegulationTemperatureThreshold: 2
+    thermalRegulationTemperatureThreshold: 20
   - type: TemperatureSpeed # You're supposed to be used to the cold why are you so slow
     baseTemperature: 285
     thresholds: # Calculated based on UI alert thresholds, rounded up
-      253: 0.8
-      231: 0.6
+      272: 0.8
+      242: 0.6
       196: 0.4
       303: 0.8   # Triad - ~30C, heat-side slowdown
       310: 0.6   # Triad - ~37C, deeper heat slowdown before damage threshold at 320.15

--- a/Resources/Prototypes/_Moffstation/Entities/Mobs/Species/resomi.yml
+++ b/Resources/Prototypes/_Moffstation/Entities/Mobs/Species/resomi.yml
@@ -91,7 +91,7 @@
     heatDamage:
       types:
         Heat : 3 #per second, scales with temperature & other constants
-  - type: ThermalRegulator
+  - type: ThermalRegulator # Triad
     metabolismHeat: 800
     radiatedHeat: 100
     implicitHeatRegulation: 500
@@ -101,10 +101,10 @@
     thermalRegulationTemperatureThreshold: 20
   - type: TemperatureSpeed # You're supposed to be used to the cold why are you so slow
     thresholds: # Calculated based on UI alert thresholds, rounded up
-      272: 0.8
-      242: 0.6
+      253: 0.8
+      231: 0.6
       196: 0.4
-      303: 0.8   # Triad - ~30C, heat-side slowdown
+      300: 0.8   # Triad - ~30C, heat-side slowdown
       310: 0.6   # Triad - ~37C, deeper heat slowdown before damage threshold at 320.15
   - type: MovementSpeedModifier
     weightlessAcceleration: 2.5 # Birb move fast in zero-g

--- a/Resources/Prototypes/_Obelisk/Entities/Mobs/Species/hydrakin.yml
+++ b/Resources/Prototypes/_Obelisk/Entities/Mobs/Species/hydrakin.yml
@@ -52,6 +52,7 @@
       types:
         Cold : 0.01 #per second, scales with temperature & other constants
   - type: TemperatureSpeed
+    baseTemperature: 210.15 # Triad
     thresholds:
       90: 0.9
       40: 0.75

--- a/Resources/Prototypes/_StarLight/Entities/Mobs/Species/avali.yml
+++ b/Resources/Prototypes/_StarLight/Entities/Mobs/Species/avali.yml
@@ -85,6 +85,7 @@
     - type: Sprite
       scale: 0.91, 0.91
     - type: TemperatureSpeed
+      baseTemperature: 261 # Triad
       thresholds:
         250: 0.9
         230: 0.8


### PR DESCRIPTION
## About the PR
<!-- What did you change? -->
<!-- If this is a code change, summarize at high level how your new code works. This makes it easier to review. -->
Adjusts the code to correctly handle temperature slow down thresholds intended to be above normal body temperatures.

## Why / Balance
<!-- Discuss how this would affect game balance or explain why it was changed. Link any relevant discussions or issues. -->
Before, the code only checked if you were warmer than the highest threshold to reset your speed, meaning attempting to use a thresold for getting to hot simply meant you would never be able to have normal move speed again.
This was done mainly for Resomi, but can be added to any species.

## Requirements
<!-- Confirm the following by placing an X in the brackets [X]: -->
- [X] I have read relevant guidelines/documentation to this PR found on [our devwiki](https://monolith-station.github.io/mono-docs/).
- [X] I have added media to this PR or it does not require an ingame showcase.
- [X] I can confirm this PR contains either no AI-generated content, or AI-generated content that meets our guidelines.
<!-- You should understand that not following the above may get your PR closed at maintainer’s discretion -->
<!-- When using AI, make sure you are already proficient in creating whatever content you are attempting to generate and that you already have experience contributing to SS14. This means using AI to enhance your preexisting workflow, not vibecoding. -->

## How to test
<!-- Describe the way it can be tested -->
Heat up a Resomi enough to be slowed, and cool them down again.

## Breaking changes
<!-- List any breaking changes, including namespaces, public class/method/field changes, prototype renames; and provide instructions for fixing them. -->
This adds an extra line to base.yml, not sure if it counts but seems like a big thing to mention

**Changelog**
<!-- Add a Changelog entry to make players aware of new features or changes that could affect gameplay.
Make sure to read the guidelines and take this Changelog template out of the comment block in order for it to show up.
Changelog must have a :cl: symbol, so the bot recognizes the changes and adds them to the game's changelog.
Remove this symbol for non-player facing PRs.-->
:cl:
- fix: Temperature slowdowns now correctly work for thresholds above normal body temperatures.
