### PR TITLE
Migrate Point Light Masks to the lightMask Prototype

### DIFF
--- a/Resources/Prototypes/Entities/Clothing/Head/base_clothinghead.yml
+++ b/Resources/Prototypes/Entities/Clothing/Head/base_clothinghead.yml
@@ -69,7 +69,7 @@
     enabled: false
     radius: 3
     energy: 1
-    mask: /Textures/Effects/LightMasks/cone.png
+    lightMask: ConeSingle
     autoRot: true
     netsync: false
   - type: Appearance
@@ -217,7 +217,7 @@
     enabled: false
     radius: 4 # 3->4 Mono
     energy: 3 # 2->3 Mono
-    mask: /Textures/Effects/LightMasks/cone.png
+    lightMask: ConeSingle
     autoRot: true
     netsync: false
   - type: Appearance

--- a/Resources/Prototypes/Entities/Clothing/Head/hardhats.yml
+++ b/Resources/Prototypes/Entities/Clothing/Head/hardhats.yml
@@ -14,7 +14,7 @@
     equippedPrefix: off
   - type: PointLight
     enabled: false
-    mask: /Textures/Effects/LightMasks/cone.png
+    lightMask: ConeSingle
     autoRot: true
     radius: 7
     netsync: false

--- a/Resources/Prototypes/Entities/Clothing/Head/helmets.yml
+++ b/Resources/Prototypes/Entities/Clothing/Head/helmets.yml
@@ -475,7 +475,7 @@
     energy: 1.4
     color: red
     netsync: false
-    mask: /Textures/Effects/LightMasks/double_cone.png
+    lightMask: ConeDouble
   - type: RotatingLight
     speed: 360
   - type: PowerCellSlot

--- a/Resources/Prototypes/Entities/Clothing/Head/misc.yml
+++ b/Resources/Prototypes/Entities/Clothing/Head/misc.yml
@@ -66,7 +66,7 @@
     enabled: false
     radius: 3
     energy: 1
-    mask: /Textures/Effects/LightMasks/cone.png
+    lightMask: ConeSingle
     autoRot: true
     color: "#cc6600"
     netsync: false

--- a/Resources/Prototypes/Entities/Clothing/OuterClothing/armor.yml
+++ b/Resources/Prototypes/Entities/Clothing/OuterClothing/armor.yml
@@ -175,7 +175,7 @@
     color: "#80ff80"
     radius: 5
     energy: 2
-    mask: /Textures/Effects/LightMasks/cone.png
+    lightMask: ConeSingle
     autoRot: true
     netsync: false
   - type: LightBehaviour

--- a/Resources/Prototypes/Entities/Clothing/OuterClothing/softsuits.yml
+++ b/Resources/Prototypes/Entities/Clothing/OuterClothing/softsuits.yml
@@ -151,7 +151,7 @@
     radius: 2
     energy: 2
     color: blue
-    mask: /Textures/Effects/LightMasks/double_cone.png
+    lightMask: ConeDouble
   - type: RotatingLight
     speed: 360
   - type: StaminaDamageResistance # Mono - Stamres

--- a/Resources/Prototypes/Entities/Mobs/Cyborgs/base_borg_chassis.yml
+++ b/Resources/Prototypes/Entities/Mobs/Cyborgs/base_borg_chassis.yml
@@ -243,7 +243,7 @@
   #- type: ToggleableVisuals
   #- type: PointLight
   #  enabled: false
-  #  mask: /Textures/Effects/LightMasks/cone.png
+  #  lightMask: ConeSingle
   #  autoRot: true
   #  radius: 4
   #  netsync: false

--- a/Resources/Prototypes/Entities/Mobs/NPCs/silicon.yml
+++ b/Resources/Prototypes/Entities/Mobs/NPCs/silicon.yml
@@ -134,7 +134,7 @@
     enabled: false
     radius: 3.5
     softness: 2
-    mask: /Textures/Effects/LightMasks/cone.png
+    lightMask: ConeSingle
     autoRot: true
 
 - type: entity
@@ -494,7 +494,7 @@
     enabled: false
     radius: 3.5
     softness: 2
-    mask: /Textures/Effects/LightMasks/cone.png
+    lightMask: ConeSingle
     autoRot: true
   - type: FootstepModifier
     footstepSoundCollection:

