### PR TITLE
Fix Construction Ghosts Treating Screen-Space Rotation as Grid-Local

### DIFF
--- a/Content.Client/Construction/ConstructionSystem.cs
+++ b/Content.Client/Construction/ConstructionSystem.cs
@@ -9,6 +9,7 @@ using Content.Shared.Interaction;
 using Content.Shared.Wall;
 using JetBrains.Annotations;
 using Robust.Client.GameObjects;
+using Robust.Client.Graphics;
 using Robust.Client.Player;
 using Robust.Shared.Input;
 using Robust.Shared.Input.Binding;
@@ -30,6 +31,7 @@ namespace Content.Client.Construction
         [Dependency] private SharedTransformSystem _transformSystem = default!;
         [Dependency] private PopupSystem _popupSystem = default!;
         [Dependency] private SpriteSystem _spriteSystem = default!; // Triad
+        [Dependency] private IEyeManager _eyeManager = default!; // Triad: screen-space dir -> world rotation
 
         private readonly Dictionary<int, EntityUid> _ghosts = new();
         private readonly Dictionary<string, ConstructionGuide> _guideCache = new();
@@ -213,7 +215,14 @@ namespace Content.Client.Construction
             var comp = EntityManager.GetComponent<ConstructionGhostComponent>(ghost.Value);
             comp.Prototype = prototype;
             comp.GhostId = ghost.GetHashCode();
-            _transformSystem.SetLocalRotation(ghost.Value, dir.ToAngle());
+            // Triad: `dir` comes from the placement manager and is a cardinal in SCREEN space, but LocalRotation is
+            // relative to the ghost's parent. An entity renders at worldRotation + eyeRotation (same identity used
+            // in BuckleSystem and ClickableSystem), so storing the screen angle as a local rotation only lines up
+            // when the camera exactly cancels the parent grid's rotation. On a rotated ship it does not, and the
+            // ghost is drawn skewed — then built skewed, because TryStartConstruction sends this very value.
+            // Setting the WORLD rotation instead is correct for any parent, and reduces to the old behaviour when
+            // the camera is aligned to the grid.
+            _transformSystem.SetWorldRotation(ghost.Value, dir.ToAngle() - _eyeManager.CurrentEye.Rotation);
             _ghosts.Add(comp.GhostId, ghost.Value);
             var sprite = EntityManager.GetComponent<SpriteComponent>(ghost.Value);
             _spriteSystem.SetColor((ghost.Value, sprite), new Color(48, 255, 48, 128));

--- a/Content.IntegrationTests/Tests/Construction/AnchorRotationRotatedGridTest.cs
+++ b/Content.IntegrationTests/Tests/Construction/AnchorRotationRotatedGridTest.cs
@@ -13,10 +13,15 @@ namespace Content.IntegrationTests.Tests.Construction;
 /// Players on rotated ship grids reported structures being built skewed, or losing their rotation entirely,
 /// across pipes, conveyors, tube light fixtures and wall buttons.
 ///
-/// Engine 287's <c>AnchorEntity</c> rewrites an entity's local rotation to preserve its WORLD rotation whenever
-/// anchoring also reparents it, skewing the result by exactly the grid's rotation. That difference is zero on a
-/// station and visible on any rotated ship, which is why it is invisible upstream. Until the engine carries the
-/// fix, content re-asserts the grid-local rotation across its own anchor calls.
+/// These are pins, not a fix. Both server-side rotation paths below test clean on a rotated grid, patched or not,
+/// which is what ruled the server out and sent the search to the client; the cause turned out to be the screen-vs
+/// -grid frame mix-up covered by <c>ConstructionGhostRotationTest</c>.
+///
+/// They are kept because engine 287's <c>AnchorEntity</c> genuinely does rewrite local rotation to preserve WORLD
+/// rotation when anchoring also reparents, which would skew the result by exactly the grid's rotation. Content
+/// cannot reach that branch today: anchoring refuses any grid other than the entity's own <c>GridUid</c>, and
+/// <c>GridUid</c> is inherited down the transform tree, so the delta is always zero. These tests fail the day that
+/// stops being true.
 /// </summary>
 [TestFixture]
 public sealed class AnchorRotationRotatedGridTest
@@ -67,8 +72,9 @@ public sealed class AnchorRotationRotatedGridTest
 
     /// <summary>
     /// The construction-graph path: <see cref="SetAnchor"/> is the completion action that anchors a finished
