### PR TITLE
Stop the Changelog Bot Erasing Main's Test Coverage

### DIFF
--- a/.github/workflows/build-map-renderer.yml
+++ b/.github/workflows/build-map-renderer.yml
@@ -3,20 +3,24 @@ name: Build & Test Map Renderer
 on:
   push:
     branches: [ main, staging, stable ]
+    # Triad: changelog-bot commits touch only Resources/Changelog. Filter here rather than in
+    # a job `if`: concurrency is per run, so a run whose jobs all skip still cancels the merge
+    # commit's run. Keep this off `pull_request`, where a required check that never runs pends.
+    paths-ignore: [ 'Resources/Changelog/**' ]
   merge_group:
   pull_request:
     types: [ opened, reopened, synchronize, ready_for_review ]
     branches: [ main, staging, stable ]
 
-# Triad: key PR runs on PR number; never cancel a merge_group run, which fails the queue.
+# Triad: key PR runs on PR number; only ever cancel PR runs. Cancelling a merge_group entry
+# fails the queue, and cancelling a push run abandons main's only test coverage.
 concurrency:
   group: ${{ github.workflow }}-${{ github.event_name == 'pull_request' && github.event.pull_request.number || github.ref }}
-  cancel-in-progress: ${{ github.event_name != 'merge_group' }}
+  cancel-in-progress: ${{ github.event_name == 'pull_request' }}
 
 jobs:
   build:
-    # Triad: skip the changelog bot's Resources/Changelog-only pushes to main.
-    if: github.event.pull_request.draft == false && github.actor != 'Triad-Sector'
+    if: github.event.pull_request.draft == false
     strategy:
       matrix:
         os: [ubuntu-latest]

--- a/.github/workflows/build-test-debug.yml
+++ b/.github/workflows/build-test-debug.yml
@@ -1,14 +1,20 @@
 name: Build & Test Debug
 
-# Triad: key PR runs on the PR number rather than the ref, and never cancel a merge_group
-# run. Cancelling a merge queue entry fails the queue rather than superseding it.
+# Triad: key PR runs on the PR number rather than the ref, and only ever cancel PR runs.
+# Cancelling a merge_group entry fails the queue rather than superseding it, and cancelling a
+# push run abandons the only test coverage main/staging/stable ever get.
 concurrency:
   group: ${{ github.workflow }}-${{ github.event_name == 'pull_request' && github.event.pull_request.number || github.ref }}
-  cancel-in-progress: ${{ github.event_name != 'merge_group' }}
+  cancel-in-progress: ${{ github.event_name == 'pull_request' }}
 
 on:
   push:
     branches: [ main, staging, stable ]
+    # Triad: changelog-bot commits touch only Resources/Changelog. Filter here rather than in
+    # a job `if`: concurrency is evaluated per run, so a run whose jobs all skip still cancels
+    # the merge commit's in-flight run. Keep this off `pull_request`, where a required check
+    # that never runs sits pending forever.
+    paths-ignore: [ 'Resources/Changelog/**' ]
   merge_group:
   pull_request:
     types: [ opened, reopened, synchronize, ready_for_review ]
@@ -16,10 +22,7 @@ on:
 
 jobs:
   build:
-    # Triad: skip the changelog bot. It pushes a Resources/Changelog-only commit straight to
-    # main after every merge, which was firing all seven push-triggered workflows for a file
-    # no test reads. Same shape as the inherited PJBot/FrontierATC guard in validate-rgas.yml.
-    if: github.event.pull_request.draft == false && github.actor != 'Triad-Sector'
+    if: github.event.pull_request.draft == false
     strategy:
       matrix:
         os: [ubuntu-latest]

--- a/.github/workflows/publish.yml
+++ b/.github/workflows/publish.yml
@@ -17,6 +17,12 @@ on:
   # and keeps the newest main staged for the next boundary.
   push:
     branches: [ main ]
