### PR TITLE
Finish the Action Bumps, and Drop the vars.GITHUB_REPOSITORY Shadow

### DIFF
--- a/.github/workflows/build-test-debug.yml
+++ b/.github/workflows/build-test-debug.yml
@@ -68,7 +68,7 @@ jobs:
     # Triad: `if: always()` on purpose. The failing run is the one whose results we want.
     - name: Archive NUnit3 test results.
       if: always()
-      uses: actions/upload-artifact@v4
+      uses: actions/upload-artifact@v7
       with:
         name: nunit3-results-${{ matrix.os }}
         path: test_results/*

--- a/.github/workflows/changelog.yml
+++ b/.github/workflows/changelog.yml
@@ -29,7 +29,7 @@ jobs:
         shell: bash
 
       - name: Setup Node
-        uses: actions/setup-node@v4
+        uses: actions/setup-node@v5
         with:
           node-version: 18.x
 

--- a/.github/workflows/close-master-pr.yml
+++ b/.github/workflows/close-master-pr.yml
@@ -16,7 +16,7 @@ jobs:
 
     # If you prefer to just comment on the pr and not close it, uncomment the bellow and comment the above
 
-    - uses: actions/github-script@v7
+    - uses: actions/github-script@v9
       with:
         script: |
           github.rest.issues.createComment({

--- a/.github/workflows/nf-mapchecker.yml
+++ b/.github/workflows/nf-mapchecker.yml
@@ -26,7 +26,7 @@ jobs:
     steps:
     - uses: actions/checkout@v7
     - name: Set up Python 3.10
-      uses: actions/setup-python@v5
+      uses: actions/setup-python@v6
       with:
         python-version: "3.10"
     - name: Install dependencies

--- a/.github/workflows/nf-shipyard-tests.yml
+++ b/.github/workflows/nf-shipyard-tests.yml
@@ -62,7 +62,7 @@ jobs:
     # without the per-test XML.
     - name: Archive NUnit3 test results.
       if: always()
-      uses: actions/upload-artifact@v4
+      uses: actions/upload-artifact@v7
       with:
         name: nunit3-results-shipyard-${{ matrix.os }}
         path: test_results/*

--- a/.github/workflows/prtitlecase.yml
+++ b/.github/workflows/prtitlecase.yml
@@ -17,7 +17,7 @@ jobs:
           token: ${{ secrets.BOT_TOKEN }}
 
       - name: Setup Node
-        uses: actions/setup-node@v4
+        uses: actions/setup-node@v5
         with:
           node-version: 18.x
 

--- a/.github/workflows/publish-testing.yml
+++ b/.github/workflows/publish-testing.yml
@@ -42,4 +42,6 @@ jobs:
       run: Tools/publish_multi_request.py --fork-id wizards-testing
       env:
         PUBLISH_TOKEN: ${{ secrets.PUBLISH_TOKEN }}
-        GITHUB_REPOSITORY: ${{ vars.GITHUB_REPOSITORY }}
+        # Triad: dropped, same reason as publish.yml. The GITHUB_ prefix is reserved for
+        # variable names, so this expression is always empty.
+        #GITHUB_REPOSITORY: ${{ vars.GITHUB_REPOSITORY }} # Triad: removed

--- a/.github/workflows/publish.yml
+++ b/.github/workflows/publish.yml
@@ -95,7 +95,12 @@ jobs:
       run: Tools/publish_multi_request.py
       env:
         PUBLISH_TOKEN: ${{ secrets.PUBLISH_TOKEN }}
-        GITHUB_REPOSITORY: ${{ vars.GITHUB_REPOSITORY }}
+        # Triad: dropped. GitHub reserves the GITHUB_ prefix for variable names, so
+        # vars.GITHUB_REPOSITORY can never be set and this only ever shadowed the built-in
+        # with an empty string. Harmless here because publish_multi_request.py does not read
+        # it, but Tools/actions_changelogs_since_last_run.py does, and one copy-paste onto
+        # that step would break the Discord changelog silently.
+        #GITHUB_REPOSITORY: ${{ vars.GITHUB_REPOSITORY }} # Triad: removed, see above
 
     - name: Publish changelog (Discord)
       continue-on-error: true

--- a/.github/workflows/validate-rsis.yml
+++ b/.github/workflows/validate-rsis.yml
@@ -27,7 +27,7 @@ jobs:
       - name: Pull engine updates
         uses: space-wizards/submodule-dependency@v0.1.5
       - name: Set up Python 3.10 # Frontier
-        uses: actions/setup-python@v5 # Frontier
+        uses: actions/setup-python@v6 # Frontier
         with: # Frontier
           python-version: "3.10" # Frontier
       - name: Install Python dependencies


### PR DESCRIPTION
## About the PR
Finishes the action version bumps from #491, which undershot on two of them, and drops the `vars.GITHUB_REPOSITORY` expression that was shadowing the built-in in both publish workflows.

## Why / Balance
No balance impact, CI only.

**The previous bump undershot.** `checkout@v7` and `setup-dotnet@v5` did clear the Node 20 deprecation, confirmed against the first runs on `main` after #491 merged. But `setup-python@v5` was still listed in the deprecation annotation, and `setup-node@v4` is the same generation. Those two were picked as versions I could confirm *existed* rather than versions that were *current*, which was the wrong call.

| Action | From | To | Sites |
| --- | --- | --- | --- |
| `actions/setup-python` | v5 | v6 | 2 |
| `actions/setup-node` | v4 | v5 | 2 |
| `actions/upload-artifact` | v4 | v7 | 2 |
| `actions/github-script` | v7 | v9 | 1 |

`upload-artifact` was added at v4 in #491 to match upstream and is the same generation. `github-script` drives a single `github.rest.issues.createComment` call, which is the most stable part of that API.

**Dropping `GITHUB_REPOSITORY: ${{ vars.GITHUB_REPOSITORY }}`.** GitHub reserves the `GITHUB_` prefix for variable names, so that expression can never resolve, and it only ever shadowed the built-in with an empty string for that step. It is inert today purely because `publish_multi_request.py` does not read it. `Tools/actions_changelogs_since_last_run.py` does read `GITHUB_REPOSITORY`, so one copy-paste of that env line onto the changelog step would break the Discord post silently. Commented rather than deleted, since it is upstream's line and will conflict.

**Deliberately not bumped:**

- `actions/labeler` stays at v5. The v4 to v5 jump changed the config file format in a breaking way, so a major bump needs `.github/labeler.yml` validated against the new schema rather than a blind version change.
- `space-wizards/submodule-dependency` is already on `v0.1.5`, the newest tag that exists, across 8 call sites. It is the reason the Node 20 warning will not fully disappear no matter what we do here.
- The `peter-evans/*@v1`, `PaulRitter/yaml-schema-validator@v1` and `Ana06/get-changed-files` cluster. Third-party, different risk class, and they drive PR comment bots that fail in ways nobody notices.

## Media
Not applicable, CI only.

## Requirements
- [x] I have read the guidelines and documentation relevant to this PR.
- [x] I have added media to this PR or it does not require an ingame showcase.
- [x] I can confirm this PR contains either no AI-generated content, or AI-generated content that meets our guidelines.

## How to test
Verified before pushing: all 28 workflows parse, every new tag resolves against its upstream repo, no `GITHUB_REPOSITORY` override remains active, and the `Publish version` step's env now contains only `PUBLISH_TOKEN`.

The checks on this PR are the real test. `RSI Validator` and `Map Prototype Checker` exercise `setup-python@v6`, `PR Title Case` exercises `setup-node@v5`, and `Build & Test Debug` exercises `upload-artifact@v7`. The deprecation annotation on those runs should list only `space-wizards/submodule-dependency@v0.1.5`.

## Breaking changes
None. The `GITHUB_REPOSITORY` removal restores the built-in value for that step rather than changing it to something new.
