### PR TITLE
Stop Persisting Do-After Handles, Which Blocks Ship Saves

### DIFF
--- a/Content.IntegrationTests/Tests/_Triad/Serialization/DoAfterIdNotPersistedTest.cs
+++ b/Content.IntegrationTests/Tests/_Triad/Serialization/DoAfterIdNotPersistedTest.cs
@@ -1,0 +1,220 @@
+// SPDX-FileCopyrightText: 2026 Triad Sector contributors
+//
+// SPDX-License-Identifier: AGPL-3.0-or-later
+
+using System;
+using System.Collections.Generic;
+using System.Reflection;
+using Content.Shared.DoAfter;
+using Robust.Shared.GameObjects;
+using Robust.Shared.Serialization.Manager.Attributes;
+using Robust.Shared.ViewVariables;
+
+namespace Content.IntegrationTests.Tests._Triad.Serialization;
+
+/// <summary>
+/// Guards the whole family of bugs behind a live ship-save outage: a <see cref="DoAfterId"/> reaching
+/// a persisted data field.
+///
+/// A do-after id is a runtime handle, a user plus an index into that user's live do-after list. It has
+/// no type serializer and no data definition, so the serializer throws "No type serializer or data
+/// definition found" the moment it is asked to write one. A component that marks such a field
+/// [DataField] therefore hard-fails map serialization as soon as the field goes non-null, taking the
+/// entire ship-grid save with it. In production this was MagicMirror on a pair of barber scissors,
+/// which blocked every save of the grid it sat on.
+///
+/// Eight components carried that mistake, all inherited. The point of this test is that the ninth
+/// cannot land quietly, including by arriving through an upstream merge.
+/// </summary>
+[TestFixture]
+[TestOf(typeof(DoAfterId))]
+public sealed class DoAfterIdNotPersistedTest
+{
+    [Test]
+    public async Task NoRegisteredComponentPersistsADoAfterHandle()
+    {
+        await using var pair = await PoolManager.GetServerClient();
+        var server = pair.Server;
+        await server.WaitIdleAsync();
+
+        var componentFactory = server.ResolveDependency<IComponentFactory>();
+
+        var offenders = new List<string>();
+
+        foreach (var registration in componentFactory.GetAllRegistrations())
+        {
+            foreach (var (memberName, memberType) in DataFieldMembers(registration.Type))
+            {
+                if (ReachesDoAfterId(memberType, new HashSet<Type>()))
+                    offenders.Add($"{registration.Name}.{memberName} ({registration.Type.Name})");
+            }
+        }
+
+        Assert.That(offenders, Is.Empty,
+            "These data fields persist a runtime do-after handle, which throws on any map or ship save " +
+            "once the field goes non-null. Drop the [DataField] and keep the member as [ViewVariables] " +
+            $"runtime state:\n  {string.Join("\n  ", offenders)}");
+
+        // Without this the pair dirty-disposes, which NUnit reports as a skip rather than a pass. A
+        // guard test that silently skips is worse than no guard at all.
+        await pair.CleanReturnAsync();
+    }
+
+    /// <summary>
+    /// Control for the sweep above. An empty offender list is only meaningful if the walk can actually
+    /// find a handle, and a reflection walk that silently returns nothing looks exactly like a clean
+    /// codebase. This asserts the detector fires on a type built to be caught, and holds its fire on the
+    /// same type without the attribute.
+    /// </summary>
+    [Test]
+    public void DetectorFindsAPlantedHandle()
+    {
+        Assert.Multiple(() =>
+        {
+            Assert.That(HasPersistedHandle(typeof(PlantedOffender)), Is.True,
+                "The detector missed a direct [DataField] do-after handle, so the sweep proves nothing.");
+
+            Assert.That(HasPersistedHandle(typeof(PlantedNestedOffender)), Is.True,
+                "The detector missed a handle reached through a nested data definition.");
+
+            Assert.That(HasPersistedHandle(typeof(PlantedCollectionOffender)), Is.True,
+                "The detector missed a handle held in a collection.");
+
+            Assert.That(HasPersistedHandle(typeof(RuntimeOnlyControl)), Is.False,
+                "The detector flagged a handle that is runtime-only state, so it would fail the fixed code.");
+        });
+    }
+
+    private static bool HasPersistedHandle(Type type)
+    {
+        foreach (var (_, memberType) in DataFieldMembers(type))
+        {
+            if (ReachesDoAfterId(memberType, new HashSet<Type>()))
+                return true;
+        }
+
+        return false;
+    }
+
+    /// <summary>
+    /// Yields every member the serializer would write, walking the base chain by hand because
+    /// GetFields does not return private fields declared on a base type.
+    /// </summary>
+    private static IEnumerable<(string Name, Type Type)> DataFieldMembers(Type type)
+    {
+        const BindingFlags flags = BindingFlags.Public
+                                   | BindingFlags.NonPublic
+                                   | BindingFlags.Instance
+                                   | BindingFlags.DeclaredOnly;
+
+        for (var current = type; current != null && current != typeof(object); current = current.BaseType)
+        {
+            foreach (var field in current.GetFields(flags))
+            {
+                if (IsDataField(field))
+                    yield return (field.Name, field.FieldType);
+            }
+
+            foreach (var property in current.GetProperties(flags))
+            {
+                if (IsDataField(property))
+                    yield return (property.Name, property.PropertyType);
+            }
+        }
+    }
+
+    /// <summary>
+    /// Both [DataField] and [IncludeDataField] derive from DataFieldBaseAttribute, and both put the
+    /// member on the serializer's write path.
+    /// </summary>
+    private static bool IsDataField(MemberInfo member)
+    {
+        foreach (var attribute in member.GetCustomAttributes(true))
+        {
+            if (attribute is DataFieldBaseAttribute)
+                return true;
+        }
+
+        return false;
+    }
+
+    /// <summary>
+    /// True if the serializer could reach a <see cref="DoAfterId"/> through this type: directly, through
+    /// a nullable, through a collection or array element, or through a nested data definition's own
+    /// fields. The visited set both terminates cycles and keeps repeat work down.
+    /// </summary>
+    private static bool ReachesDoAfterId(Type type, HashSet<Type> visited)
+    {
+        if (!visited.Add(type))
+            return false;
+
+        var underlying = Nullable.GetUnderlyingType(type) ?? type;
+
+        if (underlying == typeof(DoAfterId))
+            return true;
+
+        if (underlying.IsArray)
+            return underlying.GetElementType() is { } element && ReachesDoAfterId(element, visited);
+
+        if (underlying.IsGenericType)
+        {
+            foreach (var argument in underlying.GetGenericArguments())
+            {
+                if (ReachesDoAfterId(argument, visited))
+                    return true;
+            }
+        }
+
+        foreach (var (_, memberType) in DataFieldMembers(underlying))
+        {
+            if (ReachesDoAfterId(memberType, visited))
+                return true;
+        }
+
+        return false;
+    }
+
+}
+
+// The planted types below sit at namespace scope rather than inside the fixture because a data
+// definition must be partial, and a nested one would force the fixture to be partial with it.
+
+/// <summary>
+/// A handle persisted directly, which is the shape the eight fixed components had.
+/// </summary>
+[DataDefinition]
+internal sealed partial class PlantedOffender
+{
+    [DataField]
+    public DoAfterId? Handle = null;
+}
+
+/// <summary>
+/// A handle reached only through a nested data definition, which serializes just the same.
+/// </summary>
+[DataDefinition]
+internal sealed partial class PlantedNestedOffender
+{
+    [DataField]
+    public PlantedOffender Nested = new();
+}
+
+/// <summary>
+/// A handle held in a collection, which the write path walks element by element.
+/// </summary>
+[DataDefinition]
+internal sealed partial class PlantedCollectionOffender
+{
+    [DataField]
+    public List<DoAfterId> Handles = new();
+}
+
+/// <summary>
+/// Shaped like the fixed components: the handle is still there, it is simply not persisted. This is
+/// the negative control, and a detector that flags it would fail the corrected codebase.
+/// </summary>
+internal sealed class RuntimeOnlyControl
+{
+    [ViewVariables]
+    public DoAfterId? Handle = null;
+}

