### PR TITLE
CI Hygiene: Skip the Changelog Bot, Cap Job Runtime, Keep Test Results, Bump Actions

### DIFF
--- a/.github/workflows/benchmarks.yml
+++ b/.github/workflows/benchmarks.yml
@@ -11,7 +11,7 @@ jobs:
     name: Run Benchmarks
     runs-on: ubuntu-latest
     steps:
-    - uses: actions/checkout@v4.2.2
+    - uses: actions/checkout@v7
       with:
         submodules: 'recursive'
     - name: Get Engine version

--- a/.github/workflows/build-map-renderer.yml
+++ b/.github/workflows/build-map-renderer.yml
@@ -8,18 +8,21 @@ on:
     types: [ opened, reopened, synchronize, ready_for_review ]
     branches: [ main, staging, stable ]
 
+# Triad: key PR runs on PR number; never cancel a merge_group run, which fails the queue.
 concurrency:
-  group: ${{ github.workflow }}-${{ github.ref }}
-  cancel-in-progress: true
+  group: ${{ github.workflow }}-${{ github.event_name == 'pull_request' && github.event.pull_request.number || github.ref }}
+  cancel-in-progress: ${{ github.event_name != 'merge_group' }}
 
 jobs:
   build:
-    if: github.event.pull_request.draft == false
+    # Triad: skip the changelog bot's Resources/Changelog-only pushes to main.
+    if: github.event.pull_request.draft == false && github.actor != 'Triad-Sector'
     strategy:
       matrix:
         os: [ubuntu-latest]
 
     runs-on: ${{ matrix.os }}
+    timeout-minutes: 20 # Triad: job takes ~7m.
 
     steps:
       - name: Checkout Master

--- a/.github/workflows/build-map-renderer.yml
+++ b/.github/workflows/build-map-renderer.yml
@@ -26,7 +26,7 @@ jobs:
 
     steps:
       - name: Checkout Master
-        uses: actions/checkout@v4.2.2
+        uses: actions/checkout@v7
 
       - name: Setup Submodule
         run: |
@@ -41,7 +41,7 @@ jobs:
           git submodule update --init --recursive
 
       - name: Setup .NET Core
-        uses: actions/setup-dotnet@v4.1.0
+        uses: actions/setup-dotnet@v5
         with:
           dotnet-version: 10.0.x
 

--- a/.github/workflows/build-test-debug.yml
+++ b/.github/workflows/build-test-debug.yml
@@ -29,7 +29,7 @@ jobs:
 
     steps:
     - name: Checkout Master
-      uses: actions/checkout@v4.2.2
+      uses: actions/checkout@v7
 
     - name: Setup Submodule
       run: |
@@ -44,7 +44,7 @@ jobs:
         git submodule update --init --recursive
 
     - name: Setup .NET Core
-      uses: actions/setup-dotnet@v4.1.0
+      uses: actions/setup-dotnet@v5
       with:
         dotnet-version: 10.0.x
 

--- a/.github/workflows/build-test-debug.yml
+++ b/.github/workflows/build-test-debug.yml
@@ -1,8 +1,10 @@
 name: Build & Test Debug
 
+# Triad: key PR runs on the PR number rather than the ref, and never cancel a merge_group
+# run. Cancelling a merge queue entry fails the queue rather than superseding it.
 concurrency:
-  group: ${{ github.workflow }}-${{ github.ref }}
-  cancel-in-progress: true
+  group: ${{ github.workflow }}-${{ github.event_name == 'pull_request' && github.event.pull_request.number || github.ref }}
+  cancel-in-progress: ${{ github.event_name != 'merge_group' }}
 
 on:
   push:
@@ -14,12 +16,16 @@ on:
 
 jobs:
   build:
-    if: github.event.pull_request.draft == false
+    # Triad: skip the changelog bot. It pushes a Resources/Changelog-only commit straight to
+    # main after every merge, which was firing all seven push-triggered workflows for a file
+    # no test reads. Same shape as the inherited PJBot/FrontierATC guard in validate-rgas.yml.
+    if: github.event.pull_request.draft == false && github.actor != 'Triad-Sector'
     strategy:
       matrix:
         os: [ubuntu-latest]
 
     runs-on: ${{ matrix.os }}
+    timeout-minutes: 30 # Triad: this job takes ~10m; without a cap a hung test burns the 6h runner ceiling.
 
     steps:
     - name: Checkout Master