--- a/Resources/Prototypes/Entities/Objects/Misc/subdermal_implants.yml
+++ b/Resources/Prototypes/Entities/Objects/Misc/subdermal_implants.yml
@@ -45,7 +45,7 @@
       enabled: false
       radius: 2.5
       softness: 5
-      mask: /Textures/Effects/LightMasks/cone.png
+      lightMask: ConeSingle
       autoRot: true
     - type: Tag
       tags:

--- a/Resources/Prototypes/Entities/Objects/Specific/Mech/mechs.yml
+++ b/Resources/Prototypes/Entities/Objects/Specific/Mech/mechs.yml
@@ -124,7 +124,7 @@
     enabled: false
     softness: 5
     autoRot: true
-    mask: /Textures/Effects/LightMasks/cone.png
+    lightMask: ConeSingle
     radius: 7
     energy: 3
     netsync: false

--- a/Resources/Prototypes/Entities/Objects/Tools/flashlights.yml
+++ b/Resources/Prototypes/Entities/Objects/Tools/flashlights.yml
@@ -60,7 +60,7 @@
     storedRotation: -90
   - type: PointLight
     enabled: false
-    mask: /Textures/Effects/LightMasks/cone.png
+    lightMask: ConeSingle
     autoRot: true
     radius: 6
     netsync: false

--- a/Resources/Prototypes/Entities/Objects/Vehicles/buckleable.yml
+++ b/Resources/Prototypes/Entities/Objects/Vehicles/buckleable.yml
@@ -111,7 +111,7 @@
     enabled: false
     radius: 3.5
     softness: 2
-    mask: /Textures/Effects/LightMasks/cone.png
+    lightMask: ConeSingle
     autoRot: true
   - type: Destructible
     thresholds:
@@ -256,7 +256,7 @@
     enabled: false
     radius: 3.5
     softness: 2
-    mask: /Textures/Effects/LightMasks/cone.png
+    lightMask: ConeSingle
     autoRot: true
   - type: ItemSlots
     slots:
@@ -346,7 +346,7 @@
       enabled: false
       radius: 3.5
       softness: 2
-      mask: /Textures/Effects/LightMasks/cone.png
+      lightMask: ConeSingle
       autoRot: true
     - type: ItemSlots
       slots:

--- a/Resources/Prototypes/Entities/Structures/Decoration/decorated_fir_tree.yml
+++ b/Resources/Prototypes/Entities/Structures/Decoration/decorated_fir_tree.yml
@@ -15,7 +15,7 @@
     radius: 1.6
     energy: 1.2
     enabled: false
-    mask: /Textures/Effects/LightMasks/cone.png
+    lightMask: ConeSingle
     autoRot: true
     offset: "0, 0.6"
   - type: Damageable

--- a/Resources/Prototypes/Entities/Structures/Lighting/base_lighting.yml
+++ b/Resources/Prototypes/Entities/Structures/Lighting/base_lighting.yml
@@ -455,7 +455,7 @@
     energy: 0.6
     offset: "0, 0.4"
     color: "#7CFC00"
-    mask: /Textures/Effects/LightMasks/double_cone.png
+    lightMask: ConeDouble
   - type: ApcPowerReceiver
   - type: ExtensionCableReceiver
   - type: Battery

--- a/Resources/Prototypes/Entities/Structures/Lighting/strobe_lighting.yml
+++ b/Resources/Prototypes/Entities/Structures/Lighting/strobe_lighting.yml
@@ -31,7 +31,7 @@
       shader: unshaded
     state: base
   - type: PointLight
-    mask: /Textures/Effects/LightMasks/double_cone.png
+    lightMask: ConeDouble
     color: "#FFE4CE"
     energy: 5
     radius: 10

--- a/Resources/Prototypes/Entities/Structures/Machines/Computers/base_structurecomputers.yml
+++ b/Resources/Prototypes/Entities/Structures/Machines/Computers/base_structurecomputers.yml
@@ -52,7 +52,7 @@
     radius: 1.5
     energy: 1.6
     enabled: false
-    mask: /Textures/Effects/LightMasks/cone.png
+    lightMask: ConeSingle
     autoRot: true
     offset: "0, 0.4" # shine from the top, not bottom of the computer
     castShadows: false

