### PR TITLE
Fixes Kur/The Dark/Xen Bread --> Removes Antigravity Launch From Cutting Bread to Slices

### DIFF
--- a/Resources/Prototypes/Entities/Objects/Consumable/Food/Baked/bread.yml
+++ b/Resources/Prototypes/Entities/Objects/Consumable/Food/Baked/bread.yml
@@ -2,7 +2,7 @@
 # Base
 
 - type: entity
-  parent: [ FoodInjectableBase, LaunchableProjectileBase ] # Frontier: added LaunchableProjectileBase, located in \Resources\Prototypes\_NF\Entities\Objects\Weapons\Guns\Projectiles\base_projectiles.yml
+  parent: [ FoodInjectableBase ] # Triad Removed LaunchableProjectileBase as this applies antigravity to bread slices
   id: FoodBreadBase
   abstract: true
   components:


### PR DESCRIPTION
## About the PR
Apparently LaunchableProjectileBase makes any bread slices levitate and be launched when a full bread is cut. Though this did give me some ideas for Shadekin Cuisine later.. Ohno..

## Why / Balance
Antigravity bread is some really weird unexpected behavior

## Media
n/A

## Requirements
<!-- Confirm the following by placing an X in the brackets [X]: -->
- [X] I have read the guidelines and documentation relevant to this PR.
- [X] I have added media to this PR or it does not require an ingame showcase.
- [X] I can confirm this PR contains either no AI-generated content, or AI-generated content that meets our guidelines.
<!-- You should understand that not following the above may get your PR closed at maintainer’s discretion -->
<!-- When using AI, make sure you are already proficient in creating whatever content you are attempting to generate and that you already have experience contributing to SS14. This means using AI to enhance your preexisting workflow, not vibecoding. -->

## How to test
Get bread, cut it, note a lack of anteverse wheat in its flour and thus no antigravity components being applied to it.

## Breaking changes
None

**Changelog**
:cl:
- fix: Bread is no longer made from ingredients coming from Kur/The Dark/Xen and thus no longer levitates when cut. In other words bread slices dont float down here.