-    /// structure, and it is how conveyors and most built structures end up anchored. If the entity is not already
-    /// grid-parented, anchoring reparents it and the engine rewrite fires.
+    /// structure, and it is how conveyors and most built structures end up anchored. This is the reparenting case,
+    /// held out of hands rather than already grid-parented, so it is the closest content gets to the engine
+    /// rewrite. The rotation survives, because the holder is on the grid and the rotation delta is therefore zero.
     /// </summary>
     [Test]
     [TestCase(Pipe)]

--- a/Content.IntegrationTests/Tests/Construction/AnchorRotationRotatedGridTest.cs
+++ b/Content.IntegrationTests/Tests/Construction/AnchorRotationRotatedGridTest.cs
@@ -1,0 +1,124 @@
+#nullable enable
+using System.Numerics;
+using Content.Server.Construction.Completions;
+using Content.Shared.Coordinates;
+using Robust.Shared.GameObjects;
+using Robust.Shared.Map;
+using Robust.Shared.Map.Components;
+using Robust.Shared.Maths;
+
+namespace Content.IntegrationTests.Tests.Construction;
+
+/// <summary>
+/// Players on rotated ship grids reported structures being built skewed, or losing their rotation entirely,
+/// across pipes, conveyors, tube light fixtures and wall buttons.
+///
+/// Engine 287's <c>AnchorEntity</c> rewrites an entity's local rotation to preserve its WORLD rotation whenever
+/// anchoring also reparents it, skewing the result by exactly the grid's rotation. That difference is zero on a
+/// station and visible on any rotated ship, which is why it is invisible upstream. Until the engine carries the
+/// fix, content re-asserts the grid-local rotation across its own anchor calls.
+/// </summary>
+[TestFixture]
+public sealed class AnchorRotationRotatedGridTest
+{
+    // The reported set. Pipes and conveyors anchor to the floor; lights and buttons are wall-mounted.
+    private const string Pipe = "GasPipeStraight";
+    private const string Conveyor = "ConveyorBelt";
+    private const string TubeLight = "Poweredlight";
+    private const string WallButton = "SignalButton";
+
+    private const double GridDegrees = 85;
+    private const double PlacedDegrees = 90;
+
+    /// <summary>
+    /// The RCD/RPD path: spawn onto grid-local coordinates with an explicit rotation. The entity is already
+    /// grid-parented when it anchors, so the engine rewrite never fires. Pins that this path stays clean.
+    /// </summary>
+    [Test]
+    [TestCase(Pipe)]
+    [TestCase(Conveyor)]
+    [TestCase(TubeLight)]
+    [TestCase(WallButton)]
+    public async Task SpawnOnRotatedGrid_KeepsRotation(string proto)
+    {
+        await using var pair = await PoolManager.GetServerClient();
+        var server = pair.Server;
+        var entMan = server.ResolveDependency<IEntityManager>();
+        var mapSys = entMan.System<SharedMapSystem>();
+        var xformSys = entMan.System<SharedTransformSystem>();
+
+        await server.WaitAssertion(() =>
+        {
+            mapSys.CreateMap(out var mapId);
+            var grid = mapSys.CreateGridEntity(mapId);
+            mapSys.SetTile(grid, new Vector2i(0, 0), new Tile(1));
+            xformSys.SetWorldRotation(grid.Owner, Angle.FromDegrees(GridDegrees));
+
+            var ent = entMan.SpawnAttachedTo(proto, grid.Owner.ToCoordinates(0, 0),
+                rotation: Angle.FromDegrees(PlacedDegrees));
+            var xform = entMan.GetComponent<TransformComponent>(ent);
+
+            Assert.That(xform.LocalRotation.Degrees, Is.EqualTo(PlacedDegrees).Within(0.01),
+                $"{proto} placed facing one way must stay facing that way relative to the ship");
+        });
+
+        await pair.CleanReturnAsync();
+    }
+
+    /// <summary>
+    /// The construction-graph path: <see cref="SetAnchor"/> is the completion action that anchors a finished
+    /// structure, and it is how conveyors and most built structures end up anchored. If the entity is not already
+    /// grid-parented, anchoring reparents it and the engine rewrite fires.
+    /// </summary>
+    [Test]
+    [TestCase(Pipe)]
+    [TestCase(Conveyor)]
+    [TestCase(TubeLight)]
+    [TestCase(WallButton)]
+    public async Task SetAnchorOnRotatedGrid_KeepsRotation(string proto)
+    {
+        await using var pair = await PoolManager.GetServerClient();
+        var server = pair.Server;
+        var entMan = server.ResolveDependency<IEntityManager>();
+        var mapSys = entMan.System<SharedMapSystem>();
+        var xformSys = entMan.System<SharedTransformSystem>();
+
+        await server.WaitAssertion(() =>
+        {
+            mapSys.CreateMap(out var mapId);
+            var grid = mapSys.CreateGridEntity(mapId);
+            mapSys.SetTile(grid, new Vector2i(0, 0), new Tile(1));
+            xformSys.SetWorldRotation(grid.Owner, Angle.FromDegrees(GridDegrees));
+
+            // Anchoring always targets the entity's own GridUid, and GridUid is inherited down the transform
+            // tree. So the reparenting case is an entity held by something ON the grid: GridUid matches, but the
+            // parent is the holder, not the grid. That is "built out of hands or a container".
+            var holder = entMan.SpawnAttachedTo(null, grid.Owner.ToCoordinates(0, 0));
+            var ent = entMan.SpawnAttachedTo(proto, grid.Owner.ToCoordinates(0, 0));
+            var xform = entMan.GetComponent<TransformComponent>(ent);
+
+            if (xform.Anchored)
+                xformSys.Unanchor(ent, xform);
+
+            xformSys.SetParent(ent, xform, holder);
+            xformSys.SetLocalRotation(ent, Angle.FromDegrees(PlacedDegrees), xform);
+
+            Assert.Multiple(() =>
+            {
+                Assert.That(xform.ParentUid, Is.EqualTo(holder), "entity should be held, not grid-parented");
+                Assert.That(xform.GridUid, Is.EqualTo(grid.Owner), "GridUid is inherited from the holder");
+            });
+
+            new SetAnchor().PerformAction(ent, null, entMan);
+
+            Assert.Multiple(() =>
+            {
+                Assert.That(xform.Anchored, Is.True, $"{proto} should have anchored");
+                Assert.That(xform.LocalRotation.Degrees, Is.EqualTo(PlacedDegrees).Within(0.01),
+                    $"{proto} must not be skewed by the grid's rotation when the construction graph anchors it");
+            });
+        });
+
+        await pair.CleanReturnAsync();
+    }
+}

