### PR TITLE
Publish on Push to Main, with a Duplicate-Version Preflight

### DIFF
--- a/.github/workflows/publish.yml
+++ b/.github/workflows/publish.yml
@@ -1,14 +1,65 @@
 name: Publish
 
+# Triad: this workflow uploads build artifacts to Robust.Cdn and does nothing else.
+# It MUST NOT call the SS14.Watchdog API (/instances/*/update, /instances/*/restart).
+# Deploy timing belongs to the server: the CDN notifies the watchdog, the watchdog
+# notifies the game, and ServerUpdateManager only shuts down from inside
+# GameTicker.RestartRound (Content.Server/GameTicking/GameTicker.RoundFlow.cs). That is
+# what guarantees a published build lands at a round boundary and never mid-round.
+# A watchdog call added here would cut a live round short.
+
 on:
   workflow_dispatch:
   # Frontier: re-enabled autopublish bawk
+  # Triad: Frontier's autopublish is a daily cron; Monolith dropped the cron and kept
+  # only the comment, which is what we inherited. Push trigger instead: restart cadence
+  # is capped by round end either way, so publishing per merge costs no extra restarts
+  # and keeps the newest main staged for the next boundary.
+  push:
+    branches: [ main ]
 
+# Triad: no cancel-in-progress on purpose, though upstream sets it. Cancelling between
+# publish/start and publish/finish strands a half-open version on Robust.Cdn that 409s
+# on every later attempt at that SHA. A queued run is cheap; a poisoned version is not.
 concurrency:
   group: publish
 
 jobs:
+  # Triad: Robust.Cdn answers 409 for a version it already holds, so a re-run on an
+  # unchanged SHA fails the whole workflow. Check first and skip cleanly: a pipeline that
+  # goes red on a routine no-op teaches us to ignore red.
+  preflight:
+    runs-on: ubuntu-latest
+    outputs:
+      should_publish: ${{ steps.check.outputs.should_publish }}
+
+    steps:
+    # Keep this URL in step with ROBUST_CDN_URL/FORK_ID in Tools/publish_multi_request.py.
+    - name: Check whether this commit is already published
+      id: check
+      run: |
+        # Assign-then-override rather than `|| echo`: curl emits %{http_code} once per
+        # retry attempt, so a fallback inside the substitution concatenates onto it.
+        code=$(curl -sS -o /dev/null -w '%{http_code}' \
+          --retry 3 --retry-delay 5 --max-time 30 \
+          "https://cdn.triad-sector.com/fork/Triad/version/${GITHUB_SHA}/manifest") || code="000"
+        case "$code" in
+          404)
+            echo "should_publish=true" >> "$GITHUB_OUTPUT"
+            ;;
+          200)
+            echo "should_publish=false" >> "$GITHUB_OUTPUT"
+            echo "::notice::${GITHUB_SHA} is already on the CDN; skipping publish."
+            ;;
+          *)
+            echo "::error::Unexpected HTTP ${code} from Robust.Cdn. Refusing to guess whether this version exists."
+            exit 1
+            ;;
+        esac
+
   build:
+    needs: preflight
+    if: needs.preflight.outputs.should_publish == 'true'
     runs-on: ubuntu-latest
 
     steps:


### PR DESCRIPTION
## About the PR
Publishing now triggers on push to `main` instead of needing a manual dispatch, and a
preflight job skips the run when Robust.Cdn already holds the commit's SHA.

## Why / Balance
No balance impact, CI only.

The `on:` block was `workflow_dispatch` only, sitting under a comment claiming autopublish
was enabled. Frontier does run a daily cron; Monolith dropped the cron and kept the comment,
and that comment is what we inherited. So every publish needed someone to remember.

Separately, Robust.Cdn keys versions on the commit SHA and answers 409 for one it already
holds, so a re-dispatch on an unchanged HEAD fails the workflow. That happened twice on
2026-08-10 (runs 31408509591 and 31410034917) after the same SHA published successfully at
16:05. A pipeline that goes red on a routine no-op teaches us to ignore red.

Push trigger rather than a cron because restart cadence is capped by round end either way.
`ServerUpdateManager` only shuts the server down from inside `GameTicker.RestartRound`, so
multiple publishes between two round boundaries collapse into a single restart and the
watchdog resolves the manifest when it relaunches. Publishing per merge therefore costs no
extra server restarts and keeps the freshest `main` staged for the next boundary.

Two deliberate divergences from upstream, both commented in the file:

- No `cancel-in-progress` on the concurrency group, though upstream sets it. Cancelling
  between `publish/start` and `publish/finish` strands a half-open version that 409s on
  every later attempt at that SHA. A queued run is cheap, a poisoned version is not.
- The preflight fails hard on any status other than 200/404 instead of defaulting to skip.
  A silent skip during a CDN outage is indistinguishable from "nothing to do", which is the
  worst possible failure mode for a deploy path.

The header comment records the invariant the pipeline rests on: this workflow uploads to the
CDN and must never call the watchdog API. Deploy timing belongs to the server, and that is
what keeps a publish from ever interrupting a live round.

## Media
Not applicable, CI only.

## Requirements
- [x] I have read the guidelines and documentation relevant to this PR.
- [x] I have added media to this PR or it does not require an ingame showcase.
- [x] I can confirm this PR contains either no AI-generated content, or AI-generated content that meets our guidelines.

## How to test
The preflight step was run against the live CDN before commit, covering all three branches:

| Input | Result |
| --- | --- |
| `17b3ced7...`, already published | HTTP 200, `should_publish=false`, skip notice |
| unpublished SHA | HTTP 404, `should_publish=true` |
| CDN unreachable | HTTP 000, hard fail, exit 1 |

The job-level `needs`/`if` wiring is not exercised until this lands, since a real run
publishes. On the first Publish run after merge, confirm `preflight` reports
`should_publish=true` and that `build` actually runs rather than showing as skipped. On the
run after that, with `main` unmoved, confirm it reports the skip notice and stays green
instead of 409-ing.

## Breaking changes
None. No prototype, namespace, or public API changes.