--- a/Resources/Prototypes/Entities/Structures/Machines/nuke.yml
+++ b/Resources/Prototypes/Entities/Structures/Machines/nuke.yml
@@ -66,7 +66,7 @@
     radius: 4
     energy: 2.0
     color: "#FF4020"
-    mask: /Textures/Effects/LightMasks/double_cone.png
+    lightMask: ConeDouble
   - type: RotatingLight
     speed: 120
   - type: NavMapBeacon

--- a/Resources/Prototypes/Entities/Structures/Shuttles/thrusters.yml
+++ b/Resources/Prototypes/Entities/Structures/Shuttles/thrusters.yml
@@ -200,7 +200,7 @@
     radius: 1.3
     energy: 0.8
     enabled: false
-    mask: /Textures/Effects/LightMasks/cone.png
+    lightMask: ConeSingle
     autoRot: true
     offset: "0, 0.1" # shine from the top, not bottom of the computer
     color: "#4246b3"

--- a/Resources/Prototypes/_Goobstation/Entities/Clothing/Head/modsuit.yml
+++ b/Resources/Prototypes/_Goobstation/Entities/Clothing/Head/modsuit.yml
@@ -123,7 +123,7 @@
     enabled: false
     radius: 3
     energy: 2
-    mask: /Textures/Effects/LightMasks/cone.png
+    lightMask: ConeSingle
     autoRot: true
     netsync: false
   - type: HandheldLight
@@ -192,7 +192,7 @@
     enabled: false
     radius: 5
     energy: 3
-    mask: /Textures/Effects/LightMasks/cone.png
+    lightMask: ConeSingle
     autoRot: true
     netsync: false
   - type: HandheldLight
@@ -263,7 +263,7 @@
     enabled: false
     radius: 5
     energy: 3
-    mask: /Textures/Effects/LightMasks/cone.png
+    lightMask: ConeSingle
     autoRot: true
     netsync: false
   - type: HandheldLight
@@ -313,7 +313,7 @@
     enabled: false
     radius: 5
     energy: 3
-    mask: /Textures/Effects/LightMasks/cone.png
+    lightMask: ConeSingle
     autoRot: true
     netsync: false
   - type: HandheldLight
@@ -363,7 +363,7 @@
     enabled: false
     radius: 5
     energy: 3
-    mask: /Textures/Effects/LightMasks/cone.png
+    lightMask: ConeSingle
     autoRot: true
     netsync: false
   - type: HandheldLight
@@ -430,7 +430,7 @@
     enabled: false
     radius: 5
     energy: 3
-    mask: /Textures/Effects/LightMasks/cone.png
+    lightMask: ConeSingle
     autoRot: true
     netsync: false
   - type: HandheldLight
@@ -480,7 +480,7 @@
     enabled: false
     radius: 5
     energy: 3
-    mask: /Textures/Effects/LightMasks/cone.png
+    lightMask: ConeSingle
     autoRot: true
     netsync: false
   - type: HandheldLight
@@ -545,7 +545,7 @@
     enabled: false
     radius: 5
     energy: 3
-    mask: /Textures/Effects/LightMasks/cone.png
+    lightMask: ConeSingle
     autoRot: true
     netsync: false
   - type: HandheldLight

--- a/Resources/Prototypes/_Mono/Entities/Clothing/Head/modsuit.yml
+++ b/Resources/Prototypes/_Mono/Entities/Clothing/Head/modsuit.yml
@@ -21,7 +21,7 @@
     enabled: false
     radius: 5
     energy: 3
-    mask: /Textures/Effects/LightMasks/cone.png
+    lightMask: ConeSingle
     autoRot: true
     netsync: false
   - type: HandheldLight
@@ -91,7 +91,7 @@
     enabled: false
     radius: 5
     energy: 3
-    mask: /Textures/Effects/LightMasks/cone.png
+    lightMask: ConeSingle
     autoRot: true
     netsync: false
   - type: HandheldLight
@@ -160,7 +160,7 @@
     enabled: false
     radius: 5
     energy: 3
-    mask: /Textures/Effects/LightMasks/cone.png
+    lightMask: ConeSingle
     autoRot: true
     netsync: false
   - type: HandheldLight
@@ -229,7 +229,7 @@
     enabled: false
     radius: 5
     energy: 3
-    mask: /Textures/Effects/LightMasks/cone.png
+    lightMask: ConeSingle
     autoRot: true
     netsync: false
   - type: HandheldLight
