### PR TITLE
Fix: Stop Atmos Devices Siphoning Gas Off Expedition Planets

### DIFF
--- a/Content.Server/Atmos/EntitySystems/AirFilterSystem.cs
+++ b/Content.Server/Atmos/EntitySystems/AirFilterSystem.cs
@@ -31,6 +31,11 @@ public sealed partial class AirFilterSystem : EntitySystem
         if (air.Pressure >= intake.Pressure)
             return;
 
+        // Triad: no gas extraction off the sector map
+        if (!_atmosphere.AtmosInputCanRunOnMap(args.Map))
+            return;
+        // End Triad
+
         var environment = _atmosphere.GetContainingMixture(uid, args.Grid, args.Map, true, true);
         // nothing to intake from
         if (environment == null)

--- a/Content.Server/Atmos/EntitySystems/AtmosphereSystem.CVars.cs
+++ b/Content.Server/Atmos/EntitySystems/AtmosphereSystem.CVars.cs
@@ -1,3 +1,4 @@
+using Content.Shared._Triad.CCVar; // Triad
 using Content.Shared.CCVar;
 using Robust.Shared.Configuration;
 
@@ -26,6 +27,7 @@ namespace Content.Server.Atmos.EntitySystems
         public float AtmosTickRate { get; private set; }
         public float Speedup { get; private set; }
         public float HeatScale { get; private set; }
+        public bool AllowMapGasExtraction { get; private set; } // Triad
 
         /// <summary>
         /// Time between each atmos sub-update.  If you are writing an atmos device, use AtmosDeviceUpdateEvent.dt
@@ -55,6 +57,7 @@ namespace Content.Server.Atmos.EntitySystems
             Subs.CVar(_cfg, CCVars.AtmosHeatScale, value => { HeatScale = value; InitializeGases(); }, true);
             Subs.CVar(_cfg, CCVars.ExcitedGroups, value => ExcitedGroups = value, true);
             Subs.CVar(_cfg, CCVars.ExcitedGroupsSpaceIsAllConsuming, value => ExcitedGroupsSpaceIsAllConsuming = value, true);
+            Subs.CVar(_cfg, TriadCCVars.AllowMapGasExtraction, value => AllowMapGasExtraction = value, true); // Triad
         }
     }
 }

--- a/Content.Server/Atmos/EntitySystems/AtmosphereSystem.Utils.cs
+++ b/Content.Server/Atmos/EntitySystems/AtmosphereSystem.Utils.cs
@@ -3,6 +3,7 @@ using Content.Server.Atmos.Components;
 using Content.Shared.Atmos;
 using Content.Shared.Atmos.Components;
 using Content.Shared.Atmos.Piping.Components;
+using Content.Shared.Shuttles.Components; // Triad
 using Robust.Shared.Map.Components;
 
 namespace Content.Server.Atmos.EntitySystems;
@@ -143,4 +144,20 @@ public partial class AtmosphereSystem
             RaiseLocalEvent(uid, ref ev);
         }
     }
+
+    // Triad: cherry-pick of NF PR #3061 — no atmos extraction off the sector map
+    /// <summary>
+    /// Checks whether atmos devices that pull gas out of their surroundings are allowed to run on
+    /// the given map. Expedition and other side maps are off limits, because their atmosphere is
+    /// an infinite source: a ship parked on a planet could siphon gas forever for free.
+    /// </summary>
+    /// <param name="mapUid">The map the device is on, from <see cref="AtmosDeviceUpdateEvent.Map"/>.</param>
+    public bool AtmosInputCanRunOnMap(EntityUid? mapUid)
+    {
+        if (!TryComp<MapComponent>(mapUid, out var mapComp))
+            return false;
+
+        return AllowMapGasExtraction || HasComp<FTLMapComponent>(mapUid) || mapComp.MapId == _gameTicker.DefaultMap;
+    }
+    // End Triad
 }

