### PR TITLE
Make the Required Checks Always Report, and Trim PR Packaging

### DIFF
--- a/.github/workflows/nf-shipyard-tests.yml
+++ b/.github/workflows/nf-shipyard-tests.yml
@@ -1,19 +1,23 @@
 name: Build & Run Shipyard Tests
 
 on:
+  # Triad: the `paths` filter is commented out rather than deleted. `Build & Run Shipyard
+  # Tests` is a required check, and a required check that never runs sits as "expected" and
+  # blocks the merge forever. The job is ~6m and runs concurrently with Build & Test Debug
+  # (~10m), so always running it costs no wall-clock.
   pull_request:
     branches: [ "main" ]
-    paths:
-      - "Resources/Maps/_Mono/Shuttles/**/*.yml" # Ship grids, Mono - set to mono files
-      - "Resources/Prototypes/_Mono/Shipyard/**/*.yml" # Shipyard prototypes, Mono - set to mono files
-      - "Content.IntegrationTests/Tests/_NF/ShipyardTests.cs" # Shipyard tests
-      - "Resources/Prototypes/Entities/**/*.yml" # Mono Change, run when an entity may have changed price
+    # paths:
+    #   - "Resources/Maps/_Mono/Shuttles/**/*.yml" # Ship grids, Mono - set to mono files
+    #   - "Resources/Prototypes/_Mono/Shipyard/**/*.yml" # Shipyard prototypes, Mono - set to mono files
+    #   - "Content.IntegrationTests/Tests/_NF/ShipyardTests.cs" # Shipyard tests
+    #   - "Resources/Prototypes/Entities/**/*.yml" # Mono Change, run when an entity may have changed price
 
 # Triad: this workflow had no concurrency group, so pushing twice to a PR ran both to
-# completion. PR-triggered only, so no merge_group case to worry about here.
+# completion. Only ever cancel PR runs, matching the other validators.
 concurrency:
   group: ${{ github.workflow }}-${{ github.event_name == 'pull_request' && github.event.pull_request.number || github.ref }}
-  cancel-in-progress: ${{ github.event_name != 'merge_group' }}
+  cancel-in-progress: ${{ github.event_name == 'pull_request' }}
 
 jobs:
   build:

--- a/.github/workflows/publish-changelog.yml
+++ b/.github/workflows/publish-changelog.yml
@@ -1,5 +1,14 @@
 name: Publish Changelog
 
+# Triad: this workflow is NOT the live Discord changelog poster, despite the name. The one that
+# runs is the `Publish changelog (Discord)` step in publish.yml, which fires on every publish.
+# This one is a dormant duplicate; its cron was commented out in 6554b7a808 and again in
+# de4d30e5cb, and its last run was 2026-05-15.
+#
+# Do not re-enable the cron. Both paths run Tools/actions_changelogs_since_last_run.py, which
+# diffs against the last successful run of whichever workflow it is running under, so enabling
+# this one would double-post every future changelog and, on its first run, post every entry
+# accumulated since 2026-05-15.
 on:
   workflow_dispatch:
   # schedule:

--- a/.github/workflows/test-packaging.yml
+++ b/.github/workflows/test-packaging.yml
@@ -19,17 +19,23 @@ on:
       # concurrency is per run, so a run whose jobs all skip still cancels the merge run.
       - '!Resources/Changelog/**'
   merge_group:
+  # Triad: the `paths` filter is commented out rather than deleted. `Test Packaging` is a
+  # required check, and a required check that never runs sits as "expected" and blocks the
+  # merge forever, so a docs-only or sprite-only PR could never merge. The job is ~10m and
+  # runs concurrently with Build & Test Debug (~10m), which has no filter, so always running
+  # it does not move the critical path. The push filter above is kept: push runs are not
+  # required checks.
   pull_request:
     types: [ opened, reopened, synchronize, ready_for_review ]
     branches: [ main, staging, stable ]
-    paths:
-      - '**.cs'
-      - '**.csproj'
-      - '**.sln'
-      - '**.git**'
-      - '**.yml'
-      - 'RobustToolbox'
-      - 'RobustToolbox/**'
+    # paths:
+    #   - '**.cs'
+    #   - '**.csproj'
+    #   - '**.sln'
+    #   - '**.git**'
+    #   - '**.yml'
+    #   - 'RobustToolbox'
+    #   - 'RobustToolbox/**'
 
 # Triad: key PR runs on PR number; only ever cancel PR runs. Cancelling a merge_group entry
 # fails the queue, and cancelling a push run abandons main's only test coverage.

--- a/.github/workflows/test-packaging.yml
+++ b/.github/workflows/test-packaging.yml
@@ -49,6 +49,17 @@ jobs:
     if: github.event.pull_request.draft == false
     runs-on: ubuntu-latest
     timeout-minutes: 30 # Triad: job takes ~10m.
+    env:
+      # Triad: this job packages and then throws the output away; it exists to prove the
+      # packaging path still works. Measured at 439s of a 608s run for all four platforms,
+      # which is the single largest cost in PR CI. One platform proves the same path, so
+      # pull requests build linux-x64 only. Pushes and merge_group keep all four, because a
+      # platform-specific break (an osx-only runtime identifier, say) would otherwise not
+      # surface until Publish, and publish.yml packages all four for real.
+      SERVER_PLATFORMS: >-
+        ${{ github.event_name == 'pull_request'
+        && '--platform linux-x64'
+        || '--platform win-x64 --platform linux-x64 --platform osx-x64 --platform linux-arm64' }}
 
     steps:
       - name: Checkout Master
@@ -78,7 +89,8 @@ jobs:
         run: dotnet build Content.Packaging --configuration Release --no-restore /m
 
       - name: Package server