+    # Triad: skip the changelog bot's Resources/Changelog-only commit. It lands ~30s after
+    # every merge, and because this group never cancels, the two publishes serialized: ~21m of
+    # packaging and two CDN versions per PR. Tradeoff accepted deliberately: Triad.yml is
+    # shipped content, so a PR's in-game changelog entry now ships with the NEXT merge's
+    # publish rather than its own.
+    paths-ignore: [ 'Resources/Changelog/**' ]
 
 # Triad: no cancel-in-progress on purpose, though upstream sets it. Cancelling between
 # publish/start and publish/finish strands a half-open version on Robust.Cdn that 409s

--- a/.github/workflows/test-packaging.yml
+++ b/.github/workflows/test-packaging.yml
@@ -13,6 +13,11 @@ on:
       # why not just do both
       - 'RobustToolbox'
       - 'RobustToolbox/**'
+      # Triad: '**.yml' above matches Resources/Changelog/Triad.yml, so the changelog bot's
+      # post-merge commit was triggering this workflow. Negate it here: `paths` and
+      # `paths-ignore` cannot both be set for one event, and a job `if` cannot help because
+      # concurrency is per run, so a run whose jobs all skip still cancels the merge run.
+      - '!Resources/Changelog/**'
   merge_group:
   pull_request:
     types: [ opened, reopened, synchronize, ready_for_review ]
@@ -26,16 +31,16 @@ on:
       - 'RobustToolbox'
       - 'RobustToolbox/**'
 
-# Triad: key PR runs on PR number; never cancel a merge_group run, which fails the queue.
+# Triad: key PR runs on PR number; only ever cancel PR runs. Cancelling a merge_group entry
+# fails the queue, and cancelling a push run abandons main's only test coverage.
 concurrency:
   group: ${{ github.workflow }}-${{ github.event_name == 'pull_request' && github.event.pull_request.number || github.ref }}
-  cancel-in-progress: ${{ github.event_name != 'merge_group' }}
+  cancel-in-progress: ${{ github.event_name == 'pull_request' }}
 
 jobs:
   build:
     name: Test Packaging
-    # Triad: skip the changelog bot's Resources/Changelog-only pushes to main.
-    if: github.event.pull_request.draft == false && github.actor != 'Triad-Sector'
+    if: github.event.pull_request.draft == false
     runs-on: ubuntu-latest
     timeout-minutes: 30 # Triad: job takes ~10m.
 

--- a/.github/workflows/validate-rgas.yml
+++ b/.github/workflows/validate-rgas.yml
@@ -2,19 +2,24 @@ name: RGA schema validator
 on:
   push:
     branches: [ main, staging, stable ]
+    # Triad: changelog-bot commits touch only Resources/Changelog. Filter here rather than in
+    # a job `if`: concurrency is per run, so a run whose jobs all skip still cancels the merge
+    # commit's run. Keep this off `pull_request`, where a required check that never runs pends.
+    paths-ignore: [ 'Resources/Changelog/**' ]
   merge_group:
   pull_request:
     types: [ opened, reopened, synchronize, ready_for_review ]
 
-# Triad: key PR runs on PR number; never cancel a merge_group run, which fails the queue.
+# Triad: key PR runs on PR number; only ever cancel PR runs. Cancelling a merge_group entry
+# fails the queue, and cancelling a push run abandons main's only test coverage.
 concurrency:
   group: ${{ github.workflow }}-${{ github.event_name == 'pull_request' && github.event.pull_request.number || github.ref }}
-  cancel-in-progress: ${{ github.event_name != 'merge_group' }}
+  cancel-in-progress: ${{ github.event_name == 'pull_request' }}
 
 jobs:
   yaml-schema-validation:
     name: YAML RGA schema validator