--- a/Content.Server/Atmos/EntitySystems/AtmosphereSystem.cs
+++ b/Content.Server/Atmos/EntitySystems/AtmosphereSystem.cs
@@ -2,6 +2,7 @@ using Content.Server.Administration.Logs;
 using Content.Server.Atmos.Components;
 using Content.Server.Body.Systems;
 using Content.Server.Fluids.EntitySystems;
+using Content.Server.GameTicking; // Triad
 using Content.Server.NodeContainer.EntitySystems;
 using Content.Shared.Atmos.EntitySystems;
 using Content.Shared.Decals;
@@ -36,6 +37,7 @@ public sealed partial class AtmosphereSystem : SharedAtmosphereSystem
     [Dependency] private TileSystem _tile = default!;
     [Dependency] private MapSystem _map = default!;
     [Dependency] public PuddleSystem Puddle = default!;
+    [Dependency] private GameTicker _gameTicker = default!; // Triad: sector map lookup for AtmosInputCanRunOnMap
 
     private const float ExposedUpdateDelay = 1f;
     private float _exposedTimer = 0f;

--- a/Content.Server/Atmos/Piping/Unary/EntitySystems/GasPassiveVentSystem.cs
+++ b/Content.Server/Atmos/Piping/Unary/EntitySystems/GasPassiveVentSystem.cs
@@ -24,6 +24,11 @@ namespace Content.Server.Atmos.Piping.Unary.EntitySystems
 
         private void OnPassiveVentUpdated(EntityUid uid, GasPassiveVentComponent vent, ref AtmosDeviceUpdateEvent args)
         {
+            // Triad: no gas extraction off the sector map
+            if (!_atmosphereSystem.AtmosInputCanRunOnMap(args.Map))
+                return;
+            // End Triad
+
             var environment = _atmosphereSystem.GetContainingMixture(uid, args.Grid, args.Map, true, true);
 
             if (environment == null)

--- a/Content.Server/Atmos/Piping/Unary/EntitySystems/GasVentPumpSystem.cs
+++ b/Content.Server/Atmos/Piping/Unary/EntitySystems/GasVentPumpSystem.cs
@@ -85,6 +85,11 @@ namespace Content.Server.Atmos.Piping.Unary.EntitySystems
                 return;
             }
 
+            // Triad: no gas extraction off the sector map
+            if (!_atmosphereSystem.AtmosInputCanRunOnMap(args.Map))
+                return;
+            // End Triad
+
             var environment = _atmosphereSystem.GetContainingMixture(uid, args.Grid, args.Map, true, true);
 
             // We're in an air-blocked tile... Do nothing.

--- a/Content.Server/Atmos/Piping/Unary/EntitySystems/GasVentScrubberSystem.cs
+++ b/Content.Server/Atmos/Piping/Unary/EntitySystems/GasVentScrubberSystem.cs
@@ -66,6 +66,11 @@ namespace Content.Server.Atmos.Piping.Unary.EntitySystems
             if (args.Grid is not {} grid)
                 return;
 
+            // Triad: no gas extraction off the sector map
+            if (!_atmosphereSystem.AtmosInputCanRunOnMap(args.Map))
+                return;
+            // End Triad
+
             var position = _transformSystem.GetGridTilePositionOrDefault(uid);
             var environment = _atmosphereSystem.GetTileMixture(grid, args.Map, position, true);
 

--- a/Content.Server/Atmos/Portable/PortableScrubberSystem.cs
+++ b/Content.Server/Atmos/Portable/PortableScrubberSystem.cs
@@ -75,6 +75,15 @@ namespace Content.Server.Atmos.Portable
             if (args.Grid is not {} grid)
                 return;
 
+            // Triad: no gas extraction off the sector map. Sits below the connector-port block on
+            // purpose, so a full scrubber can still be drained into a pipe net while planetside.
+            if (!_atmosphereSystem.AtmosInputCanRunOnMap(args.Map))
+            {
+                UpdateAppearance(uid, false, false);
+                return;
+            }
+            // End Triad
+
             var position = _transformSystem.GetGridTilePositionOrDefault(uid);
             var environment = _atmosphereSystem.GetTileMixture(grid, args.Map, position, true);
 

