### PR TITLE
Bastion Shotgun Sprite Fix

### DIFF
--- a/Resources/Prototypes/_Triad/Entities/Objects/Weapons/Guns/Shotgun/shotgun.yml
+++ b/Resources/Prototypes/_Triad/Entities/Objects/Weapons/Guns/Shotgun/shotgun.yml
@@ -11,6 +11,12 @@
     shape:
     - 0,0,4,0
     sprite: _Triad/Objects/Weapons/Guns/Shotgun/tdf_doublebarrel_inhand_32x.rsi
+  - type: Clothing
+    sprite: _Triad/Objects/Weapons/Guns/Shotgun/tdf_doublebarrel_inhand_32x.rsi
+    quickEquip: false
+    slots:
+    - Back
+    - suitStorage
   - type: GunSpreadModifier #Mono
     spread: 0.4
   - type: GunRequiresWield #remove when inaccuracy on spreads is fixed


### PR DESCRIPTION
## About the PR
<!-- What did you change? -->
<!-- If this is a code change, summarize at high level how your new code works. This makes it easier to review. -->

## Why / Balance
<!-- Discuss how this would affect game balance or explain why it was changed. Link any relevant discussions or issues. -->
fixes bastion showing up as double barrel or other different kind of shotgun

## Media
<!-- Attach media if the PR makes ingame changes (clothing, items, features, etc). 
Small fixes/refactors are exempt. Media may be used in SS14 progress reports with credit. -->

## Requirements
<!-- Confirm the following by placing an X in the brackets [X]: -->
- [x] I have read relevant guidelines/documentation to this PR found on [our devwiki](https://monolith-station.github.io/mono-docs/).
- [ ] I have added media to this PR or it does not require an ingame showcase.
- [x] I can confirm this PR contains either no AI-generated content, or AI-generated content that meets our guidelines.
<!-- You should understand that not following the above may get your PR closed at maintainer’s discretion -->
<!-- When using AI, make sure you are already proficient in creating whatever content you are attempting to generate and that you already have experience contributing to SS14. This means using AI to enhance your preexisting workflow, not vibecoding. -->

## How to test
<!-- Describe the way it can be tested -->
put tdf bastion to back, should show proper sprite now
## Breaking changes
<!-- List any breaking changes, including namespaces, public class/method/field changes, prototype renames; and provide instructions for fixing them. -->

**Changelog**
<!-- Add a Changelog entry to make players aware of new features or changes that could affect gameplay.
Make sure to read the guidelines and take this Changelog template out of the comment block in order for it to show up.
Changelog must have a :cl: symbol, so the bot recognizes the changes and adds them to the game's changelog.
Remove this symbol for non-player facing PRs.-->
🆑 
- fix: fixed TDF Bastion's back sprite not showing properly