-    if: github.actor != 'PJBot' && github.event.pull_request.draft == false && github.actor != 'FrontierATC' && github.actor != 'Triad-Sector' # Frontier; Triad: our changelog bot
+    if: github.actor != 'PJBot' && github.event.pull_request.draft == false && github.actor != 'FrontierATC' # Frontier
     runs-on: ubuntu-latest
     timeout-minutes: 15 # Triad: job takes ~1m.
     steps:

--- a/.github/workflows/validate-rsis.yml
+++ b/.github/workflows/validate-rsis.yml
@@ -3,21 +3,24 @@ name: RSI Validator
 on:
   push:
     branches: [ main, staging, stable ]
+    # Triad: changelog-bot commits touch only Resources/Changelog. Filter here rather than in
+    # a job `if`: concurrency is per run, so a run whose jobs all skip still cancels the merge
+    # commit's run. Keep this off `pull_request`, where a required check that never runs pends.
+    paths-ignore: [ 'Resources/Changelog/**' ]
   merge_group:
   pull_request:
     paths:
       - '**.rsi/**'
 
-# Triad: key PR runs on PR number; never cancel a merge_group run, which fails the queue.
+# Triad: key PR runs on PR number; only ever cancel PR runs. Cancelling a merge_group entry
+# fails the queue, and cancelling a push run abandons main's only test coverage.
 concurrency:
   group: ${{ github.workflow }}-${{ github.event_name == 'pull_request' && github.event.pull_request.number || github.ref }}
-  cancel-in-progress: ${{ github.event_name != 'merge_group' }}
+  cancel-in-progress: ${{ github.event_name == 'pull_request' }}
 
 jobs:
   validate_rsis:
     name: Validate RSIs
-    # Triad: skip the changelog bot's Resources/Changelog-only pushes to main.
-    if: github.actor != 'Triad-Sector'
     runs-on: ubuntu-latest
     timeout-minutes: 15 # Triad: job takes ~1m.
     steps:

--- a/.github/workflows/validate_mapfiles.yml
+++ b/.github/workflows/validate_mapfiles.yml
@@ -2,20 +2,24 @@ name: Map file schema validator
 on:
   push:
     branches: [ main, staging, stable ]
+    # Triad: changelog-bot commits touch only Resources/Changelog. Filter here rather than in
+    # a job `if`: concurrency is per run, so a run whose jobs all skip still cancels the merge
+    # commit's run. Keep this off `pull_request`, where a required check that never runs pends.
+    paths-ignore: [ 'Resources/Changelog/**' ]
   merge_group:
   pull_request:
     types: [ opened, reopened, synchronize, ready_for_review ]
 
-# Triad: key PR runs on PR number; never cancel a merge_group run, which fails the queue.
+# Triad: key PR runs on PR number; only ever cancel PR runs. Cancelling a merge_group entry
+# fails the queue, and cancelling a push run abandons main's only test coverage.
 concurrency:
   group: ${{ github.workflow }}-${{ github.event_name == 'pull_request' && github.event.pull_request.number || github.ref }}
-  cancel-in-progress: ${{ github.event_name != 'merge_group' }}
+  cancel-in-progress: ${{ github.event_name == 'pull_request' }}
 
 jobs:
   yaml-schema-validation:
     name: YAML map schema validator
-    # Triad: skip the changelog bot's Resources/Changelog-only pushes to main.
-    if: github.event.pull_request.draft == false && github.actor != 'Triad-Sector'
+    if: github.event.pull_request.draft == false
     runs-on: ubuntu-latest
     timeout-minutes: 15 # Triad: job takes ~3m.
     steps:

--- a/.github/workflows/yaml-linter.yml
+++ b/.github/workflows/yaml-linter.yml
@@ -3,20 +3,24 @@ name: YAML Linter
 on:
   push:
     branches: [ main, staging, stable ]
+    # Triad: changelog-bot commits touch only Resources/Changelog. Filter here rather than in
+    # a job `if`: concurrency is per run, so a run whose jobs all skip still cancels the merge
+    # commit's run. Keep this off `pull_request`, where a required check that never runs pends.
+    paths-ignore: [ 'Resources/Changelog/**' ]
   merge_group:
   pull_request:
     types: [ opened, reopened, synchronize, ready_for_review ]
 