@@ -48,14 +54,26 @@ jobs:
     - name: Build Project
       run: dotnet build --configuration DebugOpt --no-restore /p:WarningsAsErrors=nullable /m
 
+    # Triad: NUnit.TestOutputXml/WorkDirectory restored (upstream has them, we had dropped
+    # them). With NUnit.ConsoleOut=0 and no XML, a failed CI run left nothing to triage from.
     - name: Run Content.Tests
-      run: dotnet test --no-build --configuration DebugOpt Content.Tests/Content.Tests.csproj -- NUnit.ConsoleOut=0
+      run: dotnet test --no-build --configuration DebugOpt Content.Tests/Content.Tests.csproj -- NUnit.ConsoleOut=0 NUnit.TestOutputXml="logs" NUnit.WorkDirectory="$(pwd)/test_results"
 
     - name: Run Content.IntegrationTests
       shell: pwsh
       run: |
         $env:DOTNET_gcServer=1
-        dotnet test --no-build --configuration DebugOpt Content.IntegrationTests/Content.IntegrationTests.csproj --filter "FullyQualifiedName!~ShipyardTest" -- NUnit.ConsoleOut=0 NUnit.MapWarningTo=Failed
+        dotnet test --no-build --configuration DebugOpt Content.IntegrationTests/Content.IntegrationTests.csproj --filter "FullyQualifiedName!~ShipyardTest" -- NUnit.ConsoleOut=0 NUnit.MapWarningTo=Failed NUnit.TestOutputXml="logs" NUnit.WorkDirectory="$(pwd)/test_results"
+
+    # Triad: `if: always()` on purpose. The failing run is the one whose results we want.
+    - name: Archive NUnit3 test results.
+      if: always()
+      uses: actions/upload-artifact@v4
+      with:
+        name: nunit3-results-${{ matrix.os }}
+        path: test_results/*
+        retention-days: 7
+        compression-level: 9
   ci-success:
     name: Build & Test Debug
     needs:

--- a/.github/workflows/changelog.yml
+++ b/.github/workflows/changelog.yml
@@ -17,7 +17,7 @@ jobs:
       contents: write
     steps:
       - name: Checkout Base Branch # Mono
-        uses: actions/checkout@v3
+        uses: actions/checkout@v7
         with:
           token: ${{ secrets.BOT_TOKEN }}
           ref: "${{ github.event.pull_request.base.ref }}" # Mono
@@ -29,7 +29,7 @@ jobs:
         shell: bash
 
       - name: Setup Node
-        uses: actions/setup-node@v3
+        uses: actions/setup-node@v4
         with:
           node-version: 18.x
 

--- a/.github/workflows/check-crlf.yml
+++ b/.github/workflows/check-crlf.yml
@@ -14,6 +14,6 @@ jobs:
     if: github.event.pull_request.draft == false
     runs-on: ubuntu-latest
     steps:
-    - uses: actions/checkout@v4.2.2
+    - uses: actions/checkout@v7
     - name: Check for CRLF
       run: Tools/check_crlf.py

--- a/.github/workflows/nf-mapchecker.yml
+++ b/.github/workflows/nf-mapchecker.yml
@@ -24,9 +24,9 @@ jobs:
     runs-on: ubuntu-latest
 
     steps:
-    - uses: actions/checkout@v3
+    - uses: actions/checkout@v7
     - name: Set up Python 3.10
-      uses: actions/setup-python@v3
+      uses: actions/setup-python@v5
       with:
         python-version: "3.10"
     - name: Install dependencies

--- a/.github/workflows/nf-shipyard-tests.yml
+++ b/.github/workflows/nf-shipyard-tests.yml
@@ -27,7 +27,7 @@ jobs:
 
     steps:
     - name: Checkout Master
-      uses: actions/checkout@v4.2.2
+      uses: actions/checkout@v7
 
     - name: Setup Submodule
       run: |
@@ -42,7 +42,7 @@ jobs:
         git submodule update --init --recursive
 
     - name: Setup .NET Core
-      uses: actions/setup-dotnet@v4.1.0
+      uses: actions/setup-dotnet@v5
       with:
         dotnet-version: 10.0.x
 

--- a/.github/workflows/nf-shipyard-tests.yml
+++ b/.github/workflows/nf-shipyard-tests.yml
@@ -9,6 +9,12 @@ on:
       - "Content.IntegrationTests/Tests/_NF/ShipyardTests.cs" # Shipyard tests
       - "Resources/Prototypes/Entities/**/*.yml" # Mono Change, run when an entity may have changed price
 