--- a/Content.Server/MagicMirror/MagicMirrorSystem.cs
+++ b/Content.Server/MagicMirror/MagicMirrorSystem.cs
@@ -104,6 +104,11 @@ public sealed partial class MagicMirrorSystem : SharedMagicMirrorSystem
 
     private void OnSelectSlotDoAfter(EntityUid uid, MagicMirrorComponent component, MagicMirrorSelectDoAfterEvent args)
     {
+        // Triad: the do-after has resolved either way, so the stored handle is dead. Upstream only
+        // cleared it when the next attempt started, leaving a stale id on the entity indefinitely.
+        component.DoAfter = null;
+        // End Triad
+
         if (args.Handled || args.Target == null || args.Cancelled)
             return;
 
@@ -182,6 +187,10 @@ public sealed partial class MagicMirrorSystem : SharedMagicMirrorSystem
     }
     private void OnChangeColorDoAfter(EntityUid uid, MagicMirrorComponent component, MagicMirrorChangeColorDoAfterEvent args)
     {
+        // Triad: the do-after has resolved either way, so the stored handle is dead.
+        component.DoAfter = null;
+        // End Triad
+
         if (args.Handled || args.Target == null || args.Cancelled)
             return;
 
@@ -262,6 +271,10 @@ public sealed partial class MagicMirrorSystem : SharedMagicMirrorSystem
 
     private void OnRemoveSlotDoAfter(EntityUid uid, MagicMirrorComponent component, MagicMirrorRemoveSlotDoAfterEvent args)
     {
+        // Triad: the do-after has resolved either way, so the stored handle is dead.
+        component.DoAfter = null;
+        // End Triad
+
         if (args.Handled || args.Target == null || args.Cancelled)
             return;
 
@@ -339,6 +352,10 @@ public sealed partial class MagicMirrorSystem : SharedMagicMirrorSystem
     }
     private void OnAddSlotDoAfter(EntityUid uid, MagicMirrorComponent component, MagicMirrorAddSlotDoAfterEvent args)
     {
+        // Triad: the do-after has resolved either way, so the stored handle is dead.
+        component.DoAfter = null;
+        // End Triad
+
         if (args.Handled || args.Target == null || args.Cancelled || !TryComp(component.Target, out HumanoidAppearanceComponent? humanoid))
             return;
 

--- a/Content.Server/Mech/Equipment/Components/MechGrabberComponent.cs
+++ b/Content.Server/Mech/Equipment/Components/MechGrabberComponent.cs
@@ -50,8 +50,13 @@ public sealed partial class MechGrabberComponent : Component
     [ViewVariables(VVAccess.ReadWrite)]
     public Container ItemContainer = default!;
 
+    // Triad: DoAfterId has no type serializer; persisting it breaks ship-grid saves. Runtime-only state.
+    /*
     [DataField, ViewVariables(VVAccess.ReadOnly)]
+    */
+    [ViewVariables(VVAccess.ReadOnly)]
     public DoAfterId? DoAfter;
+    // End Triad
 
     /// <summary>
     ///     Frontier - If any entities on the blacklist then UnanchorOnHit won't work on anything else.

--- a/Content.Server/NPC/Components/NPCSteeringComponent.cs
+++ b/Content.Server/NPC/Components/NPCSteeringComponent.cs
@@ -129,8 +129,13 @@ public sealed partial class NPCSteeringComponent : Component
     /// <summary>
     /// If the NPC is using a do_after to clear an obstacle.
     /// </summary>
+    // Triad: DoAfterId has no type serializer; persisting it breaks ship-grid saves. Runtime-only state.
+    /*
     [DataField("doAfterId")]
+    */
+    [ViewVariables]
     public DoAfterId? DoAfterId = null;
+    // End Triad
 }
 
 public enum SteeringStatus : byte

--- a/Content.Server/Resist/CanEscapeInventoryComponent.cs
+++ b/Content.Server/Resist/CanEscapeInventoryComponent.cs
@@ -13,8 +13,13 @@ public sealed partial class CanEscapeInventoryComponent : Component
 
     public bool IsEscaping => DoAfter != null;
 
+    // Triad: DoAfterId has no type serializer; persisting it breaks ship-grid saves. Runtime-only state.
+    /*
     [DataField("doAfter")]
+    */
+    [ViewVariables]
     public DoAfterId? DoAfter;
+    // End Triad
 
     // Frontier
     [DataField]

--- a/Content.Server/_NF/Botany/Components/PlantAnalyzerComponent.cs
+++ b/Content.Server/_NF/Botany/Components/PlantAnalyzerComponent.cs
@@ -20,8 +20,13 @@ public sealed partial class PlantAnalyzerComponent : Component
     [DataField, ViewVariables]
     public PlantAnalyzerSetting Settings = new();
 
+    // Triad: DoAfterId has no type serializer; persisting it breaks ship-grid saves. Runtime-only state.
+    /*
     [DataField, ViewVariables(VVAccess.ReadOnly)]
+    */
+    [ViewVariables(VVAccess.ReadOnly)]
     public DoAfterId? DoAfter;
+    // End Triad
 
     [DataField]
     public SoundSpecifier? ScanningEndSound;

--- a/Content.Server/_NF/Mech/Equipment/Components/MechForkComponent.cs
+++ b/Content.Server/_NF/Mech/Equipment/Components/MechForkComponent.cs
@@ -52,8 +52,13 @@ public sealed partial class MechForkComponent : Component
     [ViewVariables(VVAccess.ReadWrite)]
     public Container ItemContainer = default!;
 
+    // Triad: DoAfterId has no type serializer; persisting it breaks ship-grid saves. Runtime-only state.
+    /*
     [DataField, ViewVariables(VVAccess.ReadOnly)]
+    */
+    [ViewVariables(VVAccess.ReadOnly)]
     public DoAfterId? DoAfter;
+    // End Triad
 
     /// <summary>
     /// A whitelist of things this fork can pick up.

--- a/Content.Shared/Burial/Components/GraveComponent.cs
+++ b/Content.Shared/Burial/Components/GraveComponent.cs
@@ -49,6 +49,11 @@ public sealed partial class GraveComponent : Component
     /// <summary>
     /// Tracks someone digging themself out of the grave
     /// </summary>
+    // Triad: DoAfterId has no type serializer; persisting it breaks ship-grid saves. Runtime-only state.
+    /*
     [DataField, ViewVariables(VVAccess.ReadOnly)]
+    */
+    [ViewVariables(VVAccess.ReadOnly)]
     public DoAfterId? HandDiggingDoAfter;
+    // End Triad
 }

