### PR TITLE
Stop the Map Renderer Reporting Itself as "Build & Test Debug"

### DIFF
--- a/.github/workflows/build-map-renderer.yml
+++ b/.github/workflows/build-map-renderer.yml
@@ -52,7 +52,13 @@ jobs:
         run: dotnet run --project Content.MapRenderer Dev
 
   ci-success:
-    name: Build & Test Debug
+    # Triad: this aggregator was named after a different workflow. GitHub matches required
+    # status checks by name, so two workflows publishing "Build & Test Debug" means the
+    # requirement can be satisfied by whichever reports first, and a genuine test failure
+    # can be masked by the map renderer passing. Still wrong in wizden, frontier and
+    # monolith as of 2026-08-10, so expect this line to conflict on merges.
+    #name: Build & Test Debug # Triad: removed, collided with build-test-debug.yml
+    name: Build & Test Map Renderer
     needs:
       - build
     runs-on: ubuntu-latest


### PR DESCRIPTION
## About the PR
Renames the `ci-success` aggregator in `build-map-renderer.yml` so it stops reporting itself as `Build & Test Debug`, which is the aggregator name belonging to `build-test-debug.yml`.

## Why / Balance
No balance impact, CI only.

GitHub matches required status checks by name. Both workflows were publishing a check called `Build & Test Debug`, so requiring that name lets the map renderer satisfy the requirement meant for the test lane, and a genuine test failure can be masked by an unrelated workflow passing. This is a prerequisite for turning required status checks on, not a cosmetic rename.

Audited the rest of the check-name surface while here. The remaining duplicates are benign and deliberately left alone:

- `build (matrix)` across the three build workflows, and `build` across the publish workflows, are unnamed jobs that nobody would select as a required check. Avoiding exactly that is why the `ci-success` aggregator pattern exists.
- `add_label` across five labeler workflows are label bots on `pull_request_target`.

After this change each aggregator maps to exactly one workflow: `Build & Test Debug`, `Build & Test Map Renderer`, `Build & Run Shipyard Tests`, `Test Packaging`, `YAML Linter`, `Validate RSIs`.

Still wrong upstream in wizden, frontier and monolith as of 2026-08-10, so this line is expected to conflict on future merges. The upstream line is commented rather than deleted so that conflict surfaces instead of silently reverting.

## Media
Not applicable, CI only.

## Requirements
- [x] I have read the guidelines and documentation relevant to this PR.
- [x] I have added media to this PR or it does not require an ingame showcase.
- [x] I can confirm this PR contains either no AI-generated content, or AI-generated content that meets our guidelines.

## How to test
Check names are static YAML, so verification is reading the check list rendered on this PR. The map renderer's aggregator should report as `Build & Test Map Renderer`, and `Build & Test Debug` should appear exactly once.

## Breaking changes
None. If branch protection currently requires `Build & Test Debug`, it keeps working, because `build-test-debug.yml` still publishes that name. Only the duplicate goes away.