+# Triad: this workflow had no concurrency group, so pushing twice to a PR ran both to
+# completion. PR-triggered only, so no merge_group case to worry about here.
+concurrency:
+  group: ${{ github.workflow }}-${{ github.event_name == 'pull_request' && github.event.pull_request.number || github.ref }}
+  cancel-in-progress: ${{ github.event_name != 'merge_group' }}
+
 jobs:
   build:
     if: github.event.pull_request.draft == false
@@ -17,6 +23,7 @@ jobs:
         os: [ubuntu-latest]
 
     runs-on: ${{ matrix.os }}
+    timeout-minutes: 30 # Triad: builds the whole project before testing.
 
     steps:
     - name: Checkout Master
@@ -49,7 +56,18 @@ jobs:
       shell: pwsh
       run: |
         $env:DOTNET_gcServer=1
-        dotnet test --no-build --configuration DebugOpt Content.IntegrationTests/Content.IntegrationTests.csproj --filter FullyQualifiedName~ShipyardTest -- NUnit.ConsoleOut=0 NUnit.MapWarningTo=Failed
+        dotnet test --no-build --configuration DebugOpt Content.IntegrationTests/Content.IntegrationTests.csproj --filter FullyQualifiedName~ShipyardTest -- NUnit.ConsoleOut=0 NUnit.MapWarningTo=Failed NUnit.TestOutputXml="logs" NUnit.WorkDirectory="$(pwd)/test_results"
+
+    # Triad: shipyard failures are usually a per-ship price mismatch, which is unreadable
+    # without the per-test XML.
+    - name: Archive NUnit3 test results.
+      if: always()
+      uses: actions/upload-artifact@v4
+      with:
+        name: nunit3-results-shipyard-${{ matrix.os }}
+        path: test_results/*
+        retention-days: 7
+        compression-level: 9
   ci-success:
     name: Build & Run Shipyard Tests
     needs:

--- a/.github/workflows/prtitlecase.yml
+++ b/.github/workflows/prtitlecase.yml
@@ -12,12 +12,12 @@ jobs:
     runs-on: ubuntu-latest
     steps:
       - name: Checkout Master
-        uses: actions/checkout@v3
+        uses: actions/checkout@v7
         with:
           token: ${{ secrets.BOT_TOKEN }}
 
       - name: Setup Node
-        uses: actions/setup-node@v3
+        uses: actions/setup-node@v4
         with:
           node-version: 18.x
 

--- a/.github/workflows/publish-changelog.yml
+++ b/.github/workflows/publish-changelog.yml
@@ -12,7 +12,7 @@ jobs:
     steps:
 
     - name: checkout
-      uses: actions/checkout@v3
+      uses: actions/checkout@v7
       with:
         token: ${{secrets.GITHUB_TOKEN}}
         ref: main

--- a/.github/workflows/publish-testing.yml
+++ b/.github/workflows/publish-testing.yml
@@ -13,11 +13,11 @@ jobs:
     runs-on: ubuntu-latest
 
     steps:
-    - uses: actions/checkout@v4.2.2
+    - uses: actions/checkout@v7
       with:
         submodules: 'recursive'
     - name: Setup .NET Core
-      uses: actions/setup-dotnet@v4.1.0
+      uses: actions/setup-dotnet@v5
       with:
         dotnet-version: 10.0.x
 

--- a/.github/workflows/publish.yml
+++ b/.github/workflows/publish.yml
@@ -66,11 +66,11 @@ jobs:
     - name: Install dependencies
       run: sudo apt-get install -y python3-paramiko python3-lxml
 
-    - uses: actions/checkout@v4.2.2
+    - uses: actions/checkout@v7
       with:
         submodules: 'recursive'
     - name: Setup .NET Core
-      uses: actions/setup-dotnet@v4.1.0
+      uses: actions/setup-dotnet@v5
       with:
         dotnet-version: 10.0.x
 

--- a/.github/workflows/rsi-diff.yml
+++ b/.github/workflows/rsi-diff.yml
@@ -15,7 +15,7 @@ jobs:
     runs-on: ubuntu-latest
     steps:
       - name: Checkout
-        uses: actions/checkout@v4.2.2
+        uses: actions/checkout@v7
 
       - name: Get changed files
         id: files

--- a/.github/workflows/test-packaging.yml
+++ b/.github/workflows/test-packaging.yml
@@ -26,15 +26,18 @@ on:
       - 'RobustToolbox'
       - 'RobustToolbox/**'
 
+# Triad: key PR runs on PR number; never cancel a merge_group run, which fails the queue.
 concurrency:
-  group: ${{ github.workflow }}-${{ github.ref }}
-  cancel-in-progress: true
+  group: ${{ github.workflow }}-${{ github.event_name == 'pull_request' && github.event.pull_request.number || github.ref }}
+  cancel-in-progress: ${{ github.event_name != 'merge_group' }}
 
 jobs:
   build:
     name: Test Packaging
-    if: github.event.pull_request.draft == false
+    # Triad: skip the changelog bot's Resources/Changelog-only pushes to main.
+    if: github.event.pull_request.draft == false && github.actor != 'Triad-Sector'
     runs-on: ubuntu-latest
+    timeout-minutes: 30 # Triad: job takes ~10m.
 
     steps:
       - name: Checkout Master

--- a/.github/workflows/test-packaging.yml
+++ b/.github/workflows/test-packaging.yml
@@ -41,7 +41,7 @@ jobs:
 
     steps:
       - name: Checkout Master
-        uses: actions/checkout@v4.2.2
+        uses: actions/checkout@v7
 
       - name: Setup Submodule
         run: |
@@ -56,7 +56,7 @@ jobs:
           git submodule update --init --recursive
 
       - name: Setup .NET Core
-        uses: actions/setup-dotnet@v4.1.0
+        uses: actions/setup-dotnet@v5
         with:
           dotnet-version: 10.0.x
 

--- a/.github/workflows/update-credits.yml
+++ b/.github/workflows/update-credits.yml
@@ -13,7 +13,7 @@ jobs:
     if: github.repository == 'Monolith-Station/Monolith' # Mono: space-wizards/space-station-14 > Monolith-Station/Monolith
 
     steps:
-      - uses: actions/checkout@v4.2.2
+      - uses: actions/checkout@v7
         with:
           ref: main
 

--- a/.github/workflows/validate-rgas.yml
+++ b/.github/workflows/validate-rgas.yml
@@ -6,15 +6,17 @@ on:
   pull_request:
     types: [ opened, reopened, synchronize, ready_for_review ]
 
+# Triad: key PR runs on PR number; never cancel a merge_group run, which fails the queue.
 concurrency:
-  group: ${{ github.workflow }}-${{ github.ref }}
-  cancel-in-progress: true
+  group: ${{ github.workflow }}-${{ github.event_name == 'pull_request' && github.event.pull_request.number || github.ref }}
+  cancel-in-progress: ${{ github.event_name != 'merge_group' }}
 
 jobs:
   yaml-schema-validation:
     name: YAML RGA schema validator
-    if: github.actor != 'PJBot' && github.event.pull_request.draft == false && github.actor != 'FrontierATC' # Frontier
+    if: github.actor != 'PJBot' && github.event.pull_request.draft == false && github.actor != 'FrontierATC' && github.actor != 'Triad-Sector' # Frontier; Triad: our changelog bot
     runs-on: ubuntu-latest
+    timeout-minutes: 15 # Triad: job takes ~1m.
     steps:
     - uses: actions/checkout@v4.2.2
     - name: Setup Submodule

--- a/.github/workflows/validate-rgas.yml
+++ b/.github/workflows/validate-rgas.yml
@@ -18,7 +18,7 @@ jobs:
     runs-on: ubuntu-latest
     timeout-minutes: 15 # Triad: job takes ~1m.
     steps:
-    - uses: actions/checkout@v4.2.2
+    - uses: actions/checkout@v7
     - name: Setup Submodule
       run: git submodule update --init
     - name: Pull engine updates

--- a/.github/workflows/validate-rsis.yml
+++ b/.github/workflows/validate-rsis.yml
@@ -8,14 +8,18 @@ on:
     paths:
       - '**.rsi/**'
 
+# Triad: key PR runs on PR number; never cancel a merge_group run, which fails the queue.
 concurrency:
-  group: ${{ github.workflow }}-${{ github.ref }}
-  cancel-in-progress: true
+  group: ${{ github.workflow }}-${{ github.event_name == 'pull_request' && github.event.pull_request.number || github.ref }}
+  cancel-in-progress: ${{ github.event_name != 'merge_group' }}
 
 jobs:
   validate_rsis:
     name: Validate RSIs
+    # Triad: skip the changelog bot's Resources/Changelog-only pushes to main.
+    if: github.actor != 'Triad-Sector'
     runs-on: ubuntu-latest
+    timeout-minutes: 15 # Triad: job takes ~1m.
     steps:
       - uses: actions/checkout@v4.2.2
       - name: Setup Submodule

--- a/.github/workflows/validate-rsis.yml
+++ b/.github/workflows/validate-rsis.yml
@@ -21,13 +21,13 @@ jobs:
     runs-on: ubuntu-latest
     timeout-minutes: 15 # Triad: job takes ~1m.
     steps:
-      - uses: actions/checkout@v4.2.2
+      - uses: actions/checkout@v7
       - name: Setup Submodule
         run: git submodule update --init
       - name: Pull engine updates
         uses: space-wizards/submodule-dependency@v0.1.5
       - name: Set up Python 3.10 # Frontier
-        uses: actions/setup-python@v3 # Frontier
+        uses: actions/setup-python@v5 # Frontier
         with: # Frontier
           python-version: "3.10" # Frontier
       - name: Install Python dependencies

--- a/.github/workflows/validate_mapfiles.yml
+++ b/.github/workflows/validate_mapfiles.yml
@@ -6,15 +6,18 @@ on:
   pull_request:
     types: [ opened, reopened, synchronize, ready_for_review ]
 
+# Triad: key PR runs on PR number; never cancel a merge_group run, which fails the queue.
 concurrency:
-  group: ${{ github.workflow }}-${{ github.ref }}
-  cancel-in-progress: true
+  group: ${{ github.workflow }}-${{ github.event_name == 'pull_request' && github.event.pull_request.number || github.ref }}
+  cancel-in-progress: ${{ github.event_name != 'merge_group' }}
 
 jobs:
   yaml-schema-validation:
     name: YAML map schema validator
-    if: github.event.pull_request.draft == false
+    # Triad: skip the changelog bot's Resources/Changelog-only pushes to main.
+    if: github.event.pull_request.draft == false && github.actor != 'Triad-Sector'
     runs-on: ubuntu-latest
+    timeout-minutes: 15 # Triad: job takes ~3m.
     steps:
     - uses: actions/checkout@v4.2.2
     - name: Setup Submodule

--- a/.github/workflows/validate_mapfiles.yml
+++ b/.github/workflows/validate_mapfiles.yml
@@ -19,7 +19,7 @@ jobs:
     runs-on: ubuntu-latest
     timeout-minutes: 15 # Triad: job takes ~3m.
     steps:
-    - uses: actions/checkout@v4.2.2
+    - uses: actions/checkout@v7
     - name: Setup Submodule
       run: git submodule update --init
     - name: Pull engine updates

--- a/.github/workflows/yaml-linter.yml
+++ b/.github/workflows/yaml-linter.yml
@@ -7,15 +7,18 @@ on:
   pull_request:
     types: [ opened, reopened, synchronize, ready_for_review ]
 
+# Triad: key PR runs on PR number; never cancel a merge_group run, which fails the queue.
 concurrency:
-  group: ${{ github.workflow }}-${{ github.ref }}
-  cancel-in-progress: true
+  group: ${{ github.workflow }}-${{ github.event_name == 'pull_request' && github.event.pull_request.number || github.ref }}
+  cancel-in-progress: ${{ github.event_name != 'merge_group' }}
 
 jobs:
   build:
     name: YAML Linter
-    if: github.event.pull_request.draft == false
+    # Triad: skip the changelog bot's Resources/Changelog-only pushes to main.
+    if: github.event.pull_request.draft == false && github.actor != 'Triad-Sector'
     runs-on: ubuntu-latest
+    timeout-minutes: 20 # Triad: job takes ~6m.
     steps:
       - uses: actions/checkout@v4.2.2
       - name: Setup submodule

--- a/.github/workflows/yaml-linter.yml
+++ b/.github/workflows/yaml-linter.yml
@@ -20,7 +20,7 @@ jobs:
     runs-on: ubuntu-latest
     timeout-minutes: 20 # Triad: job takes ~6m.
     steps:
-      - uses: actions/checkout@v4.2.2
+      - uses: actions/checkout@v7
       - name: Setup submodule
         run: |
           git submodule update --init --recursive
@@ -31,7 +31,7 @@ jobs:
           cd RobustToolbox/
           git submodule update --init --recursive
       - name: Setup .NET Core
-        uses: actions/setup-dotnet@v4.1.0
+        uses: actions/setup-dotnet@v5
         with:
           dotnet-version: 10.0.x
       - name: Install dependencies


### PR DESCRIPTION
## About the PR
CI hygiene sweep across the workflow set: skip the changelog bot's push-triggered runs, cap job runtime, keep NUnit results as artifacts, make concurrency merge-queue safe, and bump the first-party actions off the deprecated Node 20 runtimes. Two commits, the action bumps kept separate so they can be reverted on their own.

## Why / Balance
No balance impact, CI only.

**Skip the changelog bot.** It pushes a `Resources/Changelog`-only commit straight to `main` after every merge, and that was firing all seven push-triggered workflows, roughly 36 minutes of runner time, for a file no test or validator reads. Guarded on `github.actor`, following the `PJBot`/`FrontierATC` pattern already inherited in `validate-rgas.yml`. Checked run history before writing the guard: the `Triad-Sector` account has only ever authored `Automated Changelog` commits, while humans push as `rebaserHEAD` and `TheRealMasterChief117`. Deliberately **not** applied to `publish.yml`, since the changelog is player-facing content and should still ship.

**Cap job runtime.** Nothing in the repo had `timeout-minutes`, so a hung integration test ran to the six hour runner ceiling. Caps are roughly triple observed runtime (30m on the build lanes, 20m on the linter and map renderer, 15m on the validators).

**Keep test results.** Upstream emits NUnit XML and archives it with `if: always()`. We had dropped both while keeping `NUnit.ConsoleOut=0`, which left a failed run with very little to triage from. Restored on `build-test-debug`, and added to `nf-shipyard-tests` for the same reason, since a shipyard failure is usually a per-ship price mismatch that is unreadable without the per-test XML.

**Concurrency.** PR runs now key on the PR number rather than the ref, and `cancel-in-progress` is disabled for `merge_group`, because cancelling a merge queue entry fails the queue rather than superseding it. `nf-shipyard-tests` had no concurrency group at all, so two pushes to one PR ran both to completion.

**Action bumps.** Every run was printing `Node.js 20 is deprecated ... being forced to run on Node.js 24`. Still functional, but it is a scheduled break and it buries real warnings.

| Action | From | To | Sites | Basis |
| --- | --- | --- | --- | --- |
| `actions/checkout` | v3, v4.2.2 | v7 | 18 | matches wizden/master today |
| `actions/setup-dotnet` | v4.1.0 | v5 | 7 | matches wizden/master today |
| `actions/setup-node` | v3 | v4 | 2 | no upstream precedent, conservative pick |
| `actions/setup-python` | v3 | v5 | 2 | no upstream precedent, conservative pick |

## Media
Not applicable, CI only.

## Requirements
- [x] I have read the guidelines and documentation relevant to this PR.
- [x] I have added media to this PR or it does not require an ingame showcase.
- [x] I can confirm this PR contains either no AI-generated content, or AI-generated content that meets our guidelines.

## How to test
Verified before pushing:

- All 28 workflows parse.
- Every job that should carry the bot skip, a timeout, and merge-group-safe concurrency does, confirmed by parsing the YAML rather than reading it.
- All four new action tags resolve against their upstream repos, so nothing is pinned to a version that does not exist.
- No stale `checkout@v3/v4`, `setup-dotnet@v4`, `setup-node@v3` or `setup-python@v3` references remain.

What cannot be verified locally is runtime behaviour of the new action majors. The checks on this PR are the first real exercise. Worth a glance at the run list to confirm the lanes still go green and the Node 20 warnings are gone.

The bot skip is the one behaviour that needs watching after merge: the next `Automated Changelog` commit should trigger **no** CI workflows, while `Publish` still runs on it.

## Breaking changes
None to game code. If a maintainer ever pushes to `main` using the `Triad-Sector` org account, CI will silently skip those commits. That account is bot-only today across all history checked, but it is the tradeoff of an actor-based guard versus a path-based one.