-# Triad: key PR runs on PR number; never cancel a merge_group run, which fails the queue.
+# Triad: key PR runs on PR number; only ever cancel PR runs. Cancelling a merge_group entry
+# fails the queue, and cancelling a push run abandons main's only test coverage.
 concurrency:
   group: ${{ github.workflow }}-${{ github.event_name == 'pull_request' && github.event.pull_request.number || github.ref }}
-  cancel-in-progress: ${{ github.event_name != 'merge_group' }}
+  cancel-in-progress: ${{ github.event_name == 'pull_request' }}
 
 jobs:
   build:
     name: YAML Linter
-    # Triad: skip the changelog bot's Resources/Changelog-only pushes to main.
-    if: github.event.pull_request.draft == false && github.actor != 'Triad-Sector'
+    if: github.event.pull_request.draft == false
     runs-on: ubuntu-latest
     timeout-minutes: 20 # Triad: job takes ~6m.
     steps:


### PR DESCRIPTION
## About the PR
Filters the changelog bot's commit at the workflow trigger instead of at the job level, and
stops `cancel-in-progress` from firing on push events. Right now every merge leaves `main`
with seven cancelled runs, seven skipped runs, and zero completed test runs.

## Why / Balance
#491 added a job-level `github.actor != 'Triad-Sector'` guard to skip the bot's
`Resources/Changelog`-only commit. The intent was right, but concurrency is evaluated per
workflow *run*, before any job is considered. So the bot's push still created a run, that run
still claimed the concurrency group and cancelled the merge commit's in-flight run, and only
then did its jobs skip themselves. A job-level guard cannot prevent the cancellation it causes.

Observed on #493, the first merge after #491:

```
00:39:00  merge 0d11c2a28   7 test workflows -> ALL CANCELLED
00:39:33  bot   94a152f47   7 test workflows -> ALL SKIPPED
```

Filtering at the trigger means no run is created, so there is nothing to cancel.

`cancel-in-progress` now fires only for `pull_request`. Cancelling a `merge_group` entry fails
the queue rather than superseding it (already handled), and cancelling a push run throws away
the only coverage `main`, `staging` and `stable` ever get.

`test-packaging.yml` is the odd one out: it already sets `paths` on push, and GitHub rejects
`paths` and `paths-ignore` together for one event, so it negates the pattern in place. Worth
noting its existing `'**.yml'` include was matching `Resources/Changelog/Triad.yml`, which is
how it ended up in the double wave.

Publish gets the same filter. The bot commit lands ~30s after every merge and, because that
group deliberately never cancels, the two publishes serialized into roughly 21 minutes of
packaging and two CDN versions per PR.

The actor guards come out as redundant once the trigger filter is in place. That also closes a
hole where a direct push from the `Triad-Sector` account skipped every test. The inherited
`PJBot`/`FrontierATC` guard in `validate-rgas.yml` is untouched.

## Media
N/A, CI only.

## Requirements
- [x] I have read the guidelines and documentation relevant to this PR.
- [x] I have added media to this PR or it does not require an ingame showcase.
- [x] I can confirm this PR contains either no AI-generated content, or AI-generated content that meets our guidelines.

## How to test
All eight files parse under PyYAML and no check names change, which matters because those names
are what branch protection will key off. The behavioural proof only arrives on the next merge
to `main`: expect one completed run per push-triggered workflow on the merge commit, no runs at
all on the `Automated Changelog` commit, and a single Publish instead of two.

## Breaking changes
None to code. One deliberate behavioural tradeoff: `Resources/Changelog/Triad.yml` is shipped
content, so a PR's in-game changelog entry now ships with the *next* merge's publish rather
than its own. Entries are not lost, they arrive one publish later.

**Changelog**
No `:cl:`, CI only and not player facing.
