### PR TITLE
Fix Client Crash When a Shuttle Radar Draws a VGRoid

### DIFF
--- a/Content.Client/Shuttles/UI/BaseShuttleControl.xaml.cs
+++ b/Content.Client/Shuttles/UI/BaseShuttleControl.xaml.cs
@@ -48,6 +48,10 @@ public partial class BaseShuttleControl : MapGridControl
 
     private Vector2[] _allVertices = Array.Empty<Vector2>();
 
+    // Triad: max vertices per DrawPrimitives call. The engine stackallocs 40 bytes per vertex,
+    // so this keeps each call under ~500 KiB of stack. Same batch upstream used for triangles.
+    private const int BatchVertices = 3 * 4096;
+
     private (DirectionFlag, Vector2i)[] _neighborDirections;
 
     public BaseShuttleControl() : this(32f, 32f, 32f)
@@ -670,18 +674,48 @@ public partial class BaseShuttleControl : MapGridControl
 
         _parallel.ProcessNow(_drawJob, totalData);
 
-        const float BatchSize = 3f * 4096;
-
-        for (var i = 0; i < Math.Ceiling(triCount / BatchSize); i++)
-        {
-            var start = (int) (i * BatchSize);
-            var end = (int) Math.Min(triCount, start + BatchSize);
-            var count = end - start;
-            handle.DrawPrimitives(DrawPrimitiveTopology.TriangleList, new Span<Vector2>(_allVertices, start, count), color.WithAlpha(alpha));
-        }
-
-        handle.DrawPrimitives(DrawPrimitiveTopology.LineList, new Span<Vector2>(_allVertices, gridData.EdgeIndex, edgeCount), color);
+        // Triad: batch the edge draw too. DrawPrimitives stackallocs 40 bytes per vertex with no
+        // size cap (the engine's own TODO flags it), and upstream hands the whole edge span over
+        // in one call. Survivable for a shuttle, fatal for a VGRoid: its fractal outline is ~209k
+        // vertices, an 8 MiB stackalloc that blows the game thread's stack and CTDs with an empty
+        // log, since the access violation surfaces in coreclr rather than as a managed exception.
+        // const float BatchSize = 3f * 4096;
+        //
+        // for (var i = 0; i < Math.Ceiling(triCount / BatchSize); i++)
+        // {
+        //     var start = (int) (i * BatchSize);
+        //     var end = (int) Math.Min(triCount, start + BatchSize);
+        //     var count = end - start;
+        //     handle.DrawPrimitives(DrawPrimitiveTopology.TriangleList, new Span<Vector2>(_allVertices, start, count), color.WithAlpha(alpha));
+        // }
+        //
+        // handle.DrawPrimitives(DrawPrimitiveTopology.LineList, new Span<Vector2>(_allVertices, gridData.EdgeIndex, edgeCount), color);
+        DrawBatched(handle, DrawPrimitiveTopology.TriangleList, 0, triCount, color.WithAlpha(alpha));
+        DrawBatched(handle, DrawPrimitiveTopology.LineList, gridData.EdgeIndex, edgeCount, color);
+        // End Triad
     }
+
+    // Triad: draws a range of _allVertices in batches of at most BatchVertices, aligned to whole
+    // primitives. Only list topologies can be split like this; strips, fans and loops share
+    // vertices across primitives and are rejected.
+    private void DrawBatched(DrawingHandleScreen handle, DrawPrimitiveTopology topology, int offset, int count, Color color)
+    {
+        var stride = topology switch
+        {
+            DrawPrimitiveTopology.TriangleList => 3,
+            DrawPrimitiveTopology.LineList => 2,
+            _ => throw new ArgumentOutOfRangeException(nameof(topology), topology, "Only list topologies can be batched."),
+        };
+
+        var batchSize = BatchVertices - BatchVertices % stride;
+
+        for (var start = 0; start < count; start += batchSize)
+        {
+            var batch = Math.Min(batchSize, count - start);
+            handle.DrawPrimitives(topology, _allVertices.AsSpan(offset + start, batch), color);
+        }
+    }
+    // End Triad
 
     private static int GetDirIndex(Vector2i dir)
     {


### PR DESCRIPTION
## About the PR
Anyone with a shuttle nav console open near a VGRoid was getting a hard crash to desktop. `DrawPrimitives` stackallocs 40 bytes per vertex with no size cap, and `DrawGrid` was handing it the entire edge span in a single call, so a VGRoid's outline ran off the end of the game thread's stack. Both the tile-triangle and edge draws now go through a batching helper.

## Why / Balance
No balance impact, this is a crash fix.

Fun detail that made it annoying to find: nothing lands in the client log. The access violation surfaces inside `coreclr` rather than as a managed exception, so `EXCEPTION_TOLERANCE` never gets a look at it and the log just stops mid-line. It took a crash dump, and the stack pointed straight at the draw call.

The mechanism end to end. Upstream batches the tile triangles at 4096 primitives but hands the edges over unbatched. Fine for a shuttle, fatal for an asteroid: a VGRoid is a 272x272 FBm noise blob with ridged paths carved through it, so its perimeter is fractal and survives collinear merging at roughly 209k edge vertices. At 40 bytes each that is an 8,355,968 byte stackalloc against the 8 MiB `sys.game_thread_stack_size` default.

Worth being clear that this is not a VGRoid bug and not something we broke. The unbatched call is upstream's and has not changed since space-wizards/space-station-14#31623. VGRoids are simply the only grids on the fork big enough to reach the ceiling. The engine's own note on that stackalloc is `// TODO: Maybe don't stackalloc if the data is too large.`, so the caller owning the batching is the contract as it stands. An engine-side fix is the better long-term answer and is worth raising upstream separately.

`DrawBatched` takes vertices-per-primitive from the topology so a batch boundary cannot cut a triangle or a line in half, and it rejects strip, fan and loop topologies outright, since those share vertices between primitives and cannot be split across draw calls at all.

One thing I am deliberately leaving alone: the collinear merge loop in `DrawGrid` is O(n^2) with a `RemoveAt` per merge. I expected that to be the real monster, so I measured it rather than guessing, and it is a tolerable spike at current sizes. Leaving it, but it is worth revisiting if VGRoids ever grow.

## Media
No visual change. The radar draws the same outline it always drew, it just does it in batches now.

## Requirements
- [x] I have read the guidelines and documentation relevant to this PR.
- [x] I have added media to this PR or it does not require an ingame showcase.
- [x] I can confirm this PR contains either no AI-generated content, or AI-generated content that meets our guidelines.

## How to test
Dev server, then in the client console:

    aghost
    addmap 100
    dungen 100 NFVGRoidSnow 0 0 1234
    tp 0 0 100

Then hit the Show Radar action on the ghost. Standing on the asteroid matters: it makes the VGRoid your own grid, which `ShuttleNavControl.Draw` draws unconditionally with no IFF or detection gating in the way.

On main the client dies the instant the radar paints. With this branch it draws.

Verified against a live `NFVGRoidSnow`: the same asteroid crashes on main at `BaseShuttleControl.xaml.cs:683` with 208,798 vertices in the span, and renders fine with this applied. The production dump that started this measured 208,899 at the same call site.

## Breaking changes
None.

**Changelog**
:cl:
- fix: Fixed a client crash when a shuttle radar came into range of a VGRoid.