-        run: dotnet run --project Content.Packaging server --platform win-x64 --platform linux-x64 --platform osx-x64 --platform linux-arm64
+        # Triad: unquoted on purpose, SERVER_PLATFORMS carries multiple arguments.
+        run: dotnet run --project Content.Packaging server $SERVER_PLATFORMS
 
       - name: Package client
         run: dotnet run --project Content.Packaging client --no-wipe-release

--- a/.github/workflows/validate-rsis.yml
+++ b/.github/workflows/validate-rsis.yml
@@ -8,9 +8,13 @@ on:
     # commit's run. Keep this off `pull_request`, where a required check that never runs pends.
     paths-ignore: [ 'Resources/Changelog/**' ]
   merge_group:
+  # Triad: the `paths` filter is commented out rather than deleted. `Validate RSIs` is a
+  # required check, and a required check that never runs sits as "expected" and blocks the
+  # merge forever. The job is ~1m and runs concurrently with Build & Test Debug (~10m), so
+  # always running it costs no wall-clock.
   pull_request:
-    paths:
-      - '**.rsi/**'
+    # paths:
+    #   - '**.rsi/**'
 
 # Triad: key PR runs on PR number; only ever cancel PR runs. Cancelling a merge_group entry
 # fails the queue, and cancelling a push run abandons main's only test coverage.

--- a/Tools/publish_multi_request.py
+++ b/Tools/publish_multi_request.py
@@ -15,8 +15,10 @@ RELEASE_DIR = "release"
 # CONFIGURATION PARAMETERS
 # Forks should change these to publish to their own infrastructure.
 #
-ROBUST_CDN_URL = "https://cdn.triad-sector.com/"
-FORK_ID = "Triad"
+# Triad: both values below are ours, not upstream's. Keep them in step with the preflight URL
+# in .github/workflows/publish.yml, which GETs fork/<FORK_ID>/version/<sha>/manifest.
+ROBUST_CDN_URL = "https://cdn.triad-sector.com/" # Triad
+FORK_ID = "Triad" # Triad
 
 def main():
     parser = argparse.ArgumentParser()


### PR DESCRIPTION
## About the PR
Makes every check we intend to require actually report on every pull request, and cuts the
largest single cost in PR CI. Three named checks carried `pull_request` path filters, so
requiring them would have blocked any PR that missed their paths.

## Why / Balance
A required status check that never runs sits as "expected" and blocks the merge forever. Three
of the checks slated to be required were path-filtered:

| Check | Filtered on |
| --- | --- |
| `Test Packaging` | `**.cs`, `**.csproj`, `**.sln`, `**.git**`, `**.yml`, `RobustToolbox/**` |
| `Validate RSIs` | `**.rsi/**` |
| `Build & Run Shipyard Tests` | `Resources/Maps/_Mono/Shuttles/**`, `Resources/Prototypes/_Mono/Shipyard/**`, `ShipyardTests.cs`, `Resources/Prototypes/Entities/**` |

#494 demonstrated it by accident: it touched only `.github/workflows`, so `Validate RSIs` never
reported at all. Had it been required, that PR could not have merged.

The cost of always running them is close to zero. Measured over the last six successful runs
each: `Test Packaging` ~10m, `Build & Run Shipyard Tests` ~6m, `Validate RSIs` ~1m. All three
run concurrently with `Build & Test Debug`, which has no filter and is already the ~10m
critical path. Nothing moves.

Filters are commented out rather than deleted so a future merge surfaces them. `Test Packaging`
keeps its `push` filter, including the changelog negation from #494, because push runs are not
required checks.

`nf-shipyard-tests.yml` was the last validator still keyed on `!= 'merge_group'`. Harmless
today since it has no push trigger, but it would reintroduce #494's bug the moment one is added.

Separately, `Test Packaging` packages the server for four platforms and then discards the
output; it exists to prove the packaging path still works. Measured at 439s of a 608s run, which
is the single largest cost in PR CI and longer than the whole `Build & Test Debug` critical path
it runs beside. Pull requests now package `linux-x64` only, which exercises the same path.
Pushes and `merge_group` keep all four, so a platform-specific break (an osx-only runtime
identifier, say) still surfaces before `publish.yml` packages all four for real.

No NuGet cache, having looked at it: restore measures 22s, a cache round-trip on a package
directory that size would eat most of that, and there are no `packages.lock.json` files, so
`setup-dotnet`'s cache option is not usable here regardless.

Two documentation fixes while in here. `Tools/publish_multi_request.py` holds our
`ROBUST_CDN_URL` and `FORK_ID` with no marker at all, so a merge touching those lines would
silently take upstream's values and publish to the wrong place. And `publish-changelog.yml` now
says plainly that it is not the live Discord poster, because it looks exactly like one; the live
poster is the step inside `publish.yml`, and re-enabling that dormant cron would double-post
every changelog.

## Media
N/A, CI only.

## Requirements
- [x] I have read the guidelines and documentation relevant to this PR.
- [x] I have added media to this PR or it does not require an ingame showcase.
- [x] I can confirm this PR contains either no AI-generated content, or AI-generated content that meets our guidelines.

## How to test
All four workflow files parse under PyYAML, `publish_multi_request.py` compiles, and no check
name changes, which matters because those names are what branch protection keys off. On this PR
specifically, `Test Packaging`, `Validate RSIs` and `Build & Run Shipyard Tests` should all
report, where on #494 `Validate RSIs` did not. `Test Packaging` should also come in noticeably
faster, since it will package one platform rather than four.

## Breaking changes
None. Contributors will see three more checks on pull requests that previously skipped them.

**Changelog**
No `:cl:`, CI only and not player facing.
