### PR TITLE
Priority Docking for Shipyard Ships

### DIFF
--- a/Content.Server/_NF/Shipyard/Systems/ShipyardSystem.Consoles.cs
+++ b/Content.Server/_NF/Shipyard/Systems/ShipyardSystem.Consoles.cs
@@ -161,7 +161,7 @@ public sealed partial class ShipyardSystem : SharedShipyardSystem
             return;
         }
 
-        if (!TryPurchaseShuttle(station, vessel.ShuttlePath, out var shuttleUidOut))
+        if (!TryPurchaseShuttle(station, vessel.ShuttlePath, out var shuttleUidOut, vessel.PriorityDockTag))
         {
             PlayDenySound(player, shipyardConsoleUid, component);
             return;

--- a/Content.Server/_NF/Shipyard/Systems/ShipyardSystem.cs
+++ b/Content.Server/_NF/Shipyard/Systems/ShipyardSystem.cs
@@ -137,11 +137,13 @@ public sealed partial class ShipyardSystem : SharedShipyardSystem
 
     /// <summary>
     /// Adds a ship to the shipyard, calculates its price, and attempts to ftl-dock it to the given station
+    /// Triad - added dockTag
     /// </summary>
     /// <param name="stationUid">The ID of the station to dock the shuttle to</param>
     /// <param name="shuttlePath">The path to the shuttle file to load. Must be a grid file!</param>
+    /// <param name="dockTag">The priority tag to use when choosing a valid dock the shuttle.</param>
     /// <param name="shuttleEntityUid">The EntityUid of the shuttle that was purchased</param>
-    public bool TryPurchaseShuttle(EntityUid stationUid, ResPath shuttlePath, [NotNullWhen(true)] out EntityUid? shuttleEntityUid)
+    public bool TryPurchaseShuttle(EntityUid stationUid, ResPath shuttlePath, [NotNullWhen(true)] out EntityUid? shuttleEntityUid, string? dockTag = null)
     {
         if (!TryComp<StationDataComponent>(stationUid, out var stationData)
             || !TryAddShuttle(shuttlePath, out var shuttleGrid)
@@ -165,7 +167,7 @@ public sealed partial class ShipyardSystem : SharedShipyardSystem
         var ev = new ShipBoughtEvent();
         RaiseLocalEvent(shuttleGrid.Value, ev);
         //can do TryFTLDock later instead if we need to keep the shipyard map paused
-        _shuttle.TryFTLDock(shuttleGrid.Value, shuttleComponent, targetGrid.Value);
+        _shuttle.TryFTLDock(shuttleGrid.Value, shuttleComponent, targetGrid.Value, priorityTag: dockTag); // Triad, dock tag
         shuttleEntityUid = shuttleGrid;
         return true;
     }

--- a/Content.Shared/_NF/Shipyard/Prototypes/VesselPrototype.cs
+++ b/Content.Shared/_NF/Shipyard/Prototypes/VesselPrototype.cs
@@ -134,6 +134,12 @@ public sealed partial class VesselPrototype : IPrototype, IInheritingPrototype
     /// </summary>
     [DataField]
     public List<string> Company = new();
+
+    /// <summary>
+    ///     Triad - The tag used for priority docks when buying the ship. Set to null to have no priority dock tag.
+    /// </summary>
+    [DataField]
+    public string? PriorityDockTag;
 }
 
 public enum VesselSize : byte

--- a/Resources/Prototypes/_Mono/Entities/Structures/Doors/Airlocks/shuttle.yml
+++ b/Resources/Prototypes/_Mono/Entities/Structures/Doors/Airlocks/shuttle.yml
@@ -69,6 +69,8 @@
       - !type:PlaySoundBehavior
         sound:
           collection: MetalSlam
+  - type: PriorityDock # Triad, dock priority
+    requiredShuttleTag: DockTdf # Outpost doors cannot have purchased CIVILIAN shuttles dock
 
 - type: entity
   id: AirlockShuttleNfsdOutpost
@@ -87,6 +89,8 @@
       - !type:PlaySoundBehavior
         sound:
           collection: MetalSlam
+  - type: PriorityDock # Triad, dock priority
+    requiredShuttleTag: DockTdf # Outpost doors cannot have purchased CIVILIAN shuttles dock
 
 - type: entity
   parent: AirlockShuttle

--- a/Resources/Prototypes/_NF/Entities/Structures/Doors/Airlocks/shuttle.yml
+++ b/Resources/Prototypes/_NF/Entities/Structures/Doors/Airlocks/shuttle.yml
@@ -24,6 +24,8 @@
   - type: Construction
     graph: AirlockShuttleNfsd
     node: airlockGlass
+  - type: PriorityDock # Triad, dock priority
+    tag: DockTdf
 
 - type: entity
   id: AirlockShuttleNfsd
@@ -37,3 +39,5 @@
   - type: Construction
     graph: AirlockShuttleNfsd
     node: airlock
+  - type: PriorityDock # Triad, dock priority
+    tag: DockTdf

--- a/Resources/Prototypes/_Triad/Shipyard/Base/base.yml
+++ b/Resources/Prototypes/_Triad/Shipyard/Base/base.yml
@@ -13,9 +13,23 @@
     flags: [IsPlayerShuttle]
 
 - type: vessel
+  parent: BaseVessel
+  id: BaseVesselFaction
+  abstract: true
+  addComponents:
+  - type: ShipSavingBlacklist
+
+- type: vessel
+  parent: BaseVesselFaction
+  id: BaseVesselTdf
+  abstract: true
+  description: Hell yeah.
+  priorityDockTag: DockTdf
+
+- type: vessel
+  parent: BaseVessel
   id: BaseVesselAntag
   abstract: true
-  parent: BaseVessel
   addComponents:
   - type: IFF
     flags: [IsPlayerShuttle, HideLabel]

--- a/Resources/Prototypes/_Triad/Shipyard/TDF/adjutant.yml
+++ b/Resources/Prototypes/_Triad/Shipyard/TDF/adjutant.yml
@@ -3,7 +3,7 @@
 
 - type: vessel
   id: Adjutant
-  parent: BaseVessel
+  parent: BaseVesselTdf
   name: TDF Adjutant
   description: One of the first ships that can be traced back to the first proper warship of the original CDF when the sector was in full-out war. Now, it serves as a reminder of the struggle and many lives lost in the race to break the shackle of oppression. 2 TARNYX, 2 90mm Longbow, PDW, and flare system. This ship will ensure those who defile the sanctity of the sector independence will know the struggle of oppression.
   price: 145750
@@ -17,8 +17,6 @@
   - Corvette
   engine:
   - Bananium
-  addComponents:
-  - type: ShipSavingBlacklist
 
 - type: gameMap
   id: Adjutant

--- a/Resources/Prototypes/_Triad/Shipyard/TDF/fling.yml
+++ b/Resources/Prototypes/_Triad/Shipyard/TDF/fling.yml
@@ -1,6 +1,6 @@
 - type: vessel
   id: Fling
-  parent: BaseVessel
+  parent: BaseVesselTdf
   name: TDF Fling
   description: A small competent interceptor fitted with 4 large thruster to chase any hostile alongside taking its pilot as a prisoner, its 4 dravon and 2 ak570 is good enough to soften the armor of its enemy. While it lack of armor the ship is capable of doing hit and run to disturb its opponent.
   price: 82000

--- a/Resources/Prototypes/_Triad/Shipyard/TDF/grunder.yml
+++ b/Resources/Prototypes/_Triad/Shipyard/TDF/grunder.yml
@@ -3,7 +3,7 @@
 
 - type: vessel
   id: Grunder
-  parent: BaseVessel
+  parent: BaseVesselTdf
   name: TDF Grunder
   description: Designed for rapid deployment, the Grunder is equipped to launch boarding parties from its rear bay. Despite its lack of armor, the ship excels at stripping enemy hulls and bypassing shields. However, it relies heavily on fleet support and must wait for the right opportunity to strike.
   price: 135000

--- a/Resources/Prototypes/_Triad/Shipyard/TDF/jester.yml
+++ b/Resources/Prototypes/_Triad/Shipyard/TDF/jester.yml
@@ -1,6 +1,6 @@
 - type: vessel
   id: Jester
-  parent: BaseVessel
+  parent: BaseVesselTdf
   name: TDF Jester
   description: A small cheap ship with salvaging equipment competent enough to do space mining alongside protecting itself from small incursion from light interceptor and boarder, named jester due to its crew jokingly said this ship look big enough for two people only to find out its only enough for one people.
   price: 63000

--- a/Resources/Prototypes/_Triad/Shipyard/TDF/knight.yml
+++ b/Resources/Prototypes/_Triad/Shipyard/TDF/knight.yml
@@ -3,7 +3,7 @@
 
 - type: vessel
   id: Knight
-  parent: BaseVessel
+  parent: BaseVesselTdf
   name: TDF Knight
   description: Workhorse of the TDF, the knight is a medium class vessel designed to fill mutilple roles, designed to punch up against more heavily armored vessels and provide support in larger fleet action with it laser and EMP
   price: 165000

--- a/Resources/Prototypes/_Triad/Shipyard/TDF/mercy.yml
+++ b/Resources/Prototypes/_Triad/Shipyard/TDF/mercy.yml
@@ -1,6 +1,6 @@
 - type: vessel
   id: Mercy
-  parent: BaseVessel
+  parent: BaseVesselTdf
   name: TDF Mercy
   description: Born in the need of sufficient armed medical ship for extraction of civilian from contested space, Mercy is armed with modest weapons and 2 Tovek to deter any assailant against it's precious patient cargo. It has increased armor to withstand direct attacks, but cannot survive without proper escort due to it's heavy mass and thrust to weight ratio.
   price: 135000

--- a/Resources/Prototypes/_Triad/Shipyard/TDF/phalanx.yml
+++ b/Resources/Prototypes/_Triad/Shipyard/TDF/phalanx.yml
@@ -4,7 +4,7 @@
 
 - type: vessel
   id: Phalanx
-  parent: BaseVessel
+  parent: BaseVesselTdf
   name: TDF Phalanx
   description: A relic of the UCA fleet, updated for the modern age to serve as a Mech Carrier for the TDF. The Phalanx will arrive at a point, and ensure the point remains within TDF control.
   price: 405000

--- a/Resources/Prototypes/_Triad/tags.yml
+++ b/Resources/Prototypes/_Triad/tags.yml
@@ -41,3 +41,7 @@
 
 - type: Tag
   id: DockTransitStarboard
+
+# So TDF vessels prioritize TDF docks on Venmar and civilian vessels do not dock to them
+- type: Tag
+  id: DockTdf


### PR DESCRIPTION
## About the PR
Allows purchasing a ship to interface with the shipyard system.

Vessel prototypes now have a ``priorityDockTag`` field which is a tag that the ``PriorityDockComponent`` on the docking airlocks read to dock to eachother.

This allows TDF locked docking ports. Before, we couldn't have these, since vessels would try to dock to them, which would force a player to break inside to access their ship easily. Now, only TDF ships will attempt to dock to those ports when purchasing. Civilian ships can never dock, due to the ``requiredShuttleTag`` of DockTdf on the TDF outpost airlocks, which should be used when adding TDF docking ports to civ-tdf POIs.

## Technical details
Adds base vessel prototypes, ``BaseVesselFaction`` and ``BaseVesselTdf``

BaseVesselFaction has the ship saving blacklist by default

## Breaking changes
<!-- List any breaking changes, including namespaces, public class/method/field changes, prototype renames; and provide instructions for fixing them. -->

**Changelog**
Not player facing