@@ -293,7 +293,7 @@
     enabled: false
     radius: 5
     energy: 3
-    mask: /Textures/Effects/LightMasks/cone.png
+    lightMask: ConeSingle
     autoRot: true
     netsync: false
   - type: HandheldLight

--- a/Resources/Prototypes/_Mono/Entities/Structures/Machines/heavy_drive.yml
+++ b/Resources/Prototypes/_Mono/Entities/Structures/Machines/heavy_drive.yml
@@ -92,7 +92,7 @@
     energy: 1.6
     color: "#0dc6ff"
     enabled: false
-    mask: /Textures/Effects/LightMasks/cone.png
+    lightMask: ConeSingle
     autoRot: true
     offset: "0, 0.4" # shine from the top, not bottom of the computer
     castShadows: false

--- a/Resources/Prototypes/_Mono/Entities/Structures/Machines/nuke.yml
+++ b/Resources/Prototypes/_Mono/Entities/Structures/Machines/nuke.yml
@@ -49,7 +49,7 @@
     radius: 4
     energy: 2.0
     color: "#FF4020"
-    mask: /Textures/Effects/LightMasks/double_cone.png
+    lightMask: ConeDouble
   - type: RotatingLight
     speed: 120
   - type: NavMapBeacon

--- a/Resources/Prototypes/_NF/Entities/Clothing/Head/softsuit-helmets.yml
+++ b/Resources/Prototypes/_NF/Entities/Clothing/Head/softsuit-helmets.yml
@@ -61,7 +61,7 @@
     enabled: false
     radius: 3
     energy: 2
-    mask: /Textures/Effects/LightMasks/cone.png
+    lightMask: ConeSingle
     autoRot: true
     netsync: false
 

--- a/Resources/Prototypes/_NF/Entities/Mobs/NPCs/mob_hostile_expeditions_explorers.yml
+++ b/Resources/Prototypes/_NF/Entities/Mobs/NPCs/mob_hostile_expeditions_explorers.yml
@@ -57,7 +57,7 @@
     netsync: false
     radius: 3
     energy: 1
-    mask: /Textures/Effects/LightMasks/cone.png
+    lightMask: ConeSingle
     color: "#47f8ff"
   - type: MovementSpeedModifier
     baseWalkSpeed : 4.5

--- a/Resources/Prototypes/_NF/Entities/Objects/Misc/subdermal_implants.yml
+++ b/Resources/Prototypes/_NF/Entities/Objects/Misc/subdermal_implants.yml
@@ -134,7 +134,7 @@
     enabled: false
     radius: 2.5
     softness: 5
-    mask: /Textures/Effects/LightMasks/cone.png
+    lightMask: ConeSingle
     autoRot: true
     color: "#ff0000"
   - type: UnpoweredFlashlight

--- a/Resources/Prototypes/_NF/Entities/Objects/Vehicles/vehicles.yml
+++ b/Resources/Prototypes/_NF/Entities/Objects/Vehicles/vehicles.yml
@@ -498,7 +498,7 @@
     radius: 6
     energy: 2
     color: "#FF4020"
-    mask: /Textures/Effects/LightMasks/double_cone.png
+    lightMask: ConeDouble
 
 - type: entity
   parent: VehicleHoverbikeNfsd

--- a/Resources/Prototypes/_NF/Entities/Objects/Weapons/Guns/base_turret.yml
+++ b/Resources/Prototypes/_NF/Entities/Objects/Weapons/Guns/base_turret.yml
@@ -103,7 +103,7 @@
     netsync: false
     radius: 20 # Triad 20 < 16
     energy: 8
-    mask: /Textures/_NF/Effects/LightMasks/beam.png
+    lightMask: Beam
     color: "#990000"
 
 - type: entity # Basic ballistic turret

--- a/Resources/Prototypes/_NF/Entities/Structures/Machines/material_reclaimer.yml
+++ b/Resources/Prototypes/_NF/Entities/Structures/Machines/material_reclaimer.yml
@@ -40,7 +40,7 @@
     energy: 1.6
     enabled: false
     color: "#da824d"
-    mask: /Textures/Effects/LightMasks/cone.png
+    lightMask: ConeSingle
     autoRot: true
     offset: "0, 0.4"
     castShadows: false

