### PR TITLE
Resomi Overheating Hotfix

### DIFF
--- a/Resources/Prototypes/_Moffstation/Entities/Mobs/Species/resomi.yml
+++ b/Resources/Prototypes/_Moffstation/Entities/Mobs/Species/resomi.yml
@@ -98,7 +98,7 @@
     sweatHeatRegulation: 2000
     shiveringHeatRegulation: 2000
     normalBodyTemperature: 285 # Triad - lowered base body temp as a quick fix to prevent chickens cooking themselves
-    thermalRegulationTemperatureThreshold: 20
+    thermalRegulationTemperatureThreshold: 2
   - type: TemperatureSpeed # You're supposed to be used to the cold why are you so slow
     thresholds: # Calculated based on UI alert thresholds, rounded up
       272: 0.8


### PR DESCRIPTION
## About the PR
<!-- What did you change? -->
<!-- If this is a code change, summarize at high level how your new code works. This makes it easier to review. -->
Should fix Resomi burning up with a suit on. Now they will actually cool down when wearing a suit.

## Why / Balance
<!-- Discuss how this would affect game balance or explain why it was changed. Link any relevant discussions or issues. -->
Hotfix! Turns out the Resomi's temperature regulator would wait until they were **20c** off of normal. The baseline is 2.. so I set it to 2.

## Media
<!-- Attach media if the PR makes ingame changes (clothing, items, features, etc). 
Small fixes/refactors are exempt. Media may be used in SS14 progress reports with credit. -->
<img width="900" height="416" alt="image" src="https://github.com/user-attachments/assets/d7693754-fedd-4065-8504-53fdcb0c5fc6" />

## Requirements
<!-- Confirm the following by placing an X in the brackets [X]: -->
- [X] I have read relevant guidelines/documentation to this PR found on [our devwiki](https://monolith-station.github.io/mono-docs/).
- [X] I have added media to this PR or it does not require an ingame showcase.
- [X] I can confirm this PR contains either no AI-generated content, or AI-generated content that meets our guidelines.
<!-- You should understand that not following the above may get your PR closed at maintainer’s discretion -->
<!-- When using AI, make sure you are already proficient in creating whatever content you are attempting to generate and that you already have experience contributing to SS14. This means using AI to enhance your preexisting workflow, not vibecoding. -->

## How to test
<!-- Describe the way it can be tested -->
Clothe the Bird,,,,

**Changelog**
<!-- Add a Changelog entry to make players aware of new features or changes that could affect gameplay.
Make sure to read the guidelines and take this Changelog template out of the comment block in order for it to show up.
Changelog must have a :cl: symbol, so the bot recognizes the changes and adds them to the game's changelog.
Remove this symbol for non-player facing PRs.-->
:cl:
- fix: Fixed Resomi's temperature regulation threshold.