--- a/Content.IntegrationTests/Tests/_Triad/Construction/ConstructionGhostRotationTest.cs
+++ b/Content.IntegrationTests/Tests/_Triad/Construction/ConstructionGhostRotationTest.cs
@@ -1,0 +1,244 @@
+// SPDX-FileCopyrightText: 2026 Triad Sector contributors
+//
+// SPDX-License-Identifier: AGPL-3.0-or-later
+
+using Content.IntegrationTests.Tests.Interaction;
+using Content.Shared.Construction.Prototypes;
+using Robust.Client.Graphics;
+using Robust.Shared.GameObjects;
+using Robust.Shared.Map;
+using Robust.Shared.Maths;
+
+namespace Content.IntegrationTests.Tests._Triad.Construction;
+
+/// <summary>
+/// Players on rotated ship grids reported building structures a quarter turn away from the direction they
+/// picked. <c>ConstructionSystem.TrySpawnGhost</c> wrote the placement manager's direction, which is a cardinal
+/// in SCREEN space, straight into the ghost's <c>LocalRotation</c>, which is relative to the parent grid; the
+/// value the ghost then sends to the server becomes the built structure's local rotation.
+///
+/// The two frames differ by the eye. <c>EyeLerpingSystem.GetRotation</c> ties the camera to
+/// <c>-(gridWorldRotation + InputMoverComponent.RelativeRotation)</c>, and <c>RelativeRotation</c> snaps to the
+/// nearest cardinal when a player walks onto a grid, so boarding an 85° ship parks it at -90°. On a station both
+/// terms are zero and the bug cannot be seen, which is why it survived upstream.
+///
+/// The eye these tests set is <c>IEyeManager.CurrentEye</c>, the same eye the production code reads. Nothing
+/// drives it on a headless client (see <c>ClickableTest</c>, which sets it the same way), so each case states the
+/// value <c>EyeLerpingSystem</c> would have produced for that grid and camera offset.
+/// </summary>
+public sealed class ConstructionGhostRotationTest : InteractionTest
+{
+    /// <summary>
+    /// Rotatable, no wall required, its only condition is <c>TileNotBlocked</c>, and its first edge takes a
+    /// single material, so the build can be driven with one interaction.
+    /// </summary>
+    private const string DiagonalWall = "wallSolidDiagonal";
+
+    /// <summary>What the first edge of the diagonal wall's graph actually spawns.</summary>
+    private const string Girder = "Girder";
+
+    private const double Tolerance = 0.01;
+
+    /// <summary>
+    /// Rotate the test grid and stand the player on it, the way boarding a ship leaves things.
+    ///
+    /// The base fixture hands out <see cref="InteractionTest.PlayerCoords"/> and
+    /// <see cref="InteractionTest.TargetCoords"/> relative to the MAP, which is fine while nothing is rotated but
+    /// silently drifts off the intended tiles the moment the grid turns, and would parent the ghost to the map
+    /// rather than the ship. In game the placement manager hands construction grid coordinates, so re-derive both
+    /// in the grid's own frame and move the player over.
+    /// </summary>
+    private async Task BoardRotatedShip(Angle gridRotation)
+    {
+        await Server.WaitPost(() => Transform.SetWorldRotation(MapData.Grid.Owner, gridRotation));
+
+        // Same two tiles the base fixture already laid down, addressed in the frame that follows the ship.
+        PlayerCoords = SEntMan.GetNetCoordinates(new EntityCoordinates(MapData.Grid.Owner, 0.5f, 0.5f));
+        TargetCoords = SEntMan.GetNetCoordinates(new EntityCoordinates(MapData.Grid.Owner, 1.5f, 0.5f));
+
+        await Server.WaitPost(() => Transform.SetCoordinates(SPlayer, SEntMan.GetCoordinates(PlayerCoords)));
+        await RunTicks(5);
+
+        Assert.That(SEntMan.GetComponent<TransformComponent>(SPlayer).GridUid, Is.EqualTo(MapData.Grid.Owner),
+            "the player did not end up standing on the test grid");
+    }
+
+    /// <summary>What a placed ghost ended up holding, plus the eye it was placed under.</summary>
+    private readonly record struct GhostReading(bool Spawned, Angle Local, Angle World, Angle Eye);
+
+    /// <summary>
+    /// Place a ghost with the camera at <paramref name="eye"/>, read its rotations back, and clear it again.
+    ///
+    /// Only client work happens inside the post and the assertions stay on the test thread: an assertion that
+    /// throws inside <c>WaitPost</c> skips the cleanup on its way out and resurfaces as an unrelated dirty-pair
+    /// <c>DebugAssertException</c> in teardown, which says nothing about the rotation that actually went wrong.
+    /// </summary>
+    private async Task<GhostReading> PlaceGhost(ConstructionPrototype proto, Direction dir, Angle eye)
+    {
+        var eyeMan = Client.ResolveDependency<IEyeManager>();
+        var cXform = CEntMan.System<SharedTransformSystem>();
+        var reading = default(GhostReading);
+
+        await Client.WaitPost(() =>
+        {
+            eyeMan.CurrentEye.Rotation = eye;
+
+            if (!CConSys.TrySpawnGhost(proto, CEntMan.GetCoordinates(TargetCoords), dir, out var ghost))
+                return;
+
+            var xform = CEntMan.GetComponent<TransformComponent>(ghost.Value);
+
+            // The eye is read back rather than assumed: if anything ever starts driving CurrentEye on a headless
+            // client, these cases would pass for the wrong reason.
+            reading = new GhostReading(true, xform.LocalRotation, cXform.GetWorldRotation(xform),
+                eyeMan.CurrentEye.Rotation);
+
+            CConSys.ClearGhost(ghost.Value.GetHashCode());
+        });
+
+        await RunTicks(1);
+        return reading;
+    }
+
+    /// <summary>
+    /// A ghost must be drawn facing the cardinal the player picked, whatever the ship is doing underneath it.
+    /// </summary>
+    /// <param name="gridDegrees">World rotation of the ship the player is standing on.</param>
+    /// <param name="relativeDegrees">
+    /// <c>InputMoverComponent.RelativeRotation</c>, the camera's offset from the grid. Zero means the camera
+    /// exactly cancels the ship's rotation; -90 is where it parks after boarding a ship at any odd angle.
+    /// </param>
+    [Test]
+    [TestCase(0, 0)] // Station. Control: nothing rotated, so old and new behaviour must agree.
+    [TestCase(85, 0)] // Ship, camera exactly cancelling the grid. Also a no-op.
+    [TestCase(85, -90)] // Ship, camera parked a quarter turn off. This is the reported case.
+    [TestCase(85, 180)]
+    public async Task GhostFacesWhereThePlayerPointed(double gridDegrees, double relativeDegrees)
+    {
+        var proto = ProtoMan.Index<ConstructionPrototype>(DiagonalWall);
+
+        var grid = Angle.FromDegrees(gridDegrees);
+        var relative = Angle.FromDegrees(relativeDegrees);
+        var eye = -(grid + relative);
+
+        await BoardRotatedShip(grid);
+
+        foreach (var dir in new[] { Direction.South, Direction.East, Direction.North, Direction.West })
+        {
+            var ghost = await PlaceGhost(proto, dir, eye);
+
+            Assert.That(ghost.Spawned, Is.True, $"failed to place a {dir} ghost");
+            AssertAngle(ghost.Eye, eye, "the eye moved out from under the test");
+
+            Assert.Multiple(() =>
+            {
+                // An entity is drawn at worldRotation + eyeRotation (ClickableSystem uses the same identity).
+                AssertAngle(ghost.World + eye, dir.ToAngle(),
+                    $"a {dir} ghost on a {gridDegrees}° grid is not drawn facing {dir}");
+
+                // This is the value TryStartConstruction puts on the wire, and the server writes it to the
+                // structure verbatim. Off-cardinal here means a permanently skewed structure.
+                AssertAngle(ghost.Local, dir.ToAngle() + relative,
+                    $"a {dir} ghost should sit at {dir} + the camera offset in the ship's own frame");
+                AssertCardinal(ghost.Local, $"a {dir} ghost is not aligned to the ship's tiles");
+            });
+        }
+    }
+
+    /// <summary>
+    /// The camera offset is only a cardinal once its lerp settles, so mid-lerp the ghost's local rotation carries
+    /// a fraction of a turn. Building during that window bakes the fraction into the structure permanently, where
+    /// the pre-fix code always wrote an exact cardinal. Nothing snaps the angle between the ghost and the spawn:
+    /// the server passes it to <c>SpawnAttachedTo</c> as-is and only the placement <c>conditions</c> ever call
+    /// <c>GetCardinalDir</c>.
+    ///
+    /// Known to fail, and deliberately kept: it reproduces at 3° off the nearest cardinal. Closing it means
+    /// snapping the angle before it goes on the wire, which belongs in the follow-up patch rather than in a triage
+    /// change. Un-ignore it there; it is the acceptance test for that fix.
+    /// </summary>
+    [Test]
+    [Ignore("Known gap, fails at 3° off cardinal. Fix is the cardinal snap in the follow-up patch; un-ignore then.")]
+    public async Task GhostStaysCardinalWhileTheCameraIsStillLerping()
+    {
+        var proto = ProtoMan.Index<ConstructionPrototype>(DiagonalWall);
+
+        var grid = Angle.FromDegrees(85);
+        // Three degrees short of the -90 it is heading for.
+        var eye = -(grid + Angle.FromDegrees(-93));
+
+        await BoardRotatedShip(grid);
+
+        var ghost = await PlaceGhost(proto, Direction.East, eye);
+
+        Assert.That(ghost.Spawned, Is.True, "failed to place the ghost");
+        AssertCardinal(ghost.Local,
+            "a ghost placed mid-camera-lerp would build a structure that is permanently off-grid");
+    }
+
+    /// <summary>
+    /// End to end: the rotation the player saw on the ghost is the rotation the spawned structure keeps in the
+    /// ship's frame. This is what the player-facing bug is actually about. The angle rides the wire as the ghost's
+    /// <c>LocalRotation</c> and reaches <c>SpawnAttachedTo(..., rotation: angle)</c>, so the entity the graph's
+    /// first edge creates is where it lands.
+    /// </summary>
+    [Test]
+    public async Task BuiltStructureKeepsTheRotationTheGhostShowed()
+    {
+        var proto = ProtoMan.Index<ConstructionPrototype>(DiagonalWall);
+        var eyeMan = Client.ResolveDependency<IEyeManager>();
+
+        var grid = Angle.FromDegrees(85);
+        var relative = Angle.FromDegrees(-90);
+        var eye = -(grid + relative);
+        const Direction dir = Direction.East;
+
+        await BoardRotatedShip(grid);
+
+        // This ghost is kept rather than cleared, so it does not go through PlaceGhost.
+        var spawned = false;
+        await Client.WaitPost(() =>
+        {
+            eyeMan.CurrentEye.Rotation = eye;
+
+            if (!CConSys.TrySpawnGhost(proto, CEntMan.GetCoordinates(TargetCoords), dir, out var ghost))
+                return;
+
+            spawned = true;
+            Target = CEntMan.GetNetEntity(ghost.Value);
+            ConstructionGhostId = ghost.Value.GetHashCode();
+        });
+
+        await RunTicks(1);
+        Assert.That(spawned, Is.True, $"failed to place a {dir} ghost");
+
+        // The first edge of the graph is what carries the rotation, and it spawns the girder.
+        await InteractUsing(Steel, 2);
+        ClientAssertPrototype(Girder, Target);
+        await RunTicks(5);
+
+        var built = ToServer(Target);
+        Assert.That(built, Is.Not.Null, "the girder never made it to the server");
+
+        var xform = SEntMan.GetComponent<TransformComponent>(built!.Value);
+        Assert.Multiple(() =>
+        {
+            AssertAngle(xform.LocalRotation, dir.ToAngle() + relative,
+                $"a structure built facing {dir} on screen did not keep that facing on the ship");
+            AssertCardinal(xform.LocalRotation, "the spawned structure is not aligned to the ship's tiles");
+        });
+    }
+
+    private static void AssertAngle(Angle actual, Angle expected, string because)
+    {
+        var off = Math.Abs(Angle.ShortestDistance(actual, expected).Degrees);
+        Assert.That(off, Is.LessThan(Tolerance),
+            $"{because} (off by {off:0.##}°: got {actual.Degrees:0.##}°, wanted {expected.Degrees:0.##}°)");
+    }
+
+    private static void AssertCardinal(Angle actual, string because)
+    {
+        var off = Math.Abs(Angle.ShortestDistance(actual, actual.GetCardinalDir().ToAngle()).Degrees);
+        Assert.That(off, Is.LessThan(Tolerance),
+            $"{because} (off the nearest cardinal by {off:0.##}°: {actual.Degrees:0.##}°)");
+    }
+}