--- a/Content.Shared/_Triad/CCVar/CCVars.Triad.cs
+++ b/Content.Shared/_Triad/CCVar/CCVars.Triad.cs
@@ -45,4 +45,13 @@ public sealed class TriadCCVars
 
     public static readonly CVarDef<string> NightVisionColor =
         CVarDef.Create("triad.night_vision_color", "#00FF00", CVar.CLIENTONLY | CVar.ARCHIVE, "The tint/phosphor color of night vision.");
+
+    // Triad: atmos
+    /// <summary>
+    /// Whether atmos input devices (scrubbers, siphoning vents, passive vents, intakes) may pull gas
+    /// out of a map's own atmosphere. Off by default, which limits them to the sector map and ships
+    /// in FTL, so expedition planets can no longer be drained for free gas.
+    /// </summary>
+    public static readonly CVarDef<bool> AllowMapGasExtraction =
+        CVarDef.Create("triad.atmos.allow_map_gas_extraction", false, CVar.SERVER | CVar.REPLICATED);
 }


### PR DESCRIPTION
## About the PR
Gates every atmos device that pulls gas out of its surroundings behind a new `AtmosInputCanRunOnMap` check: vent scrubbers, siphoning vent pumps, passive vents, portable scrubbers and air intakes. They keep working on the sector map and on ships in FTL, and idle everywhere else, which in practice means expedition planets.

## Why / Balance
A planet's atmosphere is an infinite source. Park an exped ship, build a scrubber chamber, wait out the timer, and that's a six-figure gas haul with nothing at stake and nothing to lose.

The discussion on #44 is worth reading before this merges, because there was real disagreement. The counter-proposals were all price and ratio tuning, which we can still do on top of this; they address how much the loop pays but not that it exists as a parallel to asteroid gas mining that requires no setup. Frontier and Coyote both run with this removal.

The gate is deliberately blunt, and this is the part with a cost. It sits above the release/siphon branch in the vent pump, so a ship landed on a planet can't repressurise its own rooms from its pipe net either. A grid-only carve-out was the obvious alternative and it doesn't hold: planet air walks onto the grid through any open airlock, so gating only map tiles is defeated by propping a door. Air grenades and canisters cover the refill case in the meantime. The one carve-out that is safe, and that I added on top of the Frontier version, is the portable scrubber, whose gate sits below the connector-port block so a full unit can still be drained into a pipe net planetside.

`triad.atmos.allow_map_gas_extraction` turns the old behaviour back on server-wide if we build a real planetary-collection loop to hang it off later.

## Media
N/A, no visual changes.

## Requirements
- [x] I have read the guidelines and documentation relevant to this PR.
- [x] I have added media to this PR or it does not require an ingame showcase.
- [x] I can confirm this PR contains either no AI-generated content, or AI-generated content that meets our guidelines.

## How to test
1. Run an expedition, land, and turn on scrubbers or siphoning vents. Pipe net should stay empty and the planet's pressure should hold.
2. Do the same on the sector map. Scrubbers, vents and intakes behave exactly as before.
3. Set `triad.atmos.allow_map_gas_extraction 1` and repeat step 1. Siphoning works again.
4. Fill a portable scrubber on the sector map, fly to a planet, drop it on a connector port. It should still empty into the pipe net.
5. Scrub while in FTL. Should still work, since FTL maps are exempt.

## Breaking changes
None. New public method `AtmosphereSystem.AtmosInputCanRunOnMap` and new CVar `triad.atmos.allow_map_gas_extraction`; nothing renamed or removed.

**Changelog**
:cl:
- remove: Atmos devices can no longer siphon gas out of an expedition planet's atmosphere. Asteroid gas deposits are unaffected.