--- a/Resources/Prototypes/_NF/Entities/Structures/Machines/shredder.yml
+++ b/Resources/Prototypes/_NF/Entities/Structures/Machines/shredder.yml
@@ -32,7 +32,7 @@
     energy: 1.6
     enabled: false
     color: "#da824d"
-    mask: /Textures/Effects/LightMasks/cone.png
+    lightMask: ConeSingle
     autoRot: true
     offset: "0, 0.4"
     castShadows: false

--- a/Resources/Prototypes/light_mask.yml
+++ b/Resources/Prototypes/light_mask.yml
@@ -1,0 +1,33 @@
+# The direction refers to the angle a cone points at from the center of the mask
+# Note that while the default single cone image points NORTH, an angle of 0 is actually SOUTH. As such:
+# North(Pointing up) = 180,
+# East(Pointing right) = 90,
+# South(Pointing down) = 0,
+# West(Pointing left) = 270
+- type: lightMask
+  id: ConeSingle
+  maskPath: /Textures/Effects/LightMasks/cone.png
+  lightCones:
+  - direction: 0
+    innerWidth: 30
+    outerWidth: 60
+
+- type: lightMask
+  id: ConeDouble
+  maskPath: /Textures/Effects/LightMasks/double_cone.png
+  lightCones:
+  - direction: 0
+    innerWidth: 30
+    outerWidth: 60
+  - direction: 180
+    innerWidth: 30
+    outerWidth: 60
+
+# Triad: narrow beam mask for the Frontier searchlight texture (engine lightMask migration)
+- type: lightMask
+  id: Beam
+  maskPath: /Textures/_NF/Effects/LightMasks/beam.png
+  lightCones:
+  - direction: 0
+    innerWidth: 5
+    outerWidth: 15


### PR DESCRIPTION
## About the PR
Engine PR #5574 (landed v284) removed the `mask:` datafield from `PointLightComponent` and replaced it with `lightMask:`, a ProtoId pointing at a new `lightMask` prototype. Our 44 remaining `mask:` fields were being silently dropped by the loader, so every directional light on the fork was rendering as a plain point light. This adds `light_mask.yml` and moves all 44 call sites onto prototype ids.

## Why / Balance
The failure mode here is the quiet kind: the loader drops an unknown datafield without complaining, so nothing errored and nothing logged. The lights just went omnidirectional and stayed that way.

What it was affecting, in practice: flashlights, hardhats, modsuits, helmets, mech and borg headlights, thrusters, strobes and the turret searchlight. Anything that was meant to throw a cone was throwing a bubble.

`light_mask.yml` carries upstream's `ConeSingle` and `ConeDouble` verbatim so we stay in step with them, plus a `Beam` entry for the Frontier turret searchlight texture, which has no upstream equivalent.

One thing I want to flag rather than bury: the new prototype carries `lightCones` angle data alongside the texture path, and those angles feed `LightLevelSystem` rather than the renderer. The `Beam` cone values are a first pass. Nothing consumes light levels off that turret today, so it does not currently matter, but if something starts to, those numbers are the ones to tune.

## Media
<img width="300" height="208" alt="image" src="https://github.com/user-attachments/assets/c91e7d74-e39e-4600-abc3-622671eede73" />

u when using ur flashlite now.

## Requirements
- [x] I have read the guidelines and documentation relevant to this PR.
- [x] I have added media to this PR or it does not require an ingame showcase.
- [x] I can confirm this PR contains either no AI-generated content, or AI-generated content that meets our guidelines.

## How to test
Spawn a flashlight, a hardhat or a modsuit helmet and turn it on. The light should throw a directional cone that turns with you, rather than an even circle. A thruster or the turret searchlight works too.

## Breaking changes
Any downstream YAML still setting `mask:` on `PointLight` is already broken by the engine bump, not by this PR, since the field no longer exists. The migration is `mask: /Textures/Effects/LightMasks/cone.png` becomes `lightMask: ConeSingle`, and likewise `double_cone.png` becomes `ConeDouble`. New masks need an entry in `Resources/Prototypes/light_mask.yml` rather than a raw texture path.

**Changelog**
:cl:
- fix: Directional lights point in a direction again. Flashlights, hardhats, modsuits, helmets, mech and borg headlights, thrusters and strobes were all casting light evenly in every direction.