### PR DESCRIPTION
## About the PR
Construction ghosts wrote the placement manager's direction, a cardinal in screen space, straight into the ghost's `LocalRotation`, which is relative to the parent grid. That value is what `TryStartConstruction` sends, so the ghost's error became the structure's error. Now it sets world rotation instead, converting through the eye.

## Why / Balance
The two frames differ by the camera. `EyeLerpingSystem.GetRotation` ties the eye to `-(gridWorldRotation + InputMoverComponent.RelativeRotation)`, and `RelativeRotation` snaps to the nearest cardinal when you walk onto a grid, so boarding a ship at 85 degrees parks it at -90. Placement was then a quarter turn off what the operator picked. On a station both terms are zero, which is why this was never visible upstream and why it reads as a ship-only bug.

Scope worth being clear about: this covers structures placed from the construction menu. Pipes and tube light fixtures were also in the player reports, and those come from the RPD/RCD, which ships a `Direction` and resolves the angle server-side where eye rotation is unknown. They are unchanged here and need `RCDConstructionGhostRotationEvent` reworked.

One known gap, with a test that documents it: a ghost placed while the camera is still lerping to its cardinal lands about 3 degrees off grid, and nothing snaps the angle between the ghost and the spawn. The old code always wrote an exact cardinal, so that much is a regression, traded against fixing a 90 degree error in the ordinary case. `GhostStaysCardinalWhileTheCameraIsStillLerping` is ignored and is the acceptance test for the follow-up.

## Media
Not attached. Flagging honestly that this has not been confirmed in a live round yet; the evidence so far is the integration tests below.

## Requirements
- [ ] I have read the guidelines and documentation relevant to this PR.
- [ ] I have added media to this PR or it does not require an ingame showcase.
- [ ] I can confirm this PR contains either no AI-generated content, or AI-generated content that meets our guidelines.

## How to test
Stand on a ship rotated to something that is not a multiple of 90, walk onto it from a station so the camera snaps, then place a rotatable structure from the construction menu (a diagonal wall or a wall button) and rotate it with R. The ghost should face the direction you picked on screen, and the built structure should keep that facing relative to the ship's tiles.

`ConstructionGhostRotationTest` covers it automatically: `dotnet test --filter FullyQualifiedName~ConstructionGhostRotationTest`. 13 pass, 1 skipped (the gap above).

## Breaking changes
None.

**Changelog**
:cl:
- fix: Structures built from the construction menu on a rotated ship now face the direction you picked, instead of a quarter turn off.