--- a/Content.Shared/MagicMirror/MagicMirrorComponent.cs
+++ b/Content.Shared/MagicMirror/MagicMirrorComponent.cs
@@ -10,8 +10,15 @@ namespace Content.Shared.MagicMirror;
 [RegisterComponent, NetworkedComponent, AutoGenerateComponentState]
 public sealed partial class MagicMirrorComponent : Component
 {
+    // Triad: DoAfterId is a runtime handle (user + index into their live do-after list) with no type
+    // serializer, so persisting it throws "No type serializer or data definition found" and kills the
+    // whole ship-grid save once it goes non-null. Runtime-only state now.
+    /*
     [DataField]
+    */
+    [ViewVariables]
     public DoAfterId? DoAfter;
+    // End Triad
 
     /// <summary>
     /// Magic mirror target, used for validating UI messages.

--- a/Content.Shared/Paper/EnvelopeComponent.cs
+++ b/Content.Shared/Paper/EnvelopeComponent.cs
@@ -21,8 +21,13 @@ public sealed partial class EnvelopeComponent : Component
     /// Stores the current sealing/tearing doafter of the envelope
     /// to prevent doafter spam/prediction issues
     /// </summary>
+    // Triad: DoAfterId has no type serializer; persisting it breaks ship-grid saves. Runtime-only state.
+    /*
     [DataField, ViewVariables]
+    */
+    [ViewVariables]
     public DoAfterId? EnvelopeDoAfter;
+    // End Triad
 
     /// <summary>
     /// How long it takes to seal the envelope closed


### PR DESCRIPTION
## About the PR

`DoAfterId` is a runtime handle with no type serializer, so writing one always throws. Eight components marked it `[DataField]` anyway, which hard-fails map serialization the moment any of them holds a non-null value. On a live server running this code it is currently blocking a player from saving their ship.

## Why / Balance

No balance impact. This is a data-loss fix.

A do-after id is a pointer into a user's live do-after list (`record struct DoAfterId(EntityUid Uid, ushort Index)`), with no `[DataDefinition]` and no serializer. It is meaningless across a map load, so it can only ever throw or write garbage. It should not have been persisted in the first place.

The failure looks like this:

```
[ERRO] entity_serializer: Caught exception while serializing component MagicMirror
       of entity barber scissors (10487741/n10487741, BarberScissors)
[ERRO] hardlight: Ship save failed for 'CRSV CENTRAL PROTOCOL 242-A0' on grid 10487225:
       System.ArgumentException: No type serializer or data definition found for type
       Content.Shared.DoAfter.DoAfterId when writing
```

`MagicMirror` also never cleared its handle when a do-after resolved. The only clears sat at the top of the *next* attempt, so any mirror or pair of barber scissors stayed permanently non-null after its first use. That is what arms the save-blocker: one used pair of scissors poisons every save of the grid it sits on, and it stays poisoned. The other seven are the same latent trap, they just need the right entity to land on a saveable grid.

The eight fields: `MagicMirror.DoAfter`, `Envelope.EnvelopeDoAfter`, `Grave.HandDiggingDoAfter`, `MechGrabber.DoAfter`, `MechFork.DoAfter` (`_NF`), `PlantAnalyzer.DoAfter` (`_NF`), `CanEscapeInventory.DoAfter`, `NPCSteering.DoAfterId`. Each keeps `[ViewVariables]`, so admin VV inspection is unchanged, and none of them had `AutoNetworkedField` on that field, so networking is untouched.

One note on the diff style: the removed attributes are commented out with `// Triad:` markers rather than deleted, which is a downstream fork convention for surfacing merge conflicts. If you would rather have clean deletions here, say so and I will rewrite the branch.

## Media

N/A, no ingame visual change.

## Requirements

- [x] I have read the guidelines and documentation relevant to this PR.
- [x] I have added media to this PR or it does not require an ingame showcase.
- [x] I can confirm this PR contains either no AI-generated content, or AI-generated content that meets our guidelines.

## How to test

1. Spawn a ship grid with a pair of barber scissors or a mirror on it.
2. Use it on someone, and let the do-after run to completion.
3. Save the ship through the shipyard console. Before this change that fails with the `ArgumentException` above and the save is lost. With this branch it saves.

The guard test also covers the general case:

```
dotnet test Content.IntegrationTests/Content.IntegrationTests.csproj \
  --filter "FullyQualifiedName~DoAfterIdNotPersistedTest"
```

`DoAfterIdNotPersistedTest` walks every registered component and fails on any data field the serializer could reach a `DoAfterId` through: directly, through a nullable, through a collection or array element, or through a nested data definition. It checks `DataFieldBaseAttribute`, so `[IncludeDataField]` is covered too, and it walks the base chain by hand since `GetFields` will not return private fields declared on a base type.

It ships with a control. An empty offender list only means something if the walk can actually find a handle, so a second test plants three shapes it must catch and one it must not. It was also falsified against the real registry: with the `[DataField]` put back on `MagicMirrorComponent` the sweep fails and names `MagicMirror.DoAfter (MagicMirrorComponent)`.

Not yet verified in-game. The steps above are the real check and have not been run, so "the save now succeeds" is a prediction backed by the compile, the reflection sweep, and the falsification, not a result.

## Breaking changes

None expected.

No prototype in `Resources/` sets any of the removed fields, so nothing starts erroring on load. Existing saved ships cannot contain these nodes either: writing one always threw, so the field could never have made it into a save file in the first place.

Worth flagging for review: the serialization generator emitted 50 read/write/validate sites for `DoAfterId` before this change and emits zero after. The only remaining use is `List<DoAfterId>` on `ShipRepairToolComponent`, which is `[ViewVariables]` only and was never serialized.

**Changelog**

:cl:
- fix: Ships carrying a used mirror or pair of barber scissors can be saved again.
