### PR TITLE
Erudite Shutters Fix

### DIFF
--- a/Resources/Maps/_Triad/Shuttles/CIV/erudite.yml
+++ b/Resources/Maps/_Triad/Shuttles/CIV/erudite.yml
@@ -1,11 +1,11 @@
 meta:
   format: 7
   category: Grid
-  engineVersion: 277.2.1
+  engineVersion: 287.0.0
   forkId: ""
   forkVersion: ""
-  time: 08/08/2026 04:46:21
-  entityCount: 723
+  time: 08/11/2026 03:43:32
+  entityCount: 722
 maps: []
 grids:
 - 1
@@ -62,9 +62,9 @@ entities:
           version: 7
     - type: Broadphase
     - type: Physics
-      bodyStatus: InAir
       fixedRotation: False
       bodyType: Dynamic
+      bodyStatus: InAir
     - type: Fixtures
       fixtures: {}
     - type: DecalGrid
@@ -72,35 +72,35 @@ entities:
         version: 2
         nodes:
         - node:
-            color: '#FFFFFFFF'
             id: Flowersbr1
+            color: '#FFFFFFFF'
           decals:
             17: 12,2
         - node:
-            color: '#FFFFFFFF'
             id: Flowerspv2
+            color: '#FFFFFFFF'
           decals:
             13: 12,2
         - node:
-            color: '#FFFFFFFF'
             id: Flowerspv3
+            color: '#FFFFFFFF'
           decals:
             16: 12,2
         - node:
-            color: '#724276FF'
             id: ShiptestSplineEast
+            color: '#724276FF'
           decals:
             140: 6,5
             177: 13,13
             178: 13,12
         - node:
-            color: '#724276FF'
             id: ShiptestSplineEastEnd
+            color: '#724276FF'
           decals:
             171: 14,11
         - node:
-            color: '#724276FF'
             id: ShiptestSplineNorth
+            color: '#724276FF'
           decals:
             117: 9,6
             126: 6,6
@@ -108,87 +108,87 @@ entities:
             128: 8,6
             143: 7,4
         - node:
-            color: '#724276FF'
             id: ShiptestSplineNorthEast
+            color: '#724276FF'
           decals:
             116: 10,6
             176: 13,14
         - node:
-            color: '#724276FF'
             id: ShiptestSplineNorthEastCorner
+            color: '#724276FF'
           decals:
             146: 6,4
             179: 13,11
         - node:
-            color: '#724276FF'
             id: ShiptestSplineNorthWest
+            color: '#724276FF'
           decals:
             125: 5,6
             175: 12,14
         - node:
-            color: '#724276FF'
             id: ShiptestSplineNorthWestCorner
+            color: '#724276FF'
           decals:
             145: 8,4
         - node:
-            color: '#724276FF'
             id: ShiptestSplineSouth
+            color: '#724276FF'
           decals:
             119: 9,5
             123: 7,4
             141: 7,6
             172: 13,11
         - node:
-            color: '#724276FF'
             id: ShiptestSplineSouthEast
+            color: '#724276FF'
           decals:
             118: 10,5
             121: 8,4
         - node:
-            color: '#724276FF'
             id: ShiptestSplineSouthEastCorner
+            color: '#724276FF'
           decals:
             120: 8,5
             144: 6,6
         - node:
-            color: '#724276FF'
             id: ShiptestSplineSouthWest
+            color: '#724276FF'
           decals:
             134: 5,4
             137: 6,4
             138: 5,5
             170: 12,11
         - node:
-            color: '#724276FF'
             id: ShiptestSplineSouthWestCorner
+            color: '#724276FF'
           decals:
             139: 6,5
             147: 8,6
         - node:
-            color: '#724276FF'
             id: ShiptestSplineWest
+            color: '#724276FF'
           decals:
             142: 8,5
             173: 12,12
             174: 12,13
         - node:
-            color: '#FFFFFFFF'
             id: TechCornerE
+            color: '#FFFFFFFF'
           decals:
             103: 7,13
         - node:
-            color: '#FFFFFFFF'
             id: TechCornerN
+            color: '#FFFFFFFF'
           decals:
             101: 5,13
         - node:
-            color: '#FFFFFFFF'
             id: TechCornerW
+            color: '#FFFFFFFF'
           decals:
             102: 5,11
         - node:
-            color: '#FFFFFFFF'
             id: TechE
+            color: '#FFFFFFFF'
           decals:
             6: 14,18
             7: 14,17
@@ -198,8 +198,8 @@ entities:
             84: 10,12
             160: 14,8
         - node:
-            color: '#FFFFFFFF'
             id: TechN
+            color: '#FFFFFFFF'
           decals:
             10: 13,19
             86: 9,13
@@ -207,8 +207,8 @@ entities:
             100: 6,14
             159: 13,9
         - node:
-            color: '#FFFFFFFF'
             id: TechNE
+            color: '#FFFFFFFF'
           decals:
             0: 14,19
             85: 10,13
@@ -218,8 +218,8 @@ entities:
             157: 14,9
             166: 9,12
         - node:
-            color: '#FFFFFFFF'
             id: TechNW
+            color: '#FFFFFFFF'
           decals:
             1: 12,19
             95: 5,14
@@ -229,8 +229,8 @@ entities:
             158: 12,9
             165: 6,12
         - node:
-            color: '#FFFFFFFF'
             id: TechS
+            color: '#FFFFFFFF'
           decals:
             2: 13,16
             89: 9,8
@@ -239,8 +239,8 @@ entities:
             92: 6,8
             161: 13,7
         - node:
-            color: '#FFFFFFFF'
             id: TechSE
+            color: '#FFFFFFFF'
           decals:
             4: 14,16
             80: 10,8
@@ -249,8 +249,8 @@ entities:
             163: 9,9
             169: 9,3
         - node:
-            color: '#FFFFFFFF'
             id: TechSW
+            color: '#FFFFFFFF'
           decals:
             5: 12,16
             88: 5,8
@@ -261,8 +261,8 @@ entities:
             167: 14,12
             168: 11,3
         - node:
-            color: '#FFFFFFFF'
             id: TechW
+            color: '#FFFFFFFF'
           decals:
             8: 12,18
             9: 12,17
@@ -271,34 +271,34 @@ entities:
             104: 5,10
             162: 12,8
         - node:
-            color: '#FFFFFFFF'
             id: WarnCornerSmallGreyscaleNE
+            color: '#FFFFFFFF'
           decals:
             59: 17,5
         - node:
-            color: '#FFFFFFFF'
             id: WarnCornerSmallGreyscaleNW
+            color: '#FFFFFFFF'
           decals:
             78: 2,5
         - node:
-            color: '#FFFFFFFF'
             id: WarnCornerSmallGreyscaleSE
+            color: '#FFFFFFFF'
           decals:
             60: 16,4
         - node:
-            color: '#FFFFFFFF'
             id: WarnCornerSmallGreyscaleSW
+            color: '#FFFFFFFF'
           decals:
             79: 3,4
         - node:
-            color: '#FFFFFFFF'
             id: WarnLineE
+            color: '#FFFFFFFF'
           decals:
             57: 18,4
             58: 18,5
         - node:
-            color: '#FFFFFFFF'
             id: WarnLineGreyscaleE
+            color: '#FFFFFFFF'
           decals:
             43: 17,6
             44: 17,7
@@ -309,22 +309,22 @@ entities:
             68: 4,3
             69: 4,2
         - node:
-            color: '#FFFFFFFF'
             id: WarnLineGreyscaleN
+            color: '#FFFFFFFF'
           decals:
             48: 18,5
             65: 1,5
         - node:
-            color: '#FFFFFFFF'
             id: WarnLineGreyscaleS
+            color: '#FFFFFFFF'
           decals:
             49: 18,4
             50: 17,4
             66: 1,4
             67: 2,4
         - node:
-            color: '#FFFFFFFF'
             id: WarnLineGreyscaleW
+            color: '#FFFFFFFF'
           decals:
             41: 16,6
             42: 16,7
@@ -335,80 +335,80 @@ entities:
             70: 3,2
             71: 3,3
         - node:
-            color: '#FFFFFFFF'
             id: WarnLineN
+            color: '#FFFFFFFF'
           decals:
             55: 16,2
             56: 15,2
             72: 4,2
             73: 3,2
         - node:
-            color: '#FFFFFFFF'
             id: WarnLineS
+            color: '#FFFFFFFF'
           decals:
             74: 1,4
             75: 1,5
         - node:
-            color: '#FFFFFFFF'
             id: WarnLineW
+            color: '#FFFFFFFF'
           decals:
             45: 17,7
             46: 16,7
             76: 2,7
             77: 3,7
         - node:
-            color: '#FFFFFFFF'
             id: WoodTrimThinCornerNe
+            color: '#FFFFFFFF'
           decals:
             20: 11,2
         - node:
-            color: '#FFFFFFFF'
             id: WoodTrimThinCornerNw
+            color: '#FFFFFFFF'
           decals:
             152: 12,5
         - node:
-            color: '#FFFFFFFF'
             id: WoodTrimThinCornerSe
+            color: '#FFFFFFFF'
           decals:
             23: 11,1
             150: 13,4
         - node:
-            color: '#FFFFFFFF'
             id: WoodTrimThinCornerSw
+            color: '#FFFFFFFF'
           decals:
             22: 8,1
             151: 12,4
         - node:
-            color: '#FFFFFFFF'
             id: WoodTrimThinEndE
+            color: '#FFFFFFFF'
           decals:
             149: 14,5
         - node:
-            color: '#FFFFFFFF'
             id: WoodTrimThinEndW
+            color: '#FFFFFFFF'
           decals:
             30: 7,2
         - node:
-            color: '#FFFFFFFF'
             id: WoodTrimThinInnerSe
+            color: '#FFFFFFFF'
           decals:
             154: 13,5
         - node:
-            color: '#FFFFFFFF'
             id: WoodTrimThinInnerSw
+            color: '#FFFFFFFF'
           decals:
             29: 8,2
         - node:
-            color: '#FFFFFFFF'
             id: WoodTrimThinLineN
+            color: '#FFFFFFFF'
           decals:
             24: 9,2
             25: 10,2
             28: 8,2
             153: 13,5
         - node:
-            color: '#FFFFFFFF'
             id: WoodTrimThinLineS
+            color: '#FFFFFFFF'
           decals:
             26: 9,1
             27: 10,1
@@ -416,10 +416,10 @@ entities:
     - type: ThermalSignature
     - type: SpreaderGrid
       spreadQueues:
-        Kudzu: []
-        MetalFoam: []
-        Puddle: []
         Smoke: []
+        Puddle: []
+        MetalFoam: []
+        Kudzu: []
     - type: Shuttle
       dampingModifier: 0.25
     - type: GridPathfinding
@@ -432,6 +432,64 @@ entities:
     - type: GridAtmosphere
       version: 2
       data:
+        uniqueMixes:
+        - temperature: 293.15
+          volume: 2500
+          moles:
+          - 0
+          - 0
+          - 0
+          - 0
+          - 0
+          - 0
+          - 0
+          - 0
+          - 0
+          - 0
+          - 0
+          - 0
+          - 0
+          - 0
+          - 0
+          - 0
+        - volume: 2500
+          moles:
+          - 0
+          - 0
+          - 0
+          - 0
+          - 0
+          - 0
+          - 0
+          - 0
+          - 0
+          - 0
+          - 0
+          - 0
+          - 0
+          - 0
+          - 0
+          - 0
+          immutable: True
+        - temperature: 293.15
+          volume: 2500
+          moles:
+          - 21.824879
+          - 82.10312
+          - 0
+          - 0
+          - 0
+          - 0
+          - 0
+          - 0
+          - 0
+          - 0
+          - 0
+          - 0
+          - 0
+          - 0
+          - 0
+          - 0
         tiles:
           0,0:
             0: 39488
@@ -494,74 +552,18 @@ entities:
             2: 5
           4,5:
             0: 1
-        uniqueMixes:
-        - volume: 2500
-          temperature: 293.15
-          moles:
-          - 0
-          - 0
-          - 0
-          - 0
-          - 0
-          - 0
-          - 0
-          - 0
-          - 0
-          - 0
-          - 0
-          - 0
-          - 0
-          - 0
-          - 0
-          - 0
-        - volume: 2500
-          immutable: True
-          moles:
-          - 0
-          - 0
-          - 0
-          - 0
-          - 0
-          - 0
-          - 0
-          - 0
-          - 0
-          - 0
-          - 0
-          - 0
-          - 0
-          - 0
-          - 0
-          - 0
-        - volume: 2500
-          temperature: 293.15
-          moles:
-          - 21.824879
-          - 82.10312
-          - 0
-          - 0
-          - 0
-          - 0
-          - 0
-          - 0
-          - 0
-          - 0
-          - 0
-          - 0
-          - 0
-          - 0
-          - 0
-          - 0
         chunkSize: 4
     - type: GasTileOverlay
+    - type: ChunkContainer
+      chunkEntities: []
 - proto: AirAlarm
   entities:
   - uid: 2
     components:
     - type: Transform
+      parent: 1
       rot: 1.5707963267948966 rad
       pos: 4.5,8.5
-      parent: 1
     - type: DeviceList
       devices:
       - 402
@@ -575,9 +577,9 @@ entities:
   - uid: 3
     components:
     - type: Transform
+      parent: 1
       rot: 1.5707963267948966 rad
       pos: 11.5,11.5
-      parent: 1
     - type: DeviceList
       devices:
       - 417
@@ -588,18 +590,18 @@ entities:
   - uid: 4
     components:
     - type: Transform
+      parent: 1
       rot: 4.71238898038469 rad
       pos: 14.5,15.5
-      parent: 1
     - type: DeviceList
       devices:
       - 411
   - uid: 5
     components:
     - type: Transform
+      parent: 1
       rot: 3.141592653589793 rad
       pos: 4.5,10.5
-      parent: 1
     - type: DeviceList
       devices:
       - 410
@@ -609,8 +611,8 @@ entities:
   - uid: 6
     components:
     - type: Transform
-      pos: 7.5,7.5
       parent: 1
+      pos: 7.5,7.5
     - type: DeviceList
       devices:
       - 292
@@ -621,8 +623,8 @@ entities:
   - uid: 7
     components:
     - type: Transform
-      pos: 7.5,3.5
       parent: 1
+      pos: 7.5,3.5
     - type: DeviceList
       devices:
       - 400
@@ -631,8 +633,8 @@ entities:
   - uid: 8
     components:
     - type: Transform
-      pos: 13.5,6.5
       parent: 1
+      pos: 13.5,6.5
     - type: DeviceList
       devices:
       - 294
@@ -641,9 +643,9 @@ entities:
   - uid: 9
     components:
     - type: Transform
+      parent: 1
       rot: 3.141592653589793 rad
       pos: 7.5,9.5
-      parent: 1
     - type: DeviceList
       devices:
       - 407
@@ -652,9 +654,9 @@ entities:
   - uid: 10
     components:
     - type: Transform
+      parent: 1
       rot: 1.5707963267948966 rad
       pos: 11.5,15.5
-      parent: 1
     - type: DeviceList
       devices:
       - 403
@@ -666,1400 +668,1400 @@ entities:
   - uid: 11
     components:
     - type: Transform
-      pos: 4.5,5.5
       parent: 1
+      pos: 4.5,5.5
   - uid: 12
     components:
     - type: Transform
-      pos: 15.5,5.5
       parent: 1
+      pos: 15.5,5.5
 - proto: AirlockGlassShuttle
   entities:
   - uid: 13
     components:
     - type: Transform
+      parent: 1
       rot: 3.141592653589793 rad
       pos: 12.5,20.5
-      parent: 1
   - uid: 14
     components:
     - type: Transform
+      parent: 1
       rot: 3.141592653589793 rad
       pos: 14.5,20.5
-      parent: 1
 - proto: AirlockHatch
   entities:
   - uid: 15
     components:
     - type: Transform
-      pos: 8.5,13.5
       parent: 1
+      pos: 8.5,13.5
   - uid: 16
     components:
     - type: Transform
-      pos: 5.5,10.5
       parent: 1
+      pos: 5.5,10.5
   - uid: 17
     components:
     - type: Transform
-      pos: 8.5,9.5
       parent: 1
+      pos: 8.5,9.5
   - uid: 18
     components:
     - type: Transform
-      pos: 8.5,7.5
       parent: 1
+      pos: 8.5,7.5
   - uid: 19
     components:
     - type: Transform
-      pos: 11.5,8.5
       parent: 1
+      pos: 11.5,8.5
   - uid: 20
     components:
     - type: Transform
-      pos: 11.5,5.5
       parent: 1
+      pos: 11.5,5.5
   - uid: 21
     components:
     - type: Transform
-      pos: 10.5,4.5
       parent: 1
+      pos: 10.5,4.5
   - uid: 22
     components:
     - type: Transform
-      pos: 11.5,13.5
       parent: 1
+      pos: 11.5,13.5
 - proto: AirlockScienceGlass
   entities:
   - uid: 23
     components:
     - type: Transform
-      pos: 14.5,13.5
       parent: 1
+      pos: 14.5,13.5
 - proto: APCBasic
   entities:
   - uid: 24
     components:
     - type: Transform
+      parent: 1
       rot: 1.5707963267948966 rad
       pos: 6.5,11.5
+  - uid: 25
+    components:
+    - type: Transform
       parent: 1
+      rot: 1.5707963267948966 rad
+      pos: 11.5,9.5
   - uid: 26
     components:
     - type: Transform
-      rot: 1.5707963267948966 rad
-      pos: 11.5,9.5
       parent: 1
+      rot: -1.5707963267948966 rad
+      pos: 4.5,4.5
   - uid: 27
     components:
     - type: Transform
-      rot: -1.5707963267948966 rad
-      pos: 4.5,4.5
       parent: 1
+      rot: 3.141592653589793 rad
+      pos: 6.5,3.5
+  - uid: 28
+    components:
+    - type: Transform
+      parent: 1
+      rot: 1.5707963267948966 rad
+      pos: 15.5,4.5
   - uid: 29
     components:
     - type: Transform
-      rot: 3.141592653589793 rad
-      pos: 6.5,3.5
       parent: 1
-  - uid: 583
-    components:
-    - type: Transform
-      rot: 1.5707963267948966 rad
-      pos: 15.5,4.5
-      parent: 1
-  - uid: 584
-    components:
-    - type: Transform
       rot: 1.5707963267948966 rad
       pos: 11.5,12.5
-      parent: 1
 - proto: AtmosDeviceFanDirectional
   entities:
   - uid: 30
     components:
     - type: Transform
+      parent: 1
       rot: 4.71238898038469 rad
       pos: 11.5,18.5
-      parent: 1
   - uid: 31
     components:
     - type: Transform
+      parent: 1
       rot: 4.71238898038469 rad
       pos: 11.5,17.5
-      parent: 1
   - uid: 32
     components:
     - type: Transform
+      parent: 1
       rot: 4.71238898038469 rad
       pos: 11.5,16.5
-      parent: 1
   - uid: 33
     components:
     - type: Transform
+      parent: 1
       rot: 3.141592653589793 rad
       pos: 14.5,20.5
-      parent: 1
   - uid: 34
     components:
     - type: Transform
+      parent: 1
       rot: 3.141592653589793 rad
       pos: 12.5,20.5
-      parent: 1
   - uid: 35
     components:
     - type: Transform
+      parent: 1
       rot: 4.71238898038469 rad
       pos: 4.5,5.5
-      parent: 1
   - uid: 36
     components:
     - type: Transform
+      parent: 1
       rot: 1.5707963267948966 rad
       pos: 15.5,5.5
-      parent: 1
   - uid: 37
     components:
     - type: Transform
+      parent: 1
       rot: 1.5707963267948966 rad
       pos: 14.5,13.5
-      parent: 1
 - proto: AtmosFixBlockerMarker
   entities:
   - uid: 38
     components:
     - type: Transform
-      pos: 10.5,20.5
       parent: 1
+      pos: 10.5,20.5
   - uid: 39
     components:
     - type: Transform
-      pos: 10.5,19.5
       parent: 1
+      pos: 10.5,19.5
   - uid: 40
     components:
     - type: Transform
-      pos: 10.5,18.5
       parent: 1
+      pos: 10.5,18.5
   - uid: 41
     components:
     - type: Transform
-      pos: 10.5,17.5
       parent: 1
+      pos: 10.5,17.5
   - uid: 42
     components:
     - type: Transform
-      pos: 10.5,16.5
       parent: 1
+      pos: 10.5,16.5
   - uid: 43
     components:
     - type: Transform
-      pos: 10.5,15.5
       parent: 1
+      pos: 10.5,15.5
   - uid: 44
     components:
     - type: Transform
-      pos: 16.5,20.5
       parent: 1
+      pos: 16.5,20.5
   - uid: 45
     components:
     - type: Transform
-      pos: 16.5,10.5
       parent: 1
+      pos: 16.5,10.5
   - uid: 46
     components:
     - type: Transform
-      pos: 16.5,8.5
       parent: 1
+      pos: 16.5,8.5
   - uid: 47
     components:
     - type: Transform
-      pos: 16.5,7.5
       parent: 1
+      pos: 16.5,7.5
   - uid: 48
     components:
     - type: Transform
-      pos: 16.5,6.5
       parent: 1
+      pos: 16.5,6.5
   - uid: 49
     components:
     - type: Transform
-      pos: 16.5,5.5
       parent: 1
+      pos: 16.5,5.5
   - uid: 50
     components:
     - type: Transform
-      pos: 16.5,4.5
       parent: 1
+      pos: 16.5,4.5
   - uid: 51
     components:
     - type: Transform
-      pos: 17.5,8.5
       parent: 1
+      pos: 17.5,8.5
   - uid: 52
     components:
     - type: Transform
-      pos: 17.5,7.5
       parent: 1
+      pos: 17.5,7.5
   - uid: 53
     components:
     - type: Transform
-      pos: 17.5,6.5
       parent: 1
+      pos: 17.5,6.5
   - uid: 54
     components:
     - type: Transform
-      pos: 17.5,4.5
       parent: 1
+      pos: 17.5,4.5
   - uid: 55
     components:
     - type: Transform
-      pos: 17.5,5.5
       parent: 1
+      pos: 17.5,5.5
   - uid: 56
     components:
     - type: Transform
-      pos: 18.5,5.5
       parent: 1
+      pos: 18.5,5.5
   - uid: 57
     components:
     - type: Transform
-      pos: 18.5,4.5
       parent: 1
+      pos: 18.5,4.5
   - uid: 58
     components:
     - type: Transform
-      pos: 19.5,5.5
       parent: 1
+      pos: 19.5,5.5
   - uid: 59
     components:
     - type: Transform
-      pos: 19.5,4.5
       parent: 1
+      pos: 19.5,4.5
   - uid: 60
     components:
     - type: Transform
-      pos: 15.5,3.5
       parent: 1
+      pos: 15.5,3.5
   - uid: 61
     components:
     - type: Transform
-      pos: 15.5,2.5
       parent: 1
+      pos: 15.5,2.5
   - uid: 62
     components:
     - type: Transform
-      pos: 15.5,1.5
       parent: 1
+      pos: 15.5,1.5
   - uid: 63
     components:
     - type: Transform
-      pos: 16.5,3.5
       parent: 1
+      pos: 16.5,3.5
   - uid: 64
     components:
     - type: Transform
-      pos: 16.5,2.5
       parent: 1
+      pos: 16.5,2.5
   - uid: 65
     components:
     - type: Transform
-      pos: 16.5,1.5
       parent: 1
+      pos: 16.5,1.5
   - uid: 66
     components:
     - type: Transform
-      pos: 14.5,1.5
       parent: 1
+      pos: 14.5,1.5
   - uid: 67
     components:
     - type: Transform
-      pos: 17.5,1.5
       parent: 1
+      pos: 17.5,1.5
   - uid: 68
     components:
     - type: Transform
-      pos: 18.5,2.5
       parent: 1
+      pos: 18.5,2.5
   - uid: 69
     components:
     - type: Transform
-      pos: 19.5,3.5
       parent: 1
+      pos: 19.5,3.5
   - uid: 70
     components:
     - type: Transform
-      pos: 19.5,6.5
       parent: 1
+      pos: 19.5,6.5
   - uid: 71
     components:
     - type: Transform
-      pos: 19.5,7.5
       parent: 1
+      pos: 19.5,7.5
   - uid: 72
     components:
     - type: Transform
-      pos: 18.5,8.5
       parent: 1
+      pos: 18.5,8.5
   - uid: 73
     components:
     - type: Transform
-      pos: 5.5,1.5
       parent: 1
+      pos: 5.5,1.5
   - uid: 74
     components:
     - type: Transform
-      pos: 4.5,1.5
       parent: 1
+      pos: 4.5,1.5
   - uid: 75
     components:
     - type: Transform
-      pos: 4.5,2.5
       parent: 1
+      pos: 4.5,2.5
   - uid: 76
     components:
     - type: Transform
-      pos: 4.5,3.5
       parent: 1
+      pos: 4.5,3.5
   - uid: 77
     components:
     - type: Transform
-      pos: 3.5,1.5
       parent: 1
+      pos: 3.5,1.5
   - uid: 78
     components:
     - type: Transform
-      pos: 3.5,2.5
       parent: 1
+      pos: 3.5,2.5
   - uid: 79
     components:
     - type: Transform
-      pos: 3.5,3.5
       parent: 1
+      pos: 3.5,3.5
   - uid: 80
     components:
     - type: Transform
-      pos: 2.5,1.5
       parent: 1
+      pos: 2.5,1.5
   - uid: 81
     components:
     - type: Transform
-      pos: 1.5,2.5
       parent: 1
+      pos: 1.5,2.5
   - uid: 82
     components:
     - type: Transform
-      pos: 0.5,4.5
       parent: 1
+      pos: 0.5,4.5
   - uid: 83
     components:
     - type: Transform
-      pos: 0.5,5.5
       parent: 1
+      pos: 0.5,5.5
   - uid: 84
     components:
     - type: Transform
-      pos: 1.5,4.5
       parent: 1
+      pos: 1.5,4.5
   - uid: 85
     components:
     - type: Transform
-      pos: 1.5,5.5
       parent: 1
+      pos: 1.5,5.5
   - uid: 86
     components:
     - type: Transform
-      pos: 2.5,4.5
       parent: 1
+      pos: 2.5,4.5
   - uid: 87
     components:
     - type: Transform
-      pos: 2.5,5.5
       parent: 1
+      pos: 2.5,5.5
   - uid: 88
     components:
     - type: Transform
-      pos: 3.5,4.5
       parent: 1
+      pos: 3.5,4.5
   - uid: 89
     components:
     - type: Transform
-      pos: 3.5,5.5
       parent: 1
+      pos: 3.5,5.5
   - uid: 90
     components:
     - type: Transform
-      pos: 2.5,6.5
       parent: 1
+      pos: 2.5,6.5
   - uid: 91
     components:
     - type: Transform
-      pos: 2.5,7.5
       parent: 1
+      pos: 2.5,7.5
   - uid: 92
     components:
     - type: Transform
-      pos: 2.5,8.5
       parent: 1
+      pos: 2.5,8.5
   - uid: 93
     components:
     - type: Transform
-      pos: 3.5,6.5
       parent: 1
+      pos: 3.5,6.5
   - uid: 94
     components:
     - type: Transform
-      pos: 3.5,7.5
       parent: 1
+      pos: 3.5,7.5
   - uid: 95
     components:
     - type: Transform
-      pos: 3.5,8.5
       parent: 1
+      pos: 3.5,8.5
   - uid: 96
     components:
     - type: Transform
-      pos: 1.5,8.5
       parent: 1
+      pos: 1.5,8.5
   - uid: 97
     components:
     - type: Transform
-      pos: 0.5,6.5
       parent: 1
+      pos: 0.5,6.5
   - uid: 98
     components:
     - type: Transform
-      pos: 0.5,7.5
       parent: 1
+      pos: 0.5,7.5
   - uid: 99
     components:
     - type: Transform
-      pos: 0.5,3.5
       parent: 1
+      pos: 0.5,3.5
   - uid: 100
     components:
     - type: Transform
-      pos: 3.5,10.5
       parent: 1
+      pos: 3.5,10.5
   - uid: 101
     components:
     - type: Transform
-      pos: 3.5,14.5
       parent: 1
+      pos: 3.5,14.5
   - uid: 102
     components:
     - type: Transform
-      pos: 4.5,15.5
       parent: 1
+      pos: 4.5,15.5
   - uid: 103
     components:
     - type: Transform
-      pos: 8.5,15.5
       parent: 1
+      pos: 8.5,15.5
   - uid: 104
     components:
     - type: Transform
-      pos: 13.5,1.5
       parent: 1
+      pos: 13.5,1.5
   - uid: 105
     components:
     - type: Transform
-      pos: 12.5,0.5
       parent: 1
+      pos: 12.5,0.5
   - uid: 106
     components:
     - type: Transform
-      pos: 7.5,0.5
       parent: 1
+      pos: 7.5,0.5
   - uid: 107
     components:
     - type: Transform
-      pos: 6.5,1.5
       parent: 1
+      pos: 6.5,1.5
 - proto: Autolathe
   entities:
   - uid: 108
     components:
     - type: Transform
-      pos: 5.5,6.5
       parent: 1
+      pos: 5.5,6.5
 - proto: Bed
   entities:
   - uid: 109
     components:
     - type: Transform
-      pos: 12.5,4.5
       parent: 1
+      pos: 12.5,4.5
 - proto: BedsheetRD
   entities:
   - uid: 110
     components:
     - type: Transform
+      parent: 1
       rot: 1.5707963267948966 rad
       pos: 12.5,4.5
-      parent: 1
 - proto: BenchSofaCorpLeft
   entities:
   - uid: 111
     components:
     - type: Transform
-      pos: 11.5,1.5
       parent: 1
+      pos: 11.5,1.5
 - proto: BenchSofaCorpMiddle
   entities:
   - uid: 112
     components:
     - type: Transform
-      pos: 10.5,1.5
       parent: 1
+      pos: 10.5,1.5
 - proto: BenchSofaCorpRight
   entities:
   - uid: 113
     components:
     - type: Transform
-      pos: 9.5,1.5
       parent: 1
+      pos: 9.5,1.5
 - proto: BlastDoor
   entities:
   - uid: 114
     components:
     - type: Transform
+      parent: 1
       rot: 4.71238898038469 rad
       pos: 11.5,18.5
-      parent: 1
   - uid: 115
     components:
     - type: Transform
+      parent: 1
       rot: 4.71238898038469 rad
       pos: 11.5,17.5
-      parent: 1
   - uid: 116
     components:
     - type: Transform
+      parent: 1
       rot: 4.71238898038469 rad
       pos: 11.5,16.5
-      parent: 1
   - uid: 117
     components:
     - type: Transform
+      parent: 1
       rot: 1.5707963267948966 rad
       pos: 16.5,13.5
-      parent: 1
 - proto: BlueprintLithograph
   entities:
   - uid: 118
     components:
     - type: Transform
-      pos: 9.5,6.5
       parent: 1
+      pos: 9.5,6.5
 - proto: BorgCharger
   entities:
   - uid: 119
     components:
     - type: Transform
-      pos: 7.5,10.5
       parent: 1
+      pos: 7.5,10.5
 - proto: BoxFolderWhite
   entities:
   - uid: 120
     components:
     - type: Transform
-      pos: 6.6706104,14.450595
       parent: 1
+      pos: 6.6706104,14.450595
 - proto: ButtonFrameCaution
   entities:
   - uid: 121
     components:
     - type: Transform
+      parent: 1
       rot: 1.5707963267948966 rad
       pos: 11.5,19.5
-      parent: 1
 - proto: ButtonFrameGrey
   entities:
-  - uid: 251
+  - uid: 122
     components:
     - type: Transform
+      parent: 1
       rot: 1.5707963267948966 rad
       pos: 11.5,14.75
-      parent: 1
 - proto: ButtonFrameJanitor
   entities:
-  - uid: 25
+  - uid: 123
     components:
     - type: Transform
+      parent: 1
       rot: 1.5707963267948966 rad
       pos: 11.5,14.25
-      parent: 1
 - proto: CableApcExtension
   entities:
   - uid: 124
     components:
     - type: Transform
-      pos: 15.5,4.5
       parent: 1
+      pos: 15.5,4.5
   - uid: 125
     components:
     - type: Transform
-      pos: 16.5,4.5
       parent: 1
+      pos: 16.5,4.5
   - uid: 126
     components:
     - type: Transform
-      pos: 16.5,5.5
       parent: 1
+      pos: 16.5,5.5
   - uid: 127
     components:
     - type: Transform
-      pos: 15.5,5.5
       parent: 1
+      pos: 15.5,5.5
   - uid: 128
     components:
     - type: Transform
-      pos: 4.5,4.5
       parent: 1
+      pos: 4.5,4.5
   - uid: 129
     components:
     - type: Transform
-      pos: 3.5,4.5
       parent: 1
+      pos: 3.5,4.5
   - uid: 130
     components:
     - type: Transform
-      pos: 3.5,5.5
       parent: 1
+      pos: 3.5,5.5
   - uid: 131
     components:
     - type: Transform
-      pos: 4.5,5.5
       parent: 1
+      pos: 4.5,5.5
   - uid: 132
     components:
     - type: Transform
-      pos: 6.5,3.5
       parent: 1
+      pos: 6.5,3.5
   - uid: 133
     components:
     - type: Transform
-      pos: 6.5,4.5
       parent: 1
+      pos: 6.5,4.5
   - uid: 134
     components:
     - type: Transform
-      pos: 7.5,5.5
       parent: 1
+      pos: 7.5,5.5
   - uid: 135
     components:
     - type: Transform
-      pos: 6.5,5.5
       parent: 1
+      pos: 6.5,5.5
   - uid: 136
     components:
     - type: Transform
-      pos: 8.5,5.5
       parent: 1
+      pos: 8.5,5.5
   - uid: 137
     components:
     - type: Transform
-      pos: 9.5,5.5
       parent: 1
+      pos: 9.5,5.5
   - uid: 138
     components:
     - type: Transform
-      pos: 10.5,5.5
       parent: 1
+      pos: 10.5,5.5
   - uid: 139
     components:
     - type: Transform
-      pos: 8.5,2.5
       parent: 1
+      pos: 8.5,2.5
   - uid: 140
     components:
     - type: Transform
-      pos: 9.5,2.5
       parent: 1
+      pos: 9.5,2.5
   - uid: 141
     components:
     - type: Transform
-      pos: 10.5,2.5
       parent: 1
+      pos: 10.5,2.5
   - uid: 142
     components:
     - type: Transform
-      pos: 11.5,2.5
       parent: 1
+      pos: 11.5,2.5
   - uid: 143
     components:
     - type: Transform
-      pos: 11.5,5.5
       parent: 1
+      pos: 11.5,5.5
   - uid: 144
     components:
     - type: Transform
-      pos: 12.5,5.5
       parent: 1
+      pos: 12.5,5.5
   - uid: 145
     components:
     - type: Transform
-      pos: 13.5,5.5
       parent: 1
+      pos: 13.5,5.5
   - uid: 146
     components:
     - type: Transform
-      pos: 6.5,11.5
       parent: 1
+      pos: 6.5,11.5
   - uid: 147
     components:
     - type: Transform
-      pos: 7.5,11.5
       parent: 1
+      pos: 7.5,11.5
   - uid: 148
     components:
     - type: Transform
-      pos: 8.5,11.5
       parent: 1
+      pos: 8.5,11.5
   - uid: 149
     components:
     - type: Transform
-      pos: 8.5,10.5
       parent: 1
+      pos: 8.5,10.5
   - uid: 150
     components:
     - type: Transform
-      pos: 7.5,10.5
       parent: 1
+      pos: 7.5,10.5
   - uid: 151
     components:
     - type: Transform
-      pos: 5.5,11.5
       parent: 1
+      pos: 5.5,11.5
   - uid: 152
     components:
     - type: Transform
-      pos: 5.5,12.5
       parent: 1
+      pos: 5.5,12.5
   - uid: 153
     components:
     - type: Transform
-      pos: 5.5,13.5
       parent: 1
+      pos: 5.5,13.5
   - uid: 154
     components:
     - type: Transform
-      pos: 6.5,13.5
       parent: 1
+      pos: 6.5,13.5
   - uid: 155
     components:
     - type: Transform
-      pos: 7.5,13.5
       parent: 1
+      pos: 7.5,13.5
   - uid: 156
     components:
     - type: Transform
-      pos: 8.5,13.5
       parent: 1
+      pos: 8.5,13.5
   - uid: 157
     components:
     - type: Transform
-      pos: 9.5,13.5
       parent: 1
+      pos: 9.5,13.5
   - uid: 158
     components:
     - type: Transform
-      pos: 5.5,10.5
       parent: 1
+      pos: 5.5,10.5
   - uid: 159
     components:
     - type: Transform
-      pos: 5.5,9.5
       parent: 1
+      pos: 5.5,9.5
   - uid: 160
     components:
     - type: Transform
-      pos: 5.5,8.5
       parent: 1
+      pos: 5.5,8.5
   - uid: 161
     components:
     - type: Transform
-      pos: 6.5,8.5
       parent: 1
+      pos: 6.5,8.5
   - uid: 162
     components:
     - type: Transform
-      pos: 7.5,8.5
       parent: 1
+      pos: 7.5,8.5
   - uid: 163
     components:
     - type: Transform
-      pos: 8.5,8.5
       parent: 1
+      pos: 8.5,8.5
   - uid: 164
     components:
     - type: Transform
-      pos: 9.5,8.5
       parent: 1
+      pos: 9.5,8.5
   - uid: 165
     components:
     - type: Transform
-      pos: 12.5,11.5
       parent: 1
+      pos: 12.5,11.5
   - uid: 166
     components:
     - type: Transform
-      pos: 12.5,12.5
       parent: 1
+      pos: 12.5,12.5
   - uid: 167
     components:
     - type: Transform
-      pos: 12.5,13.5
       parent: 1
+      pos: 12.5,13.5
   - uid: 168
     components:
     - type: Transform
-      pos: 12.5,14.5
       parent: 1
+      pos: 12.5,14.5
   - uid: 169
     components:
     - type: Transform
-      pos: 12.5,16.5
       parent: 1
+      pos: 12.5,16.5
   - uid: 170
     components:
     - type: Transform
-      pos: 12.5,17.5
       parent: 1
+      pos: 12.5,17.5
   - uid: 171
     components:
     - type: Transform
-      pos: 12.5,18.5
       parent: 1
+      pos: 12.5,18.5
   - uid: 172
     components:
     - type: Transform
-      pos: 12.5,19.5
       parent: 1
+      pos: 12.5,19.5
   - uid: 173
     components:
     - type: Transform
-      pos: 13.5,19.5
       parent: 1
+      pos: 13.5,19.5
   - uid: 174
     components:
     - type: Transform
-      pos: 14.5,19.5
       parent: 1
+      pos: 14.5,19.5
   - uid: 175
     components:
     - type: Transform
-      pos: 13.5,16.5
       parent: 1
+      pos: 13.5,16.5
   - uid: 176
     components:
     - type: Transform
-      pos: 11.5,12.5
       parent: 1
+      pos: 11.5,12.5
   - uid: 177
     components:
     - type: Transform
-      pos: 11.5,9.5
       parent: 1
+      pos: 11.5,9.5
   - uid: 178
     components:
     - type: Transform
-      pos: 12.5,9.5
       parent: 1
+      pos: 12.5,9.5
   - uid: 179
     components:
     - type: Transform
-      pos: 13.5,9.5
       parent: 1
+      pos: 13.5,9.5
   - uid: 180
     components:
     - type: Transform
-      pos: 13.5,8.5
       parent: 1
+      pos: 13.5,8.5
   - uid: 181
     components:
     - type: Transform
-      pos: 13.5,7.5
       parent: 1
+      pos: 13.5,7.5
   - uid: 182
     components:
     - type: Transform
-      pos: 10.5,8.5
       parent: 1
+      pos: 10.5,8.5
   - uid: 183
     components:
     - type: Transform
-      pos: 10.5,13.5
       parent: 1
+      pos: 10.5,13.5
   - uid: 184
     components:
     - type: Transform
-      pos: 10.5,4.5
       parent: 1
+      pos: 10.5,4.5
   - uid: 185
     components:
     - type: Transform
-      pos: 10.5,3.5
       parent: 1
+      pos: 10.5,3.5
   - uid: 186
     components:
     - type: Transform
-      pos: 8.5,9.5
       parent: 1
+      pos: 8.5,9.5
   - uid: 187
     components:
     - type: Transform
-      pos: 14.5,11.5
       parent: 1
+      pos: 14.5,11.5
   - uid: 188
     components:
     - type: Transform
-      pos: 13.5,11.5
       parent: 1
+      pos: 13.5,11.5
   - uid: 189
     components:
     - type: Transform
-      pos: 12.5,15.5
       parent: 1
+      pos: 12.5,15.5
   - uid: 190
     components:
     - type: Transform
-      pos: 13.5,13.5
       parent: 1
+      pos: 13.5,13.5
   - uid: 191
     components:
     - type: Transform
-      pos: 14.5,13.5
       parent: 1
+      pos: 14.5,13.5
   - uid: 192
     components:
     - type: Transform
-      pos: 14.5,18.5
       parent: 1
+      pos: 14.5,18.5
   - uid: 193
     components:
     - type: Transform
-      pos: 14.5,17.5
       parent: 1
+      pos: 14.5,17.5
   - uid: 194
     components:
     - type: Transform
-      pos: 14.5,16.5
       parent: 1
+      pos: 14.5,16.5
   - uid: 195
     components:
     - type: Transform
-      pos: 2.5,5.5
       parent: 1
+      pos: 2.5,5.5
   - uid: 196
     components:
     - type: Transform
-      pos: 17.5,5.5
       parent: 1
+      pos: 17.5,5.5
 - proto: CableHV
   entities:
   - uid: 197
     components:
     - type: Transform
-      pos: 14.5,7.5
       parent: 1
+      pos: 14.5,7.5
   - uid: 198
     components:
     - type: Transform
-      pos: 14.5,8.5
       parent: 1
+      pos: 14.5,8.5
   - uid: 199
     components:
     - type: Transform
-      pos: 12.5,8.5
       parent: 1
+      pos: 12.5,8.5
   - uid: 200
     components:
     - type: Transform
-      pos: 11.5,8.5
       parent: 1
+      pos: 11.5,8.5
   - uid: 201
     components:
     - type: Transform
-      pos: 10.5,8.5
       parent: 1
+      pos: 10.5,8.5
   - uid: 202
     components:
     - type: Transform
-      pos: 9.5,8.5
       parent: 1
+      pos: 9.5,8.5
   - uid: 203
     components:
     - type: Transform
-      pos: 8.5,8.5
       parent: 1
+      pos: 8.5,8.5
   - uid: 204
     components:
     - type: Transform
-      pos: 11.5,7.5
       parent: 1
+      pos: 11.5,7.5
   - uid: 205
     components:
     - type: Transform
-      pos: 10.5,9.5
       parent: 1
+      pos: 10.5,9.5
   - uid: 206
     components:
     - type: Transform
-      pos: 10.5,10.5
       parent: 1
+      pos: 10.5,10.5
   - uid: 207
     components:
     - type: Transform
-      pos: 10.5,11.5
       parent: 1
+      pos: 10.5,11.5
   - uid: 208
     components:
     - type: Transform
-      pos: 10.5,12.5
       parent: 1
+      pos: 10.5,12.5
   - uid: 209
     components:
     - type: Transform
-      pos: 10.5,13.5
       parent: 1
+      pos: 10.5,13.5
+  - uid: 210
+    components:
+    - type: Transform
+      parent: 1
+      pos: 8.5,7.5
+  - uid: 211
+    components:
+    - type: Transform
+      parent: 1
+      pos: 8.5,6.5
   - uid: 212
     components:
     - type: Transform
-      pos: 8.5,7.5
       parent: 1
+      pos: 8.5,5.5
   - uid: 213
     components:
     - type: Transform
-      pos: 8.5,6.5
       parent: 1
+      pos: 7.5,5.5
   - uid: 214
     components:
     - type: Transform
-      pos: 8.5,5.5
       parent: 1
+      pos: 6.5,5.5
   - uid: 215
     components:
     - type: Transform
-      pos: 7.5,5.5
       parent: 1
+      pos: 5.5,5.5
   - uid: 216
     components:
     - type: Transform
-      pos: 6.5,5.5
       parent: 1
+      pos: 4.5,5.5
   - uid: 217
     components:
     - type: Transform
-      pos: 5.5,5.5
       parent: 1
+      pos: 4.5,6.5
   - uid: 218
     components:
     - type: Transform
-      pos: 4.5,5.5
       parent: 1
+      pos: 9.5,5.5
   - uid: 219
     components:
     - type: Transform
-      pos: 4.5,6.5
       parent: 1
+      pos: 10.5,5.5
   - uid: 220
     components:
     - type: Transform
-      pos: 9.5,5.5
       parent: 1
+      pos: 11.5,5.5
   - uid: 221
     components:
     - type: Transform
-      pos: 10.5,5.5
       parent: 1
+      pos: 12.5,5.5
   - uid: 222
     components:
     - type: Transform
-      pos: 11.5,5.5
       parent: 1
+      pos: 13.5,5.5
   - uid: 223
     components:
     - type: Transform
-      pos: 12.5,5.5
       parent: 1
+      pos: 14.5,5.5
   - uid: 224
     components:
     - type: Transform
-      pos: 13.5,5.5
       parent: 1
+      pos: 15.5,5.5
   - uid: 225
     components:
     - type: Transform
-      pos: 14.5,5.5
       parent: 1
+      pos: 15.5,6.5
   - uid: 226
     components:
     - type: Transform
-      pos: 15.5,5.5
       parent: 1
+      pos: 13.5,7.5
   - uid: 227
     components:
     - type: Transform
-      pos: 15.5,6.5
       parent: 1
+      pos: 12.5,7.5
+  - uid: 228
+    components:
+    - type: Transform
+      parent: 1
+      pos: 14.5,9.5
   - uid: 229
     components:
     - type: Transform
-      pos: 13.5,7.5
       parent: 1
+      pos: 12.5,9.5
   - uid: 230
     components:
     - type: Transform
-      pos: 12.5,7.5
       parent: 1
+      pos: 10.5,14.5
+- proto: CableMV
+  entities:
   - uid: 231
     components:
     - type: Transform
-      pos: 14.5,9.5
       parent: 1
+      pos: 10.5,14.5
   - uid: 232
     components:
     - type: Transform
-      pos: 12.5,9.5
       parent: 1
-  - uid: 243
-    components:
-    - type: Transform
-      pos: 10.5,14.5
-      parent: 1
-- proto: CableMV
-  entities:
-  - uid: 122
-    components:
-    - type: Transform
-      pos: 10.5,14.5
-      parent: 1
+      pos: 11.5,7.5
   - uid: 233
     components:
     - type: Transform
-      pos: 11.5,7.5
       parent: 1
+      pos: 11.5,8.5
   - uid: 234
     components:
     - type: Transform
-      pos: 11.5,8.5
       parent: 1
+      pos: 10.5,8.5
   - uid: 235
     components:
     - type: Transform
-      pos: 10.5,8.5
       parent: 1
+      pos: 9.5,8.5
   - uid: 236
     components:
     - type: Transform
-      pos: 9.5,8.5
       parent: 1
+      pos: 8.5,8.5
   - uid: 237
     components:
     - type: Transform
-      pos: 8.5,8.5
       parent: 1
+      pos: 8.5,9.5
   - uid: 238
     components:
     - type: Transform
-      pos: 8.5,9.5
       parent: 1
+      pos: 8.5,10.5
   - uid: 239
     components:
     - type: Transform
-      pos: 8.5,10.5
       parent: 1
+      pos: 7.5,10.5
   - uid: 240
     components:
     - type: Transform
-      pos: 7.5,10.5
       parent: 1
+      pos: 6.5,10.5
   - uid: 241
     components:
     - type: Transform
-      pos: 6.5,10.5
       parent: 1
+      pos: 11.5,13.5
   - uid: 242
     components:
     - type: Transform
-      pos: 11.5,13.5
       parent: 1
+      pos: 8.5,7.5
+  - uid: 243
+    components:
+    - type: Transform
+      parent: 1
+      pos: 8.5,6.5
   - uid: 244
     components:
     - type: Transform
-      pos: 8.5,7.5
       parent: 1
+      pos: 8.5,5.5
   - uid: 245
     components:
     - type: Transform
-      pos: 8.5,6.5
       parent: 1
+      pos: 7.5,5.5
   - uid: 246
     components:
     - type: Transform
-      pos: 8.5,5.5
       parent: 1
+      pos: 6.5,5.5
   - uid: 247
     components:
     - type: Transform
-      pos: 7.5,5.5
       parent: 1
+      pos: 4.5,5.5
   - uid: 248
     components:
     - type: Transform
-      pos: 6.5,5.5
       parent: 1
+      pos: 4.5,6.5
   - uid: 249
     components:
     - type: Transform
-      pos: 4.5,5.5
       parent: 1
+      pos: 15.5,5.5
   - uid: 250
     components:
     - type: Transform
-      pos: 4.5,6.5
       parent: 1
+      pos: 15.5,6.5
+  - uid: 251
+    components:
+    - type: Transform
+      parent: 1
+      pos: 6.5,4.5
+  - uid: 252
+    components:
+    - type: Transform
+      parent: 1
+      pos: 4.5,4.5
   - uid: 253
     components:
     - type: Transform
-      pos: 15.5,5.5
       parent: 1
+      pos: 15.5,4.5
   - uid: 254
     components:
     - type: Transform
-      pos: 15.5,6.5
       parent: 1
+      pos: 6.5,11.5
   - uid: 255
     components:
     - type: Transform
-      pos: 6.5,4.5
       parent: 1
+      pos: 11.5,12.5
   - uid: 256
     components:
     - type: Transform
-      pos: 4.5,4.5
       parent: 1
+      pos: 11.5,9.5
   - uid: 257
     components:
     - type: Transform
-      pos: 15.5,4.5
       parent: 1
+      pos: 6.5,3.5
   - uid: 258
     components:
     - type: Transform
-      pos: 6.5,11.5
       parent: 1
+      pos: 10.5,13.5
+- proto: CableTerminal
+  entities:
   - uid: 259
     components:
     - type: Transform
-      pos: 11.5,12.5
       parent: 1
+      pos: 14.5,8.5
+- proto: CarpetPink
+  entities:
   - uid: 260
     components:
     - type: Transform
-      pos: 11.5,9.5
       parent: 1
+      pos: 12.5,4.5
   - uid: 261
     components:
     - type: Transform
-      pos: 6.5,3.5
       parent: 1
-  - uid: 574
-    components:
-    - type: Transform
-      pos: 10.5,13.5
-      parent: 1
-- proto: CableTerminal
+      pos: 13.5,4.5
+- proto: Catwalk
   entities:
   - uid: 262
     components:
     - type: Transform
-      pos: 14.5,8.5
       parent: 1
-- proto: CarpetPink
-  entities:
+      pos: 18.5,2.5
   - uid: 263
     components:
     - type: Transform
-      pos: 12.5,4.5
       parent: 1
+      pos: 1.5,2.5
   - uid: 264
     components:
     - type: Transform
-      pos: 13.5,4.5
       parent: 1
-- proto: Catwalk
-  entities:
+      pos: 10.5,18.5
   - uid: 265
     components:
     - type: Transform
-      pos: 18.5,2.5
       parent: 1
+      pos: 10.5,17.5
   - uid: 266
     components:
     - type: Transform
-      pos: 1.5,2.5
       parent: 1
+      pos: 10.5,16.5
   - uid: 267
     components:
     - type: Transform
-      pos: 10.5,18.5
       parent: 1
+      pos: 10.5,15.5
   - uid: 268
     components:
     - type: Transform
-      pos: 10.5,17.5
       parent: 1
+      pos: 10.5,19.5
   - uid: 269
     components:
     - type: Transform
-      pos: 10.5,16.5
       parent: 1
+      pos: 0.5,7.5
   - uid: 270
     components:
     - type: Transform
-      pos: 10.5,15.5
       parent: 1
+      pos: 19.5,7.5
+- proto: ChairPilotSeat
+  entities:
   - uid: 271
     components:
     - type: Transform
-      pos: 10.5,19.5
       parent: 1
+      rot: 3.141592653589793 rad
+      pos: 4.5,12.5
+- proto: CircuitImprinter
+  entities:
   - uid: 272
     components:
     - type: Transform
-      pos: 0.5,7.5
       parent: 1
+      pos: 10.5,6.5
+- proto: ComputerAnalysisConsole
+  entities:
   - uid: 273
     components:
     - type: Transform
-      pos: 19.5,7.5
       parent: 1
-- proto: ChairPilotSeat
-  entities:
-  - uid: 274
-    components:
-    - type: Transform
-      rot: 3.141592653589793 rad
-      pos: 4.5,12.5
-      parent: 1
-- proto: CircuitImprinter
-  entities:
-  - uid: 275
-    components:
-    - type: Transform
-      pos: 10.5,6.5
-      parent: 1
-- proto: ComputerAnalysisConsole
-  entities:
-  - uid: 276
-    components:
-    - type: Transform
       rot: 4.71238898038469 rad
       pos: 14.5,11.5
-      parent: 1
     - type: DeviceLinkSource
       linkedPorts:
         473:
@@ -2071,11 +2073,11 @@ entities:
       startingCharge: 0
 - proto: ComputerShuttle
   entities:
-  - uid: 277
+  - uid: 274
     components:
     - type: Transform
-      pos: 4.5,13.5
       parent: 1
+      pos: 4.5,13.5
     - type: DeviceLinkSource
       linkedPorts:
         609:
@@ -2124,130 +2126,130 @@ entities:
       startingCharge: 0
 - proto: ComputerTabletopGunneryConsole
   entities:
-  - uid: 278
+  - uid: 275
     components:
     - type: Transform
+      parent: 1
       rot: 3.141592653589793 rad
       pos: 4.5,11.5
-      parent: 1
     - type: ApcPowerReceiver
       powerLoad: 5
     - type: Battery
       startingCharge: 0
 - proto: ComputerTabletopResearchAndDevelopment
   entities:
-  - uid: 279
+  - uid: 276
     components:
     - type: Transform
-      pos: 6.5,14.5
       parent: 1
+      pos: 6.5,14.5
     - type: ApcPowerReceiver
       powerLoad: 5
     - type: Battery
       startingCharge: 0
 - proto: ComputerWallmountStationRecords
   entities:
-  - uid: 280
+  - uid: 277
     components:
     - type: Transform
+      parent: 1
       rot: 3.141592653589793 rad
       pos: 7.5,12.5
-      parent: 1
     - type: ApcPowerReceiver
       powerLoad: 5
     - type: Battery
       startingCharge: 0
 - proto: ComputerWallmountWithdrawBankATM
   entities:
-  - uid: 713
+  - uid: 278
     components:
     - type: Transform
+      parent: 1
       rot: 3.141592653589793 rad
       pos: 12.5,10.5
-      parent: 1
     - type: ApcPowerReceiver
       powerLoad: 5
     - type: Battery
       startingCharge: 0
 - proto: CrateMaterialsBasic10Filled
   entities:
+  - uid: 279
+    components:
+    - type: Transform
+      parent: 1
+      pos: 13.5,18.5
+- proto: CurtainsPurpleOpen
+  entities:
+  - uid: 280
+    components:
+    - type: Transform
+      parent: 1
+      pos: 12.5,4.5
+- proto: CyborgEndoskeleton
+  entities:
   - uid: 281
     components:
     - type: Transform
-      pos: 13.5,18.5
       parent: 1
-- proto: CurtainsPurpleOpen
+      pos: 7.497606,4.5846515
+- proto: DefibrillatorCabinetFilled
   entities:
   - uid: 282
     components:
     - type: Transform
-      pos: 12.5,4.5
       parent: 1
-- proto: CyborgEndoskeleton
-  entities:
-  - uid: 228
-    components:
-    - type: Transform
-      pos: 7.497606,4.5846515
-      parent: 1
-- proto: DefibrillatorCabinetFilled
+      rot: 1.5707963267948966 rad
+      pos: 9.5,11.5
+- proto: Dresser
   entities:
   - uid: 283
     components:
     - type: Transform
-      rot: 1.5707963267948966 rad
-      pos: 9.5,11.5
       parent: 1
-- proto: Dresser
+      pos: 13.5,4.5
+- proto: DrinkMugMetal
   entities:
   - uid: 284
     components:
     - type: Transform
-      pos: 13.5,4.5
       parent: 1
-- proto: DrinkMugMetal
+      pos: 7.645588,2.913497
+- proto: DrinkMugMoebius
   entities:
   - uid: 285
     components:
     - type: Transform
-      pos: 7.645588,2.913497
       parent: 1
-- proto: DrinkMugMoebius
+      pos: 7.398374,2.8319185
+- proto: ExosuitFabricator
   entities:
   - uid: 286
     components:
     - type: Transform
-      pos: 7.398374,2.8319185
       parent: 1
-- proto: ExosuitFabricator
+      pos: 8.5,4.5
+- proto: ExtinguisherCabinetFilled
   entities:
   - uid: 287
     components:
     - type: Transform
-      pos: 8.5,4.5
       parent: 1
-- proto: ExtinguisherCabinetFilled
-  entities:
-  - uid: 723
-    components:
-    - type: Transform
       rot: 3.141592653589793 rad
       pos: 13.5,10.5
-      parent: 1
 - proto: FaxMachineShip
   entities:
   - uid: 288
     components:
     - type: Transform
-      pos: 7.5,14.5
       parent: 1
+      pos: 7.5,14.5
 - proto: Firelock
   entities:
   - uid: 289
     components:
     - type: Transform
-      pos: 8.5,13.5
       parent: 1
+      pos: 8.5,13.5
     - type: DeviceNetwork
       deviceLists:
       - 2
@@ -2255,8 +2257,8 @@ entities:
   - uid: 290
     components:
     - type: Transform
-      pos: 5.5,10.5
       parent: 1
+      pos: 5.5,10.5
     - type: DeviceNetwork
       deviceLists:
       - 2
@@ -2264,8 +2266,8 @@ entities:
   - uid: 291
     components:
     - type: Transform
-      pos: 8.5,9.5
       parent: 1
+      pos: 8.5,9.5
     - type: DeviceNetwork
       deviceLists:
       - 2
@@ -2273,8 +2275,8 @@ entities:
   - uid: 292
     components:
     - type: Transform
-      pos: 8.5,7.5
       parent: 1
+      pos: 8.5,7.5
     - type: DeviceNetwork
       deviceLists:
       - 2
@@ -2282,16 +2284,16 @@ entities:
   - uid: 293
     components:
     - type: Transform
-      pos: 11.5,8.5
       parent: 1
+      pos: 11.5,8.5
     - type: DeviceNetwork
       deviceLists:
       - 2
   - uid: 294
     components:
     - type: Transform
-      pos: 11.5,5.5
       parent: 1
+      pos: 11.5,5.5
     - type: DeviceNetwork
       deviceLists:
       - 6
@@ -2299,8 +2301,8 @@ entities:
   - uid: 295
     components:
     - type: Transform
-      pos: 11.5,13.5
       parent: 1
+      pos: 11.5,13.5
     - type: DeviceNetwork
       deviceLists:
       - 3
@@ -2308,8 +2310,8 @@ entities:
   - uid: 296
     components:
     - type: Transform
-      pos: 10.5,4.5
       parent: 1
+      pos: 10.5,4.5
     - type: DeviceNetwork
       deviceLists:
       - 6
@@ -2319,9 +2321,9 @@ entities:
   - uid: 297
     components:
     - type: Transform
+      parent: 1
       rot: 3.141592653589793 rad
       pos: 13.5,15.5
-      parent: 1
     - type: DeviceNetwork
       deviceLists:
       - 10
@@ -2329,9 +2331,9 @@ entities:
   - uid: 298
     components:
     - type: Transform
+      parent: 1
       rot: 3.141592653589793 rad
       pos: 12.5,15.5
-      parent: 1
     - type: DeviceNetwork
       deviceLists:
       - 10
@@ -2341,8 +2343,8 @@ entities:
   - uid: 299
     components:
     - type: Transform
-      pos: 6.5,4.5
       parent: 1
+      pos: 6.5,4.5
     - type: Fixtures
       fixtures: {}
 - proto: GasMixerFlipped
@@ -2350,8 +2352,8 @@ entities:
   - uid: 300
     components:
     - type: Transform
-      pos: 13.5,8.5
       parent: 1
+      pos: 13.5,8.5
     - type: AtmosPipeLayers
       pipeLayer: Secondary
     - type: GasMixer
@@ -2365,17 +2367,17 @@ entities:
   - uid: 301
     components:
     - type: Transform
+      parent: 1
       rot: 4.71238898038469 rad
       pos: 15.5,13.5
-      parent: 1
 - proto: GasPassiveVentAlt2
   entities:
   - uid: 302
     components:
     - type: Transform
+      parent: 1
       rot: 1.5707963267948966 rad
       pos: 3.5,5.5
-      parent: 1
     - type: AtmosPipeColor
       color: '#990000FF'
 - proto: GasPipeBend
@@ -2383,116 +2385,116 @@ entities:
   - uid: 303
     components:
     - type: Transform
+      parent: 1
       rot: 1.5707963267948966 rad
       pos: 13.5,13.5
-      parent: 1
   - uid: 304
     components:
     - type: Transform
+      parent: 1
       rot: 1.5707963267948966 rad
       pos: 12.5,14.5
-      parent: 1
 - proto: GasPipeBendAlt1
   entities:
   - uid: 305
     components:
     - type: Transform
+      parent: 1
       rot: 1.5707963267948966 rad
       pos: 12.5,8.5
-      parent: 1
     - type: AtmosPipeColor
       color: '#0055CCFF'
   - uid: 306
     components:
     - type: Transform
+      parent: 1
       rot: -1.5707963267948966 rad
       pos: 12.5,8.5
-      parent: 1
     - type: AtmosPipeColor
       color: '#0055CCFF'
   - uid: 307
     components:
     - type: Transform
+      parent: 1
       rot: 1.5707963267948966 rad
       pos: 12.5,9.5
-      parent: 1
     - type: AtmosPipeColor
       color: '#0055CCFF'
   - uid: 308
     components:
     - type: Transform
-      pos: 13.5,9.5
       parent: 1
+      pos: 13.5,9.5
     - type: AtmosPipeColor
       color: '#0055CCFF'
   - uid: 309
     components:
     - type: Transform
+      parent: 1
       rot: 1.5707963267948966 rad
       pos: 5.5,13.5
-      parent: 1
     - type: AtmosPipeColor
       color: '#0055CCFF'
   - uid: 310
     components:
     - type: Transform
+      parent: 1
       rot: 3.141592653589793 rad
       pos: 5.5,8.5
-      parent: 1
     - type: AtmosPipeColor
       color: '#0055CCFF'
   - uid: 311
     components:
     - type: Transform
+      parent: 1
       rot: -1.5707963267948966 rad
       pos: 13.5,13.5
-      parent: 1
     - type: AtmosPipeColor
       color: '#0055CCFF'
   - uid: 312
     components:
     - type: Transform
+      parent: 1
       rot: 1.5707963267948966 rad
       pos: 13.5,16.5
-      parent: 1
     - type: AtmosPipeColor
       color: '#0055CCFF'
   - uid: 313
     components:
     - type: Transform
+      parent: 1
       rot: 1.5707963267948966 rad
       pos: 10.5,13.5
-      parent: 1
     - type: AtmosPipeColor
       color: '#0055CCFF'
   - uid: 314
     components:
     - type: Transform
+      parent: 1
       rot: 3.141592653589793 rad
       pos: 7.5,10.5
-      parent: 1
     - type: AtmosPipeColor
       color: '#0055CCFF'
   - uid: 315
     components:
     - type: Transform
-      pos: 8.5,10.5
       parent: 1
+      pos: 8.5,10.5
     - type: AtmosPipeColor
       color: '#0055CCFF'
   - uid: 316
     components:
     - type: Transform
+      parent: 1
       rot: 3.141592653589793 rad
       pos: 8.5,5.5
-      parent: 1
     - type: AtmosPipeColor
       color: '#0055CCFF'
   - uid: 317
     components:
     - type: Transform
-      pos: 12.5,5.5
       parent: 1
+      pos: 12.5,5.5
     - type: AtmosPipeColor
       color: '#0055CCFF'
 - proto: GasPipeBendAlt2
@@ -2500,32 +2502,32 @@ entities:
   - uid: 318
     components:
     - type: Transform
+      parent: 1
       rot: 1.5707963267948966 rad
       pos: 5.5,13.5
-      parent: 1
     - type: AtmosPipeColor
       color: '#990000FF'
   - uid: 319
     components:
     - type: Transform
+      parent: 1
       rot: -1.5707963267948966 rad
       pos: 13.5,13.5
-      parent: 1
     - type: AtmosPipeColor
       color: '#990000FF'
   - uid: 320
     components:
     - type: Transform
+      parent: 1
       rot: 1.5707963267948966 rad
       pos: 12.5,17.5
-      parent: 1
     - type: AtmosPipeColor
       color: '#990000FF'
   - uid: 321
     components:
     - type: Transform
-      pos: 13.5,5.5
       parent: 1
+      pos: 13.5,5.5
     - type: AtmosPipeColor
       color: '#990000FF'
 - proto: GasPipeFourwayAlt1
@@ -2533,15 +2535,15 @@ entities:
   - uid: 322
     components:
     - type: Transform
-      pos: 8.5,8.5
       parent: 1
+      pos: 8.5,8.5
     - type: AtmosPipeColor
       color: '#0055CCFF'
   - uid: 323
     components:
     - type: Transform
-      pos: 10.5,5.5
       parent: 1
+      pos: 10.5,5.5
     - type: AtmosPipeColor
       color: '#0055CCFF'
 - proto: GasPipeStraight
@@ -2549,208 +2551,208 @@ entities:
   - uid: 324
     components:
     - type: Transform
-      pos: 12.5,13.5
       parent: 1
+      pos: 12.5,13.5
   - uid: 325
     components:
     - type: Transform
+      parent: 1
       rot: -1.5707963267948966 rad
       pos: 13.5,14.5
-      parent: 1
   - uid: 326
     components:
     - type: Transform
+      parent: 1
       rot: -1.5707963267948966 rad
       pos: 14.5,14.5
-      parent: 1
   - uid: 327
     components:
     - type: Transform
+      parent: 1
       rot: -1.5707963267948966 rad
       pos: 14.5,13.5
-      parent: 1
 - proto: GasPipeStraightAlt1
   entities:
   - uid: 328
     components:
     - type: Transform
+      parent: 1
       rot: -1.5707963267948966 rad
       pos: 11.5,8.5
-      parent: 1
     - type: AtmosPipeColor
       color: '#0055CCFF'
   - uid: 329
     components:
     - type: Transform
-      pos: 5.5,10.5
       parent: 1
+      pos: 5.5,10.5
     - type: AtmosPipeColor
       color: '#0055CCFF'
   - uid: 330
     components:
     - type: Transform
-      pos: 5.5,9.5
       parent: 1
+      pos: 5.5,9.5
     - type: AtmosPipeColor
       color: '#0055CCFF'
   - uid: 331
     components:
     - type: Transform
+      parent: 1
       rot: -1.5707963267948966 rad
       pos: 6.5,13.5
-      parent: 1
     - type: AtmosPipeColor
       color: '#0055CCFF'
   - uid: 332
     components:
     - type: Transform
+      parent: 1
       rot: -1.5707963267948966 rad
       pos: 7.5,13.5
-      parent: 1
     - type: AtmosPipeColor
       color: '#0055CCFF'
   - uid: 333
     components:
     - type: Transform
+      parent: 1
       rot: -1.5707963267948966 rad
       pos: 8.5,13.5
-      parent: 1
     - type: AtmosPipeColor
       color: '#0055CCFF'
   - uid: 334
     components:
     - type: Transform
+      parent: 1
       rot: 3.141592653589793 rad
       pos: 5.5,12.5
-      parent: 1
     - type: AtmosPipeColor
       color: '#0055CCFF'
   - uid: 335
     components:
     - type: Transform
+      parent: 1
       rot: 1.5707963267948966 rad
       pos: 6.5,8.5
-      parent: 1
     - type: AtmosPipeColor
       color: '#0055CCFF'
   - uid: 336
     components:
     - type: Transform
+      parent: 1
       rot: 1.5707963267948966 rad
       pos: 7.5,8.5
-      parent: 1
     - type: AtmosPipeColor
       color: '#0055CCFF'
   - uid: 337
     components:
     - type: Transform
+      parent: 1
       rot: 3.141592653589793 rad
       pos: 13.5,14.5
-      parent: 1
     - type: AtmosPipeColor
       color: '#0055CCFF'
   - uid: 338
     components:
     - type: Transform
+      parent: 1
       rot: 3.141592653589793 rad
       pos: 13.5,15.5
-      parent: 1
     - type: AtmosPipeColor
       color: '#0055CCFF'
   - uid: 339
     components:
     - type: Transform
+      parent: 1
       rot: -1.5707963267948966 rad
       pos: 14.5,16.5
-      parent: 1
     - type: AtmosPipeColor
       color: '#0055CCFF'
   - uid: 340
     components:
     - type: Transform
+      parent: 1
       rot: 1.5707963267948966 rad
       pos: 11.5,13.5
-      parent: 1
     - type: AtmosPipeColor
       color: '#0055CCFF'
   - uid: 341
     components:
     - type: Transform
-      pos: 10.5,12.5
       parent: 1
+      pos: 10.5,12.5
     - type: AtmosPipeColor
       color: '#0055CCFF'
   - uid: 342
     components:
     - type: Transform
-      pos: 10.5,11.5
       parent: 1
+      pos: 10.5,11.5
     - type: AtmosPipeColor
       color: '#0055CCFF'
   - uid: 343
     components:
     - type: Transform
-      pos: 10.5,10.5
       parent: 1
+      pos: 10.5,10.5
     - type: AtmosPipeColor
       color: '#0055CCFF'
   - uid: 344
     components:
     - type: Transform
-      pos: 10.5,9.5
       parent: 1
+      pos: 10.5,9.5
     - type: AtmosPipeColor
       color: '#0055CCFF'
   - uid: 345
     components:
     - type: Transform
+      parent: 1
       rot: -1.5707963267948966 rad
       pos: 9.5,8.5
-      parent: 1
     - type: AtmosPipeColor
       color: '#0055CCFF'
   - uid: 346
     components:
     - type: Transform
-      pos: 8.5,9.5
       parent: 1
+      pos: 8.5,9.5
     - type: AtmosPipeColor
       color: '#0055CCFF'
   - uid: 347
     components:
     - type: Transform
-      pos: 8.5,7.5
       parent: 1
+      pos: 8.5,7.5
     - type: AtmosPipeColor
       color: '#0055CCFF'
   - uid: 348
     components:
     - type: Transform
+      parent: 1
       rot: 1.5707963267948966 rad
       pos: 9.5,5.5
-      parent: 1
     - type: AtmosPipeColor
       color: '#0055CCFF'
   - uid: 349
     components:
     - type: Transform
+      parent: 1
       rot: 1.5707963267948966 rad
       pos: 11.5,5.5
-      parent: 1
     - type: AtmosPipeColor
       color: '#0055CCFF'
   - uid: 350
     components:
     - type: Transform
-      pos: 8.5,6.5
       parent: 1
+      pos: 8.5,6.5
     - type: AtmosPipeColor
       color: '#0055CCFF'
   - uid: 351
     components:
     - type: Transform
-      pos: 10.5,4.5
       parent: 1
+      pos: 10.5,4.5
     - type: AtmosPipeColor
       color: '#0055CCFF'
 - proto: GasPipeStraightAlt2
@@ -2758,254 +2760,254 @@ entities:
   - uid: 352
     components:
     - type: Transform
+      parent: 1
       rot: -1.5707963267948966 rad
       pos: 14.5,17.5
-      parent: 1
     - type: AtmosPipeColor
       color: '#990000FF'
   - uid: 353
     components:
     - type: Transform
+      parent: 1
       rot: -1.5707963267948966 rad
       pos: 13.5,17.5
-      parent: 1
     - type: AtmosPipeColor
       color: '#990000FF'
   - uid: 354
     components:
     - type: Transform
+      parent: 1
       rot: 3.141592653589793 rad
       pos: 10.5,2.5
-      parent: 1
     - type: AtmosPipeColor
       color: '#990000FF'
   - uid: 355
     components:
     - type: Transform
+      parent: 1
       rot: -1.5707963267948966 rad
       pos: 8.5,13.5
-      parent: 1
     - type: AtmosPipeColor
       color: '#990000FF'
   - uid: 356
     components:
     - type: Transform
+      parent: 1
       rot: -1.5707963267948966 rad
       pos: 9.5,13.5
-      parent: 1
     - type: AtmosPipeColor
       color: '#990000FF'
   - uid: 357
     components:
     - type: Transform
+      parent: 1
       rot: 1.5707963267948966 rad
       pos: 6.5,13.5
-      parent: 1
     - type: AtmosPipeColor
       color: '#990000FF'
   - uid: 358
     components:
     - type: Transform
-      pos: 5.5,10.5
       parent: 1
+      pos: 5.5,10.5
     - type: AtmosPipeColor
       color: '#990000FF'
   - uid: 359
     components:
     - type: Transform
-      pos: 5.5,11.5
       parent: 1
+      pos: 5.5,11.5
     - type: AtmosPipeColor
       color: '#990000FF'
   - uid: 360
     components:
     - type: Transform
-      pos: 5.5,12.5
       parent: 1
+      pos: 5.5,12.5
     - type: AtmosPipeColor
       color: '#990000FF'
   - uid: 361
     components:
     - type: Transform
-      pos: 10.5,12.5
       parent: 1
+      pos: 10.5,12.5
     - type: AtmosPipeColor
       color: '#990000FF'
   - uid: 362
     components:
     - type: Transform
-      pos: 10.5,11.5
       parent: 1
+      pos: 10.5,11.5
     - type: AtmosPipeColor
       color: '#990000FF'
   - uid: 363
     components:
     - type: Transform
-      pos: 10.5,9.5
       parent: 1
+      pos: 10.5,9.5
     - type: AtmosPipeColor
       color: '#990000FF'
   - uid: 364
     components:
     - type: Transform
-      pos: 10.5,10.5
       parent: 1
+      pos: 10.5,10.5
     - type: AtmosPipeColor
       color: '#990000FF'
   - uid: 365
     components:
     - type: Transform
+      parent: 1
       rot: 3.141592653589793 rad
       pos: 12.5,14.5
-      parent: 1
     - type: AtmosPipeColor
       color: '#990000FF'
   - uid: 366
     components:
     - type: Transform
+      parent: 1
       rot: 3.141592653589793 rad
       pos: 12.5,15.5
-      parent: 1
     - type: AtmosPipeColor
       color: '#990000FF'
   - uid: 367
     components:
     - type: Transform
-      pos: 12.5,16.5
       parent: 1
+      pos: 12.5,16.5
     - type: AtmosPipeColor
       color: '#990000FF'
   - uid: 368
     components:
     - type: Transform
+      parent: 1
       rot: 1.5707963267948966 rad
       pos: 11.5,13.5
-      parent: 1
     - type: AtmosPipeColor
       color: '#990000FF'
   - uid: 369
     components:
     - type: Transform
+      parent: 1
       rot: 3.141592653589793 rad
       pos: 8.5,10.5
-      parent: 1
     - type: AtmosPipeColor
       color: '#990000FF'
   - uid: 370
     components:
     - type: Transform
+      parent: 1
       rot: 3.141592653589793 rad
       pos: 8.5,9.5
-      parent: 1
     - type: AtmosPipeColor
       color: '#990000FF'
   - uid: 371
     components:
     - type: Transform
+      parent: 1
       rot: 1.5707963267948966 rad
       pos: 9.5,8.5
-      parent: 1
     - type: AtmosPipeColor
       color: '#990000FF'
   - uid: 372
     components:
     - type: Transform
-      pos: 8.5,7.5
       parent: 1
+      pos: 8.5,7.5
     - type: AtmosPipeColor
       color: '#990000FF'
   - uid: 373
     components:
     - type: Transform
+      parent: 1
       rot: -1.5707963267948966 rad
       pos: 11.5,8.5
-      parent: 1
     - type: AtmosPipeColor
       color: '#990000FF'
   - uid: 374
     components:
     - type: Transform
+      parent: 1
       rot: -1.5707963267948966 rad
       pos: 12.5,8.5
-      parent: 1
     - type: AtmosPipeColor
       color: '#990000FF'
   - uid: 375
     components:
     - type: Transform
+      parent: 1
       rot: -1.5707963267948966 rad
       pos: 13.5,8.5
-      parent: 1
     - type: AtmosPipeColor
       color: '#990000FF'
   - uid: 376
     components:
     - type: Transform
+      parent: 1
       rot: 1.5707963267948966 rad
       pos: 11.5,5.5
-      parent: 1
     - type: AtmosPipeColor
       color: '#990000FF'
   - uid: 377
     components:
     - type: Transform
+      parent: 1
       rot: 1.5707963267948966 rad
       pos: 12.5,5.5
-      parent: 1
     - type: AtmosPipeColor
       color: '#990000FF'
   - uid: 378
     components:
     - type: Transform
-      pos: 8.5,6.5
       parent: 1
+      pos: 8.5,6.5
     - type: AtmosPipeColor
       color: '#990000FF'
   - uid: 379
     components:
     - type: Transform
+      parent: 1
       rot: 1.5707963267948966 rad
       pos: 7.5,5.5
-      parent: 1
     - type: AtmosPipeColor
       color: '#990000FF'
   - uid: 380
     components:
     - type: Transform
+      parent: 1
       rot: 1.5707963267948966 rad
       pos: 6.5,5.5
-      parent: 1
     - type: AtmosPipeColor
       color: '#990000FF'
   - uid: 381
     components:
     - type: Transform
+      parent: 1
       rot: 1.5707963267948966 rad
       pos: 5.5,5.5
-      parent: 1
     - type: AtmosPipeColor
       color: '#990000FF'
   - uid: 382
     components:
     - type: Transform
+      parent: 1
       rot: 1.5707963267948966 rad
       pos: 4.5,5.5
-      parent: 1
     - type: AtmosPipeColor
       color: '#990000FF'
   - uid: 383
     components:
     - type: Transform
-      pos: 10.5,4.5
       parent: 1
+      pos: 10.5,4.5
     - type: AtmosPipeColor
       color: '#990000FF'
   - uid: 384
     components:
     - type: Transform
+      parent: 1
       rot: 3.141592653589793 rad
       pos: 10.5,3.5
-      parent: 1
     - type: AtmosPipeColor
       color: '#990000FF'
 - proto: GasPipeTJunctionAlt1
@@ -3013,25 +3015,25 @@ entities:
   - uid: 385
     components:
     - type: Transform
+      parent: 1
       rot: -1.5707963267948966 rad
       pos: 5.5,11.5
-      parent: 1
     - type: AtmosPipeColor
       color: '#0055CCFF'
   - uid: 386
     components:
     - type: Transform
+      parent: 1
       rot: 3.141592653589793 rad
       pos: 12.5,13.5
-      parent: 1
     - type: AtmosPipeColor
       color: '#0055CCFF'
   - uid: 387
     components:
     - type: Transform
+      parent: 1
       rot: 3.141592653589793 rad
       pos: 10.5,8.5
-      parent: 1
     - type: AtmosPipeColor
       color: '#0055CCFF'
 - proto: GasPipeTJunctionAlt2
@@ -3039,63 +3041,63 @@ entities:
   - uid: 388
     components:
     - type: Transform
+      parent: 1
       rot: 3.141592653589793 rad
       pos: 7.5,13.5
-      parent: 1
     - type: AtmosPipeColor
       color: '#990000FF'
   - uid: 389
     components:
     - type: Transform
-      pos: 10.5,13.5
       parent: 1
+      pos: 10.5,13.5
     - type: AtmosPipeColor
       color: '#990000FF'
   - uid: 390
     components:
     - type: Transform
+      parent: 1
       rot: 3.141592653589793 rad
       pos: 10.5,8.5
-      parent: 1
     - type: AtmosPipeColor
       color: '#990000FF'
   - uid: 391
     components:
     - type: Transform
+      parent: 1
       rot: 3.141592653589793 rad
       pos: 12.5,13.5
-      parent: 1
     - type: AtmosPipeColor
       color: '#990000FF'
   - uid: 392
     components:
     - type: Transform
+      parent: 1
       rot: 1.5707963267948966 rad
       pos: 8.5,8.5
-      parent: 1
     - type: AtmosPipeColor
       color: '#990000FF'
   - uid: 393
     components:
     - type: Transform
+      parent: 1
       rot: 3.141592653589793 rad
       pos: 8.5,5.5
-      parent: 1
     - type: AtmosPipeColor
       color: '#990000FF'
   - uid: 394
     components:
     - type: Transform
+      parent: 1
       rot: 3.141592653589793 rad
       pos: 9.5,5.5
-      parent: 1
     - type: AtmosPipeColor
       color: '#990000FF'
   - uid: 395
     components:
     - type: Transform
-      pos: 10.5,5.5
       parent: 1
+      pos: 10.5,5.5
     - type: AtmosPipeColor
       color: '#990000FF'
 - proto: GasPort
@@ -3103,9 +3105,9 @@ entities:
   - uid: 396
     components:
     - type: Transform
+      parent: 1
       rot: 3.141592653589793 rad
       pos: 12.5,7.5
-      parent: 1
     - type: AtmosPipeLayers
       pipeLayer: Secondary
     - type: AtmosPipeColor
@@ -3113,9 +3115,9 @@ entities:
   - uid: 397
     components:
     - type: Transform
+      parent: 1
       rot: 3.141592653589793 rad
       pos: 13.5,7.5
-      parent: 1
     - type: AtmosPipeLayers
       pipeLayer: Secondary
     - type: AtmosPipeColor
@@ -3123,23 +3125,23 @@ entities:
   - uid: 398
     components:
     - type: Transform
+      parent: 1
       rot: 3.141592653589793 rad
       pos: 13.5,11.5
-      parent: 1
   - uid: 399
     components:
     - type: Transform
+      parent: 1
       rot: 3.141592653589793 rad
       pos: 12.5,11.5
-      parent: 1
 - proto: GasVentPump
   entities:
   - uid: 400
     components:
     - type: Transform
+      parent: 1
       rot: 3.141592653589793 rad
       pos: 10.5,3.5
-      parent: 1
     - type: DeviceNetwork
       deviceLists:
       - 7
@@ -3150,9 +3152,9 @@ entities:
   - uid: 401
     components:
     - type: Transform
+      parent: 1
       rot: 1.5707963267948966 rad
       pos: 4.5,11.5
-      parent: 1
     - type: DeviceNetwork
       deviceLists:
       - 5
@@ -3163,9 +3165,9 @@ entities:
   - uid: 402
     components:
     - type: Transform
+      parent: 1
       rot: -1.5707963267948966 rad
       pos: 9.5,13.5
-      parent: 1
     - type: DeviceNetwork
       deviceLists:
       - 2
@@ -3176,9 +3178,9 @@ entities:
   - uid: 403
     components:
     - type: Transform
+      parent: 1
       rot: -1.5707963267948966 rad
       pos: 15.5,16.5
-      parent: 1
     - type: DeviceNetwork
       deviceLists:
       - 10
@@ -3191,8 +3193,8 @@ entities:
   - uid: 404
     components:
     - type: Transform
-      pos: 10.5,6.5
       parent: 1
+      pos: 10.5,6.5
     - type: DeviceNetwork
       deviceLists:
       - 6
@@ -3201,9 +3203,9 @@ entities:
   - uid: 405
     components:
     - type: Transform
+      parent: 1
       rot: 3.141592653589793 rad
       pos: 12.5,4.5
-      parent: 1
     - type: DeviceNetwork
       deviceLists:
       - 8
@@ -3212,8 +3214,8 @@ entities:
   - uid: 406
     components:
     - type: Transform
-      pos: 12.5,14.5
       parent: 1
+      pos: 12.5,14.5
     - type: DeviceNetwork
       deviceLists:
       - 3
@@ -3222,8 +3224,8 @@ entities:
   - uid: 407
     components:
     - type: Transform
-      pos: 7.5,11.5
       parent: 1
+      pos: 7.5,11.5
     - type: DeviceNetwork
       deviceLists:
       - 9
@@ -3234,9 +3236,9 @@ entities:
   - uid: 408
     components:
     - type: Transform
+      parent: 1
       rot: 3.141592653589793 rad
       pos: 10.5,1.5
-      parent: 1
     - type: DeviceNetwork
       deviceLists:
       - 7
@@ -3247,9 +3249,9 @@ entities:
   - uid: 409
     components:
     - type: Transform
+      parent: 1
       rot: -1.5707963267948966 rad
       pos: 14.5,8.5
-      parent: 1
     - type: AtmosPipeLayers
       pipeLayer: Tertiary
     - type: AtmosPipeColor
@@ -3257,8 +3259,8 @@ entities:
   - uid: 410
     components:
     - type: Transform
-      pos: 7.5,14.5
       parent: 1
+      pos: 7.5,14.5
     - type: DeviceNetwork
       deviceLists:
       - 5
@@ -3269,18 +3271,18 @@ entities:
   - uid: 411
     components:
     - type: Transform
+      parent: 1
       rot: 4.71238898038469 rad
       pos: 15.5,14.5
-      parent: 1
     - type: DeviceNetwork
       deviceLists:
       - 4
   - uid: 412
     components:
     - type: Transform
+      parent: 1
       rot: 3.141592653589793 rad
       pos: 5.5,9.5
-      parent: 1
     - type: DeviceNetwork
       deviceLists:
       - 2
@@ -3294,9 +3296,9 @@ entities:
   - uid: 413
     components:
     - type: Transform
+      parent: 1
       rot: -1.5707963267948966 rad
       pos: 15.5,17.5
-      parent: 1
     - type: DeviceNetwork
       deviceLists:
       - 10
@@ -3309,8 +3311,8 @@ entities:
   - uid: 414
     components:
     - type: Transform
-      pos: 8.5,11.5
       parent: 1
+      pos: 8.5,11.5
     - type: DeviceNetwork
       deviceLists:
       - 9
@@ -3319,8 +3321,8 @@ entities:
   - uid: 415
     components:
     - type: Transform
-      pos: 9.5,6.5
       parent: 1
+      pos: 9.5,6.5
     - type: DeviceNetwork
       deviceLists:
       - 6
@@ -3329,9 +3331,9 @@ entities:
   - uid: 416
     components:
     - type: Transform
+      parent: 1
       rot: 3.141592653589793 rad
       pos: 13.5,4.5
-      parent: 1
     - type: DeviceNetwork
       deviceLists:
       - 8
@@ -3340,8 +3342,8 @@ entities:
   - uid: 417
     components:
     - type: Transform
-      pos: 13.5,14.5
       parent: 1
+      pos: 13.5,14.5
     - type: DeviceNetwork
       deviceLists:
       - 3
@@ -3352,21 +3354,21 @@ entities:
   - uid: 418
     components:
     - type: Transform
-      pos: 12.5,12.5
       parent: 1
+      pos: 12.5,12.5
   - uid: 419
     components:
     - type: Transform
+      parent: 1
       rot: 3.141592653589793 rad
       pos: 13.5,12.5
-      parent: 1
 - proto: GeneratorCRPinchShuttle
   entities:
   - uid: 420
     components:
     - type: Transform
-      pos: 14.5,9.5
       parent: 1
+      pos: 14.5,9.5
     - type: FuelGenerator
       targetPower: 121000
 - proto: GravityGeneratorMini
@@ -3374,232 +3376,232 @@ entities:
   - uid: 421
     components:
     - type: Transform
-      pos: 12.5,2.5
       parent: 1
+      pos: 12.5,2.5
 - proto: GreebleAntenna1
   entities:
   - uid: 422
     components:
     - type: Transform
-      pos: 9.5,14.5
       parent: 1
+      pos: 9.5,14.5
 - proto: GreebleElint1
   entities:
   - uid: 423
     components:
     - type: Transform
-      pos: 9.5,14.5
       parent: 1
+      pos: 9.5,14.5
 - proto: GreebleRadarpanel2
   entities:
   - uid: 424
     components:
     - type: Transform
+      parent: 1
       rot: 3.141592653589793 rad
       pos: 16.5,15.5
-      parent: 1
   - uid: 425
     components:
     - type: Transform
+      parent: 1
       rot: 3.141592653589793 rad
       pos: 16.5,19.5
-      parent: 1
   - uid: 426
     components:
     - type: Transform
+      parent: 1
       rot: 3.141592653589793 rad
       pos: 16.5,17.5
-      parent: 1
 - proto: Grille
   entities:
   - uid: 427
     components:
     - type: Transform
-      pos: 13.5,2.5
       parent: 1
+      pos: 13.5,2.5
   - uid: 428
     components:
     - type: Transform
-      pos: 6.5,2.5
       parent: 1
+      pos: 6.5,2.5
   - uid: 429
     components:
     - type: Transform
-      pos: 17.5,8.5
       parent: 1
+      pos: 17.5,8.5
   - uid: 430
     components:
     - type: Transform
-      pos: 16.5,8.5
       parent: 1
+      pos: 16.5,8.5
   - uid: 431
     components:
     - type: Transform
-      pos: 19.5,5.5
       parent: 1
+      pos: 19.5,5.5
   - uid: 432
     components:
     - type: Transform
-      pos: 19.5,4.5
       parent: 1
+      pos: 19.5,4.5
   - uid: 433
     components:
     - type: Transform
-      pos: 3.5,8.5
       parent: 1
+      pos: 3.5,8.5
   - uid: 434
     components:
     - type: Transform
-      pos: 2.5,8.5
       parent: 1
+      pos: 2.5,8.5
   - uid: 435
     components:
     - type: Transform
-      pos: 0.5,5.5
       parent: 1
+      pos: 0.5,5.5
   - uid: 436
     components:
     - type: Transform
-      pos: 0.5,4.5
       parent: 1
+      pos: 0.5,4.5
   - uid: 437
     components:
     - type: Transform
-      pos: 3.5,1.5
       parent: 1
+      pos: 3.5,1.5
   - uid: 438
     components:
     - type: Transform
-      pos: 4.5,1.5
       parent: 1
+      pos: 4.5,1.5
   - uid: 439
     components:
     - type: Transform
-      pos: 15.5,1.5
       parent: 1
+      pos: 15.5,1.5
   - uid: 440
     components:
     - type: Transform
-      pos: 16.5,1.5
       parent: 1
+      pos: 16.5,1.5
   - uid: 441
     components:
     - type: Transform
-      pos: 3.5,11.5
       parent: 1
+      pos: 3.5,11.5
   - uid: 442
     components:
     - type: Transform
-      pos: 3.5,12.5
       parent: 1
+      pos: 3.5,12.5
   - uid: 443
     components:
     - type: Transform
-      pos: 3.5,13.5
       parent: 1
+      pos: 3.5,13.5
   - uid: 444
     components:
     - type: Transform
-      pos: 4.5,14.5
       parent: 1
+      pos: 4.5,14.5
   - uid: 445
     components:
     - type: Transform
-      pos: 5.5,15.5
       parent: 1
+      pos: 5.5,15.5
   - uid: 446
     components:
     - type: Transform
-      pos: 6.5,15.5
       parent: 1
+      pos: 6.5,15.5
   - uid: 447
     components:
     - type: Transform
-      pos: 7.5,15.5
       parent: 1
+      pos: 7.5,15.5
   - uid: 448
     components:
     - type: Transform
-      pos: 13.5,20.5
       parent: 1
+      pos: 13.5,20.5
   - uid: 449
     components:
     - type: Transform
-      pos: 14.5,14.5
       parent: 1
+      pos: 14.5,14.5
   - uid: 450
     components:
     - type: Transform
-      pos: 10.5,0.5
       parent: 1
+      pos: 10.5,0.5
   - uid: 451
     components:
     - type: Transform
-      pos: 11.5,0.5
       parent: 1
+      pos: 11.5,0.5
   - uid: 452
     components:
     - type: Transform
-      pos: 12.5,1.5
       parent: 1
+      pos: 12.5,1.5
   - uid: 453
     components:
     - type: Transform
-      pos: 7.5,1.5
       parent: 1
+      pos: 7.5,1.5
   - uid: 454
     components:
     - type: Transform
-      pos: 8.5,0.5
       parent: 1
+      pos: 8.5,0.5
   - uid: 455
     components:
     - type: Transform
-      pos: 9.5,0.5
       parent: 1
+      pos: 9.5,0.5
 - proto: GrilleDiagonal
   entities:
   - uid: 456
     components:
     - type: Transform
+      parent: 1
       rot: 1.5707963267948966 rad
       pos: 6.5,1.5
-      parent: 1
   - uid: 457
     components:
     - type: Transform
+      parent: 1
       rot: 3.141592653589793 rad
       pos: 12.5,0.5
-      parent: 1
   - uid: 458
     components:
     - type: Transform
-      pos: 3.5,14.5
       parent: 1
+      pos: 3.5,14.5
   - uid: 459
     components:
     - type: Transform
-      pos: 4.5,15.5
       parent: 1
+      pos: 4.5,15.5
   - uid: 460
     components:
     - type: Transform
+      parent: 1
       rot: 3.141592653589793 rad
       pos: 13.5,1.5
-      parent: 1
   - uid: 461
     components:
     - type: Transform
+      parent: 1
       rot: 1.5707963267948966 rad
       pos: 7.5,0.5
-      parent: 1
 - proto: GunneryServerLow
   entities:
   - uid: 462
     components:
     - type: Transform
-      pos: 4.5,11.5
       parent: 1
+      pos: 4.5,11.5
     - type: Battery
       startingCharge: 0
     - type: ApcPowerReceiver
@@ -3609,123 +3611,123 @@ entities:
   - uid: 463
     components:
     - type: Transform
-      pos: 3.5,4.5
       parent: 1
+      pos: 3.5,4.5
   - uid: 464
     components:
     - type: Transform
-      pos: 16.5,4.5
       parent: 1
+      pos: 16.5,4.5
 - proto: ImpCoffeeMachine
   entities:
   - uid: 465
     components:
     - type: Transform
+      parent: 1
       rot: 1.5707963267948966 rad
       pos: 7.5,2.5
-      parent: 1
 - proto: KitchenReagentGrinder
   entities:
   - uid: 466
     components:
     - type: Transform
-      pos: 7.5,6.5
       parent: 1
+      pos: 7.5,6.5
 - proto: LockerSalvageSpecialistFilledHardsuit
   entities:
   - uid: 467
     components:
     - type: Transform
-      pos: 14.5,16.5
       parent: 1
+      pos: 14.5,16.5
 - proto: LockerScienceFilled
   entities:
   - uid: 468
     components:
     - type: Transform
-      pos: 12.5,12.5
       parent: 1
+      pos: 12.5,12.5
 - proto: LockerWallColorL2RadiationFilled
   entities:
   - uid: 469
     components:
     - type: Transform
+      parent: 1
       rot: -1.5707963267948966 rad
       pos: 11.5,10.5
-      parent: 1
 - proto: LockerWallMaterialsFuelPlasmaFilled
   entities:
   - uid: 470
     components:
     - type: Transform
+      parent: 1
       rot: 3.141592653589793 rad
       pos: 10.5,7.5
-      parent: 1
 - proto: MachineAnomalyVessel
   entities:
   - uid: 471
     components:
     - type: Transform
-      pos: 15.5,11.5
       parent: 1
+      pos: 15.5,11.5
 - proto: MachineAPE
   entities:
   - uid: 472
     components:
     - type: Transform
+      parent: 1
       rot: 4.71238898038469 rad
       pos: 10.5,19.5
-      parent: 1
 - proto: MachineArtifactAnalyzer
   entities:
   - uid: 473
     components:
     - type: Transform
-      pos: 15.5,14.5
       parent: 1
+      pos: 15.5,14.5
 - proto: MachineHeavyFTLDriveConsole
   entities:
   - uid: 474
     components:
     - type: Transform
-      pos: 12.5,9.5
       parent: 1
+      pos: 12.5,9.5
 - proto: MachineHeavyFTLDriveCore
   entities:
   - uid: 475
     components:
     - type: Transform
-      pos: 13.5,9.5
       parent: 1
+      pos: 13.5,9.5
 - proto: MachineMaterialSilo
   entities:
   - uid: 476
     components:
     - type: Transform
-      pos: 15.5,17.5
       parent: 1
+      pos: 15.5,17.5
 - proto: MaterialReclaimer
   entities:
   - uid: 477
     components:
     - type: Transform
-      pos: 15.5,18.5
       parent: 1
+      pos: 15.5,18.5
 - proto: NFHolopadShip
   entities:
   - uid: 478
     components:
     - type: Transform
-      pos: 5.5,13.5
       parent: 1
+      pos: 5.5,13.5
 - proto: NitrogenCanister
   entities:
   - uid: 479
     components:
     - type: Transform
-      anchored: True
-      pos: 12.5,7.5
       parent: 1
+      pos: 12.5,7.5
+      anchored: True
     - type: Physics
       bodyType: Static
 - proto: OreProcessor
@@ -3733,16 +3735,16 @@ entities:
   - uid: 480
     components:
     - type: Transform
-      pos: 15.5,16.5
       parent: 1
+      pos: 15.5,16.5
 - proto: OxygenCanister
   entities:
   - uid: 481
     components:
     - type: Transform
-      anchored: True
-      pos: 13.5,7.5
       parent: 1
+      pos: 13.5,7.5
+      anchored: True
     - type: Physics
       bodyType: Static
 - proto: PlasmaReinforcedWindowDirectional
@@ -3750,552 +3752,552 @@ entities:
   - uid: 482
     components:
     - type: Transform
+      parent: 1
       rot: 4.71238898038469 rad
       pos: 14.5,9.5
-      parent: 1
   - uid: 483
     components:
     - type: Transform
+      parent: 1
       rot: 3.141592653589793 rad
       pos: 14.5,7.5
-      parent: 1
 - proto: PlayerStationAiVessel
   entities:
   - uid: 484
     components:
     - type: Transform
-      pos: 7.5,11.5
       parent: 1
+      pos: 7.5,11.5
 - proto: PlushieIpc
   entities:
   - uid: 485
     components:
     - type: Transform
-      pos: 6.8679295,14.56609
       parent: 1
+      pos: 6.8679295,14.56609
 - proto: PosterLegit50thAnniversaryVintageReprint
   entities:
   - uid: 486
     components:
     - type: Transform
-      pos: 9.5,4.5
       parent: 1
+      pos: 9.5,4.5
 - proto: PosterLegitSMAnomalies
   entities:
   - uid: 487
     components:
     - type: Transform
-      pos: 14.5,10.5
       parent: 1
+      pos: 14.5,10.5
 - proto: PoweredDimSmallLight
   entities:
   - uid: 488
     components:
     - type: Transform
+      parent: 1
       rot: 1.5707963267948966 rad
       pos: 18.5,2.5
-      parent: 1
   - uid: 489
     components:
     - type: Transform
+      parent: 1
       rot: 1.5707963267948966 rad
       pos: 19.5,7.5
-      parent: 1
   - uid: 490
     components:
     - type: Transform
+      parent: 1
       rot: -1.5707963267948966 rad
       pos: 1.5,2.5
-      parent: 1
   - uid: 491
     components:
     - type: Transform
+      parent: 1
       rot: -1.5707963267948966 rad
       pos: 0.5,7.5
-      parent: 1
 - proto: Poweredlight
   entities:
   - uid: 492
     components:
     - type: Transform
-      pos: 7.5,2.5
       parent: 1
+      pos: 7.5,2.5
   - uid: 493
     components:
     - type: Transform
-      pos: 12.5,2.5
       parent: 1
+      pos: 12.5,2.5
 - proto: PoweredlightCyan
   entities:
   - uid: 494
     components:
     - type: Transform
+      parent: 1
       rot: 3.141592653589793 rad
       pos: 13.5,7.5
-      parent: 1
 - proto: PoweredlightExterior
   entities:
   - uid: 495
     components:
     - type: Transform
+      parent: 1
       rot: 3.141592653589793 rad
       pos: 10.5,15.5
-      parent: 1
   - uid: 496
     components:
     - type: Transform
-      pos: 10.5,19.5
       parent: 1
+      pos: 10.5,19.5
 - proto: PoweredlightLED
   entities:
   - uid: 497
     components:
     - type: Transform
+      parent: 1
       rot: 3.141592653589793 rad
       pos: 14.5,16.5
-      parent: 1
   - uid: 498
     components:
     - type: Transform
+      parent: 1
       rot: 1.5707963267948966 rad
       pos: 12.5,14.5
-      parent: 1
   - uid: 499
     components:
     - type: Transform
+      parent: 1
       rot: -1.5707963267948966 rad
       pos: 15.5,11.5
-      parent: 1
   - uid: 500
     components:
     - type: Transform
+      parent: 1
       rot: 1.5707963267948966 rad
       pos: 5.5,8.5
-      parent: 1
   - uid: 501
     components:
     - type: Transform
-      pos: 10.5,13.5
       parent: 1
+      pos: 10.5,13.5
   - uid: 502
     components:
     - type: Transform
-      pos: 6.5,6.5
       parent: 1
+      pos: 6.5,6.5
 - proto: PoweredlightUltraviolet
   entities:
   - uid: 503
     components:
     - type: Transform
+      parent: 1
       rot: 1.5707963267948966 rad
       pos: 16.5,4.5
-      parent: 1
   - uid: 504
     components:
     - type: Transform
+      parent: 1
       rot: -1.5707963267948966 rad
       pos: 3.5,4.5
-      parent: 1
 - proto: PoweredSmallLight
   entities:
   - uid: 505
     components:
     - type: Transform
+      parent: 1
       rot: -1.5707963267948966 rad
       pos: 5.5,11.5
-      parent: 1
   - uid: 506
     components:
     - type: Transform
+      parent: 1
       rot: 3.141592653589793 rad
       pos: 7.5,13.5
-      parent: 1
 - proto: PoweredWarmSmallLight
   entities:
   - uid: 507
     components:
     - type: Transform
-      pos: 13.5,5.5
       parent: 1
+      pos: 13.5,5.5
 - proto: Protolathe
   entities:
   - uid: 508
     components:
     - type: Transform
-      pos: 6.5,6.5
       parent: 1
+      pos: 6.5,6.5
 - proto: RadarEdgeMarkerDiagonal
   entities:
   - uid: 509
     components:
     - type: Transform
+      parent: 1
       rot: 1.5707963267948966 rad
       pos: 15.5,8.5
-      parent: 1
   - uid: 510
     components:
     - type: Transform
+      parent: 1
       rot: 1.5707963267948966 rad
       pos: 14.5,4.5
-      parent: 1
   - uid: 511
     components:
     - type: Transform
-      pos: 4.5,8.5
       parent: 1
+      pos: 4.5,8.5
   - uid: 512
     components:
     - type: Transform
-      pos: 5.5,4.5
       parent: 1
+      pos: 5.5,4.5
   - uid: 513
     components:
     - type: Transform
+      parent: 1
       rot: 3.141592653589793 rad
       pos: 4.5,9.5
-      parent: 1
   - uid: 514
     components:
     - type: Transform
-      pos: 9.5,14.5
       parent: 1
+      pos: 9.5,14.5
   - uid: 515
     components:
     - type: Transform
+      parent: 1
       rot: -1.5707963267948966 rad
       pos: 9.5,10.5
-      parent: 1
   - uid: 516
     components:
     - type: Transform
+      parent: 1
       rot: -1.5707963267948966 rad
       pos: 8.5,9.5
-      parent: 1
   - uid: 517
     components:
     - type: Transform
+      parent: 1
       rot: 3.141592653589793 rad
       pos: 15.5,12.5
-      parent: 1
   - uid: 518
     components:
     - type: Transform
+      parent: 1
       rot: 1.5707963267948966 rad
       pos: 15.5,15.5
-      parent: 1
 - proto: RadarEdgeMarkerStraight
   entities:
   - uid: 519
     components:
     - type: Transform
+      parent: 1
       rot: 3.141592653589793 rad
       pos: 14.5,2.5
-      parent: 1
   - uid: 520
     components:
     - type: Transform
+      parent: 1
       rot: 3.141592653589793 rad
       pos: 14.5,3.5
-      parent: 1
   - uid: 521
     components:
     - type: Transform
+      parent: 1
       rot: 3.141592653589793 rad
       pos: 15.5,5.5
-      parent: 1
   - uid: 522
     components:
     - type: Transform
+      parent: 1
       rot: 3.141592653589793 rad
       pos: 15.5,6.5
-      parent: 1
   - uid: 523
     components:
     - type: Transform
+      parent: 1
       rot: 3.141592653589793 rad
       pos: 15.5,7.5
-      parent: 1
   - uid: 524
     components:
     - type: Transform
-      pos: 4.5,7.5
       parent: 1
+      pos: 4.5,7.5
   - uid: 525
     components:
     - type: Transform
-      pos: 4.5,6.5
       parent: 1
+      pos: 4.5,6.5
   - uid: 526
     components:
     - type: Transform
-      pos: 4.5,5.5
       parent: 1
+      pos: 4.5,5.5
   - uid: 527
     components:
     - type: Transform
-      pos: 5.5,3.5
       parent: 1
+      pos: 5.5,3.5
   - uid: 528
     components:
     - type: Transform
-      pos: 5.5,2.5
       parent: 1
+      pos: 5.5,2.5
   - uid: 529
     components:
     - type: Transform
+      parent: 1
       rot: -1.5707963267948966 rad
       pos: 5.5,9.5
-      parent: 1
   - uid: 530
     components:
     - type: Transform
+      parent: 1
       rot: -1.5707963267948966 rad
       pos: 6.5,9.5
-      parent: 1
   - uid: 531
     components:
     - type: Transform
+      parent: 1
       rot: -1.5707963267948966 rad
       pos: 7.5,9.5
-      parent: 1
   - uid: 532
     components:
     - type: Transform
-      pos: 9.5,13.5
       parent: 1
+      pos: 9.5,13.5
   - uid: 533
     components:
     - type: Transform
-      pos: 9.5,11.5
       parent: 1
+      pos: 9.5,11.5
   - uid: 534
     components:
     - type: Transform
-      pos: 9.5,12.5
       parent: 1
+      pos: 9.5,12.5
   - uid: 535
     components:
     - type: Transform
+      parent: 1
       rot: -1.5707963267948966 rad
       pos: 16.5,12.5
-      parent: 1
   - uid: 536
     components:
     - type: Transform
+      parent: 1
       rot: 3.141592653589793 rad
       pos: 15.5,14.5
-      parent: 1
   - uid: 537
     components:
     - type: Transform
+      parent: 1
       rot: 3.141592653589793 rad
       pos: 15.5,13.5
-      parent: 1
   - uid: 538
     components:
     - type: Transform
+      parent: 1
       rot: 1.5707963267948966 rad
       pos: 16.5,15.5
-      parent: 1
 - proto: Railing
   entities:
   - uid: 539
     components:
     - type: Transform
-      pos: 15.5,14.5
       parent: 1
+      pos: 15.5,14.5
   - uid: 540
     components:
     - type: Transform
+      parent: 1
       rot: -1.5707963267948966 rad
       pos: 12.5,2.5
-      parent: 1
 - proto: ReinforcedPlasmaWindow
   entities:
   - uid: 541
     components:
     - type: Transform
-      pos: 6.5,2.5
       parent: 1
+      pos: 6.5,2.5
   - uid: 542
     components:
     - type: Transform
-      pos: 7.5,1.5
       parent: 1
+      pos: 7.5,1.5
   - uid: 543
     components:
     - type: Transform
-      pos: 13.5,2.5
       parent: 1
+      pos: 13.5,2.5
   - uid: 544
     components:
     - type: Transform
-      pos: 3.5,11.5
       parent: 1
+      pos: 3.5,11.5
   - uid: 545
     components:
     - type: Transform
-      pos: 3.5,12.5
       parent: 1
+      pos: 3.5,12.5
   - uid: 546
     components:
     - type: Transform
-      pos: 3.5,13.5
       parent: 1
+      pos: 3.5,13.5
   - uid: 547
     components:
     - type: Transform
-      pos: 4.5,14.5
       parent: 1
+      pos: 4.5,14.5
   - uid: 548
     components:
     - type: Transform
-      pos: 5.5,15.5
       parent: 1
+      pos: 5.5,15.5
   - uid: 549
     components:
     - type: Transform
-      pos: 6.5,15.5
       parent: 1
+      pos: 6.5,15.5
   - uid: 550
     components:
     - type: Transform
-      pos: 7.5,15.5
       parent: 1
+      pos: 7.5,15.5
   - uid: 551
     components:
     - type: Transform
-      pos: 13.5,20.5
       parent: 1
+      pos: 13.5,20.5
   - uid: 552
     components:
     - type: Transform
-      pos: 12.5,1.5
       parent: 1
+      pos: 12.5,1.5
   - uid: 553
     components:
     - type: Transform
-      pos: 10.5,0.5
       parent: 1
+      pos: 10.5,0.5
   - uid: 554
     components:
     - type: Transform
-      pos: 9.5,0.5
       parent: 1
+      pos: 9.5,0.5
   - uid: 555
     components:
     - type: Transform
-      pos: 8.5,0.5
       parent: 1
+      pos: 8.5,0.5
   - uid: 556
     components:
     - type: Transform
-      pos: 11.5,0.5
       parent: 1
+      pos: 11.5,0.5
 - proto: ReinforcedPlasmaWindowDiagonal
   entities:
   - uid: 557
     components:
     - type: Transform
+      parent: 1
       rot: 3.141592653589793 rad
       pos: 12.5,0.5
-      parent: 1
   - uid: 558
     components:
     - type: Transform
+      parent: 1
       rot: 3.141592653589793 rad
       pos: 13.5,1.5
-      parent: 1
   - uid: 559
     components:
     - type: Transform
+      parent: 1
       rot: 1.5707963267948966 rad
       pos: 6.5,1.5
-      parent: 1
   - uid: 560
     components:
     - type: Transform
-      pos: 3.5,14.5
       parent: 1
+      pos: 3.5,14.5
   - uid: 561
     components:
     - type: Transform
-      pos: 4.5,15.5
       parent: 1
+      pos: 4.5,15.5
   - uid: 562
     components:
     - type: Transform
+      parent: 1
       rot: 1.5707963267948966 rad
       pos: 7.5,0.5
-      parent: 1
 - proto: ResearchAndDevelopmentServer
   entities:
   - uid: 563
     components:
     - type: Transform
-      pos: 6.5,14.5
       parent: 1
+      pos: 6.5,14.5
 - proto: ScrapProcessor
   entities:
   - uid: 564
     components:
     - type: Transform
-      pos: 15.5,19.5
       parent: 1
+      pos: 15.5,19.5
 - proto: ShieldGeneratorSmall
   entities:
   - uid: 565
     components:
     - type: Transform
-      pos: 8.5,11.5
       parent: 1
-- proto: ShutterWindowIndestructibleOpen
+      pos: 8.5,11.5
+- proto: ShuttersNormalOpen
   entities:
   - uid: 566
     components:
     - type: Transform
+      parent: 1
       rot: 3.141592653589793 rad
       pos: 13.5,15.5
-      parent: 1
   - uid: 567
     components:
     - type: Transform
+      parent: 1
       rot: 3.141592653589793 rad
       pos: 12.5,15.5
-      parent: 1
 - proto: ShuttleWindow
   entities:
   - uid: 568
     components:
     - type: Transform
-      pos: 14.5,14.5
       parent: 1
+      pos: 14.5,14.5
 - proto: SignAi
   entities:
   - uid: 569
     components:
     - type: Transform
-      pos: 9.5,10.5
       parent: 1
+      pos: 9.5,10.5
 - proto: SignalButton
   entities:
-  - uid: 210
+  - uid: 570
     components:
     - type: Transform
+      parent: 1
       rot: 1.5707963267948966 rad
       pos: 11.5,14.25
-      parent: 1
     - type: DeviceLinkSource
       linkedPorts:
         117:
         - - Pressed
           - Toggle
-  - uid: 211
+  - uid: 571
     components:
     - type: Transform
+      parent: 1
       rot: 1.5707963267948966 rad
       pos: 11.5,14.75
-      parent: 1
     - type: DeviceLinkSource
       linkedPorts:
         567:
@@ -4304,13 +4306,13 @@ entities:
         566:
         - - Pressed
           - Toggle
-  - uid: 570
+  - uid: 572
     components:
     - type: MetaData
       name: ZETA
     - type: Transform
-      pos: 5.5,14.5
       parent: 1
+      pos: 5.5,14.5
     - type: DeviceLinkSource
       linkedPorts:
         472:
@@ -4318,14 +4320,14 @@ entities:
           - Toggle
         - - Pressed
           - SetParticleZeta
-  - uid: 571
+  - uid: 573
     components:
     - type: MetaData
       name: SIGMA
     - type: Transform
+      parent: 1
       rot: 4.71238898038469 rad
       pos: 5.5,14.5
-      parent: 1
     - type: DeviceLinkSource
       linkedPorts:
         472:
@@ -4333,14 +4335,14 @@ entities:
           - Toggle
         - - Pressed
           - SetParticleSigma
-  - uid: 572
+  - uid: 574
     components:
     - type: MetaData
       name: DELTA
     - type: Transform
+      parent: 1
       rot: 3.141592653589793 rad
       pos: 5.5,14.5
-      parent: 1
     - type: DeviceLinkSource
       linkedPorts:
         472:
@@ -4348,14 +4350,14 @@ entities:
           - Toggle
         - - Pressed
           - SetParticleDelta
-  - uid: 573
+  - uid: 575
     components:
     - type: MetaData
       name: EPSILON
     - type: Transform
+      parent: 1
       rot: 1.5707963267948966 rad
       pos: 5.5,14.5
-      parent: 1
     - type: DeviceLinkSource
       linkedPorts:
         472:
@@ -4365,12 +4367,12 @@ entities:
           - SetParticleEpsilon
 - proto: SignalSwitchDirectional
   entities:
-  - uid: 575
+  - uid: 576
     components:
     - type: Transform
+      parent: 1
       rot: 1.5707963267948966 rad
       pos: 11.5,19.5
-      parent: 1
     - type: DeviceLinkSource
       linkedPorts:
         114:
@@ -4390,817 +4392,812 @@ entities:
           - Close
 - proto: SinkWide
   entities:
-  - uid: 576
-    components:
-    - type: Transform
-      rot: 3.141592653589793 rad
-      pos: 6.5,4.5
-      parent: 1
-- proto: SMESAdvanced
-  entities:
   - uid: 577
     components:
     - type: Transform
-      pos: 14.5,7.5
       parent: 1
-- proto: SpawnPointLatejoin
+      rot: 3.141592653589793 rad
+      pos: 6.5,4.5
+- proto: SMESAdvanced
   entities:
   - uid: 578
     components:
     - type: Transform
-      pos: 9.5,1.5
       parent: 1
+      pos: 14.5,7.5
+- proto: SpawnPointLatejoin
+  entities:
   - uid: 579
     components:
     - type: Transform
-      pos: 10.5,1.5
       parent: 1
+      pos: 9.5,1.5
   - uid: 580
     components:
     - type: Transform
-      pos: 11.5,1.5
       parent: 1
-- proto: SubstationWallBasic
-  entities:
-  - uid: 28
-    components:
-    - type: Transform
-      rot: 1.5707963267948966 rad
-      pos: 15.5,6.5
-      parent: 1
-  - uid: 252
-    components:
-    - type: Transform
-      pos: 10.5,14.5
-      parent: 1
+      pos: 10.5,1.5
   - uid: 581
     components:
     - type: Transform
-      rot: -1.5707963267948966 rad
-      pos: 4.5,6.5
       parent: 1
+      pos: 11.5,1.5
+- proto: SubstationWallBasic
+  entities:
   - uid: 582
     components:
     - type: Transform
-      rot: 1.5707963267948966 rad
-      pos: 11.5,7.5
       parent: 1
-- proto: SuitStorageEVAScientist
-  entities:
+      rot: 1.5707963267948966 rad
+      pos: 15.5,6.5
+  - uid: 583
+    components:
+    - type: Transform
+      parent: 1
+      pos: 10.5,14.5
+  - uid: 584
+    components:
+    - type: Transform
+      parent: 1
+      rot: -1.5707963267948966 rad
+      pos: 4.5,6.5
   - uid: 585
     components:
     - type: Transform
-      pos: 13.5,19.5
       parent: 1
-- proto: SuitStorageWallmountRD
+      rot: 1.5707963267948966 rad
+      pos: 11.5,7.5
+- proto: SuitStorageEVAScientist
   entities:
   - uid: 586
     components:
     - type: Transform
-      pos: 12.5,6.5
       parent: 1
-- proto: SurveillanceCameraConstructed
+      pos: 13.5,19.5
+- proto: SuitStorageWallmountRD
   entities:
   - uid: 587
     components:
     - type: Transform
-      rot: -1.5707963267948966 rad
-      pos: 19.5,7.5
       parent: 1
+      pos: 12.5,6.5
+- proto: SurveillanceCameraConstructed
+  entities:
   - uid: 588
     components:
     - type: Transform
-      pos: 13.5,7.5
       parent: 1
+      rot: -1.5707963267948966 rad
+      pos: 19.5,7.5
   - uid: 589
     components:
     - type: Transform
-      rot: -1.5707963267948966 rad
-      pos: 12.5,12.5
       parent: 1
+      pos: 13.5,7.5
   - uid: 590
     components:
     - type: Transform
-      rot: -1.5707963267948966 rad
-      pos: 16.5,4.5
       parent: 1
+      rot: -1.5707963267948966 rad
+      pos: 12.5,12.5
   - uid: 591
     components:
     - type: Transform
-      rot: 3.141592653589793 rad
-      pos: 6.5,6.5
       parent: 1
+      rot: -1.5707963267948966 rad
+      pos: 16.5,4.5
   - uid: 592
     components:
     - type: Transform
-      rot: 3.141592653589793 rad
-      pos: 10.5,13.5
       parent: 1
+      rot: 3.141592653589793 rad
+      pos: 6.5,6.5
   - uid: 593
     components:
     - type: Transform
-      rot: 1.5707963267948966 rad
-      pos: 3.5,4.5
       parent: 1
+      rot: 3.141592653589793 rad
+      pos: 10.5,13.5
   - uid: 594
     components:
     - type: Transform
-      rot: -1.5707963267948966 rad
-      pos: 18.5,2.5
       parent: 1
+      rot: 1.5707963267948966 rad
+      pos: 3.5,4.5
   - uid: 595
     components:
     - type: Transform
-      rot: 1.5707963267948966 rad
-      pos: 1.5,2.5
       parent: 1
+      rot: -1.5707963267948966 rad
+      pos: 18.5,2.5
   - uid: 596
     components:
     - type: Transform
-      rot: 3.141592653589793 rad
-      pos: 12.5,2.5
       parent: 1
+      rot: 1.5707963267948966 rad
+      pos: 1.5,2.5
   - uid: 597
     components:
     - type: Transform
-      pos: 13.5,7.5
       parent: 1
+      rot: 3.141592653589793 rad
+      pos: 12.5,2.5
   - uid: 598
     components:
     - type: Transform
+      parent: 1
       rot: 3.141592653589793 rad
       pos: 13.5,5.5
-      parent: 1
   - uid: 599
     components:
     - type: Transform
-      pos: 10.5,15.5
       parent: 1
+      pos: 10.5,15.5
   - uid: 600
     components:
     - type: Transform
+      parent: 1
       rot: 1.5707963267948966 rad
       pos: 0.5,7.5
-      parent: 1
   - uid: 601
     components:
     - type: Transform
+      parent: 1
       rot: 3.141592653589793 rad
       pos: 13.5,19.5
-      parent: 1
   - uid: 602
     components:
     - type: Transform
+      parent: 1
       rot: -1.5707963267948966 rad
       pos: 5.5,8.5
-      parent: 1
 - proto: TableFancyPurple
   entities:
   - uid: 603
     components:
     - type: Transform
-      pos: 7.5,2.5
       parent: 1
+      pos: 7.5,2.5
 - proto: TableReinforced
   entities:
   - uid: 604
     components:
     - type: Transform
-      pos: 7.5,6.5
       parent: 1
+      pos: 7.5,6.5
   - uid: 605
     components:
     - type: Transform
-      pos: 5.5,14.5
       parent: 1
+      pos: 5.5,14.5
   - uid: 606
     components:
     - type: Transform
-      pos: 7.5,14.5
       parent: 1
+      pos: 7.5,14.5
 - proto: ThrusterLarge
   entities:
   - uid: 607
     components:
     - type: Transform
+      parent: 1
       rot: 3.141592653589793 rad
       pos: 16.5,2.5
-      parent: 1
   - uid: 608
     components:
     - type: Transform
+      parent: 1
       rot: -1.5707963267948966 rad
       pos: 18.5,5.5
-      parent: 1
   - uid: 609
     components:
     - type: Transform
-      pos: 16.5,7.5
       parent: 1
+      pos: 16.5,7.5
   - uid: 610
     components:
     - type: Transform
-      pos: 2.5,7.5
       parent: 1
+      pos: 2.5,7.5
   - uid: 611
     components:
     - type: Transform
+      parent: 1
       rot: 1.5707963267948966 rad
       pos: 1.5,4.5
-      parent: 1
   - uid: 612
     components:
     - type: Transform
+      parent: 1
       rot: 3.141592653589793 rad
       pos: 4.5,2.5
-      parent: 1
 - proto: WallShuttle
   entities:
   - uid: 613
     components:
     - type: Transform
-      pos: 5.5,3.5
       parent: 1
+      pos: 5.5,3.5
   - uid: 614
     components:
     - type: Transform
-      pos: 13.5,3.5
       parent: 1
+      pos: 13.5,3.5
   - uid: 615
     components:
     - type: Transform
-      pos: 18.5,7.5
       parent: 1
+      pos: 18.5,7.5
   - uid: 616
     components:
     - type: Transform
-      pos: 15.5,7.5
       parent: 1
+      pos: 15.5,7.5
   - uid: 617
     components:
     - type: Transform
-      pos: 18.5,6.5
       parent: 1
+      pos: 18.5,6.5
   - uid: 618
     components:
     - type: Transform
-      pos: 15.5,6.5
       parent: 1
+      pos: 15.5,6.5
   - uid: 619
     components:
     - type: Transform
-      pos: 4.5,7.5
       parent: 1
+      pos: 4.5,7.5
   - uid: 620
     components:
     - type: Transform
-      pos: 1.5,7.5
       parent: 1
+      pos: 1.5,7.5
   - uid: 621
     components:
     - type: Transform
-      pos: 1.5,6.5
       parent: 1
+      pos: 1.5,6.5
   - uid: 622
     components:
     - type: Transform
-      pos: 4.5,8.5
       parent: 1
+      pos: 4.5,8.5
   - uid: 623
     components:
     - type: Transform
-      pos: 15.5,8.5
       parent: 1
+      pos: 15.5,8.5
   - uid: 624
     components:
     - type: Transform
-      pos: 15.5,9.5
       parent: 1
+      pos: 15.5,9.5
   - uid: 625
     components:
     - type: Transform
-      pos: 15.5,10.5
       parent: 1
+      pos: 15.5,10.5
   - uid: 626
     components:
     - type: Transform
-      pos: 2.5,2.5
       parent: 1
+      pos: 2.5,2.5
   - uid: 627
     components:
     - type: Transform
-      pos: 5.5,2.5
       parent: 1
+      pos: 5.5,2.5
   - uid: 628
     components:
     - type: Transform
-      pos: 2.5,3.5
       parent: 1
+      pos: 2.5,3.5
   - uid: 629
     components:
     - type: Transform
-      pos: 1.5,3.5
       parent: 1
+      pos: 1.5,3.5
   - uid: 630
     components:
     - type: Transform
-      pos: 14.5,2.5
       parent: 1
+      pos: 14.5,2.5
   - uid: 631
     components:
     - type: Transform
-      pos: 17.5,2.5
       parent: 1
+      pos: 17.5,2.5
   - uid: 632
     components:
     - type: Transform
-      pos: 14.5,3.5
       parent: 1
+      pos: 14.5,3.5
   - uid: 633
     components:
     - type: Transform
-      pos: 17.5,3.5
       parent: 1
+      pos: 17.5,3.5
   - uid: 634
     components:
     - type: Transform
-      pos: 18.5,3.5
       parent: 1
+      pos: 18.5,3.5
   - uid: 635
     components:
     - type: Transform
-      pos: 14.5,6.5
       parent: 1
+      pos: 14.5,6.5
   - uid: 636
     components:
     - type: Transform
-      pos: 16.5,14.5
       parent: 1
+      pos: 16.5,14.5
   - uid: 637
     components:
     - type: Transform
-      pos: 16.5,15.5
       parent: 1
+      pos: 16.5,15.5
   - uid: 638
     components:
     - type: Transform
-      pos: 16.5,16.5
       parent: 1
+      pos: 16.5,16.5
   - uid: 639
     components:
     - type: Transform
-      pos: 16.5,17.5
       parent: 1
+      pos: 16.5,17.5
   - uid: 640
     components:
     - type: Transform
-      pos: 16.5,18.5
       parent: 1
+      pos: 16.5,18.5
   - uid: 641
     components:
     - type: Transform
-      pos: 4.5,9.5
       parent: 1
+      pos: 4.5,9.5
   - uid: 642
     components:
     - type: Transform
-      pos: 7.5,9.5
       parent: 1
+      pos: 7.5,9.5
   - uid: 643
     components:
     - type: Transform
-      pos: 4.5,10.5
       parent: 1
+      pos: 4.5,10.5
   - uid: 644
     components:
     - type: Transform
-      pos: 9.5,11.5
       parent: 1
+      pos: 9.5,11.5
   - uid: 645
     components:
     - type: Transform
-      pos: 8.5,14.5
       parent: 1
+      pos: 8.5,14.5
   - uid: 646
     components:
     - type: Transform
-      pos: 9.5,14.5
       parent: 1
+      pos: 9.5,14.5
   - uid: 647
     components:
     - type: Transform
-      pos: 10.5,14.5
       parent: 1
+      pos: 10.5,14.5
   - uid: 648
     components:
     - type: Transform
-      pos: 11.5,15.5
       parent: 1
+      pos: 11.5,15.5
   - uid: 649
     components:
     - type: Transform
-      pos: 15.5,15.5
       parent: 1
+      pos: 15.5,15.5
   - uid: 650
     components:
     - type: Transform
-      pos: 8.5,12.5
       parent: 1
+      pos: 8.5,12.5
   - uid: 651
     components:
     - type: Transform
-      pos: 7.5,12.5
       parent: 1
+      pos: 7.5,12.5
   - uid: 652
     components:
     - type: Transform
-      pos: 6.5,11.5
       parent: 1
+      pos: 6.5,11.5
   - uid: 653
     components:
     - type: Transform
-      pos: 6.5,10.5
       parent: 1
+      pos: 6.5,10.5
   - uid: 654
     components:
     - type: Transform
-      pos: 9.5,10.5
       parent: 1
+      pos: 9.5,10.5
   - uid: 655
     components:
     - type: Transform
-      pos: 13.5,6.5
       parent: 1
+      pos: 13.5,6.5
   - uid: 656
     components:
     - type: Transform
-      pos: 12.5,6.5
       parent: 1
+      pos: 12.5,6.5
   - uid: 657
     components:
     - type: Transform
-      pos: 14.5,10.5
       parent: 1
+      pos: 14.5,10.5
   - uid: 658
     components:
     - type: Transform
-      pos: 13.5,10.5
       parent: 1
+      pos: 13.5,10.5
   - uid: 659
     components:
     - type: Transform
-      pos: 12.5,10.5
       parent: 1
+      pos: 12.5,10.5
   - uid: 660
     components:
     - type: Transform
-      pos: 11.5,6.5
       parent: 1
+      pos: 11.5,6.5
   - uid: 661
     components:
     - type: Transform
-      pos: 12.5,3.5
       parent: 1
+      pos: 12.5,3.5
   - uid: 662
     components:
     - type: Transform
-      pos: 11.5,10.5
       parent: 1
+      pos: 11.5,10.5
   - uid: 663
     components:
     - type: Transform
-      pos: 11.5,7.5
       parent: 1
+      pos: 11.5,7.5
   - uid: 664
     components:
     - type: Transform
-      pos: 11.5,9.5
       parent: 1
+      pos: 11.5,9.5
   - uid: 665
     components:
     - type: Transform
-      pos: 7.5,3.5
       parent: 1
+      pos: 7.5,3.5
   - uid: 666
     components:
     - type: Transform
-      pos: 6.5,3.5
       parent: 1
+      pos: 6.5,3.5
   - uid: 667
     components:
     - type: Transform
-      pos: 11.5,4.5
       parent: 1
+      pos: 11.5,4.5
   - uid: 668
     components:
     - type: Transform
-      pos: 4.5,6.5
       parent: 1
+      pos: 4.5,6.5
   - uid: 669
     components:
     - type: Transform
-      pos: 4.5,4.5
       parent: 1
+      pos: 4.5,4.5
   - uid: 670
     components:
     - type: Transform
-      pos: 15.5,4.5
       parent: 1
+      pos: 15.5,4.5
   - uid: 671
     components:
     - type: Transform
-      pos: 5.5,7.5
       parent: 1
+      pos: 5.5,7.5
   - uid: 672
     components:
     - type: Transform
-      pos: 6.5,7.5
       parent: 1
+      pos: 6.5,7.5
   - uid: 673
     components:
     - type: Transform
-      pos: 7.5,7.5
       parent: 1
+      pos: 7.5,7.5
   - uid: 674
     components:
     - type: Transform
-      pos: 9.5,7.5
       parent: 1
+      pos: 9.5,7.5
   - uid: 675
     components:
     - type: Transform
-      pos: 10.5,7.5
       parent: 1
+      pos: 10.5,7.5
   - uid: 676
     components:
     - type: Transform
-      pos: 9.5,4.5
       parent: 1
+      pos: 9.5,4.5
   - uid: 677
     components:
     - type: Transform
-      pos: 8.5,3.5
       parent: 1
+      pos: 8.5,3.5
   - uid: 678
     components:
     - type: Transform
-      pos: 11.5,14.5
       parent: 1
+      pos: 11.5,14.5
   - uid: 679
     components:
     - type: Transform
-      pos: 11.5,11.5
       parent: 1
+      pos: 11.5,11.5
   - uid: 680
     components:
     - type: Transform
-      pos: 11.5,12.5
       parent: 1
+      pos: 11.5,12.5
   - uid: 681
     components:
     - type: Transform
-      pos: 11.5,20.5
       parent: 1
+      pos: 11.5,20.5
   - uid: 682
     components:
     - type: Transform
-      pos: 15.5,20.5
       parent: 1
+      pos: 15.5,20.5
   - uid: 683
     components:
     - type: Transform
-      pos: 11.5,19.5
       parent: 1
+      pos: 11.5,19.5
   - uid: 684
     components:
     - type: Transform
-      pos: 16.5,19.5
       parent: 1
+      pos: 16.5,19.5
   - uid: 685
     components:
     - type: Transform
-      pos: 16.5,11.5
       parent: 1
+      pos: 16.5,11.5
   - uid: 686
     components:
     - type: Transform
-      pos: 14.5,15.5
       parent: 1
+      pos: 14.5,15.5
   - uid: 687
     components:
     - type: Transform
-      pos: 16.5,12.5
       parent: 1
+      pos: 16.5,12.5
   - uid: 688
     components:
     - type: Transform
-      pos: 15.5,12.5
       parent: 1
+      pos: 15.5,12.5
 - proto: WallShuttleDiagonal
   entities:
   - uid: 689
     components:
     - type: Transform
+      parent: 1
       rot: 4.71238898038469 rad
       pos: 18.5,8.5
-      parent: 1
   - uid: 690
     components:
     - type: Transform
+      parent: 1
       rot: 4.71238898038469 rad
       pos: 19.5,6.5
-      parent: 1
   - uid: 691
     components:
     - type: Transform
+      parent: 1
       rot: 3.141592653589793 rad
       pos: 19.5,3.5
-      parent: 1
   - uid: 692
     components:
     - type: Transform
-      pos: 1.5,8.5
       parent: 1
+      pos: 1.5,8.5
   - uid: 693
     components:
     - type: Transform
-      pos: 0.5,6.5
       parent: 1
+      pos: 0.5,6.5
   - uid: 694
     components:
     - type: Transform
+      parent: 1
       rot: 1.5707963267948966 rad
       pos: 0.5,3.5
-      parent: 1
   - uid: 695
     components:
     - type: Transform
+      parent: 1
       rot: 1.5707963267948966 rad
       pos: 2.5,1.5
-      parent: 1
   - uid: 696
     components:
     - type: Transform
+      parent: 1
       rot: 3.141592653589793 rad
       pos: 5.5,1.5
-      parent: 1
   - uid: 697
     components:
     - type: Transform
+      parent: 1
       rot: 1.5707963267948966 rad
       pos: 14.5,1.5
-      parent: 1
   - uid: 698
     components:
     - type: Transform
+      parent: 1
       rot: 3.141592653589793 rad
       pos: 17.5,1.5
-      parent: 1
   - uid: 699
     components:
     - type: Transform
+      parent: 1
       rot: 3.141592653589793 rad
       pos: 16.5,10.5
-      parent: 1
   - uid: 700
     components:
     - type: Transform
+      parent: 1
       rot: 1.5707963267948966 rad
       pos: 3.5,10.5
-      parent: 1
   - uid: 701
     components:
     - type: Transform
+      parent: 1
       rot: 4.71238898038469 rad
       pos: 8.5,15.5
-      parent: 1
   - uid: 702
     components:
     - type: Transform
+      parent: 1
       rot: 3.141592653589793 rad
       pos: 9.5,9.5
-      parent: 1
   - uid: 703
     components:
     - type: Transform
-      pos: 6.5,12.5
       parent: 1
+      pos: 6.5,12.5
   - uid: 704
     components:
     - type: Transform
+      parent: 1
       rot: 1.5707963267948966 rad
       pos: 6.5,9.5
-      parent: 1
   - uid: 705
     components:
     - type: Transform
+      parent: 1
       rot: 4.71238898038469 rad
       pos: 9.5,12.5
-      parent: 1
   - uid: 706
     components:
     - type: Transform
+      parent: 1
       rot: 1.5707963267948966 rad
       pos: 11.5,3.5
-      parent: 1
   - uid: 707
     components:
     - type: Transform
+      parent: 1
       rot: 4.71238898038469 rad
       pos: 5.5,4.5
-      parent: 1
   - uid: 708
     components:
     - type: Transform
-      pos: 14.5,4.5
       parent: 1
+      pos: 14.5,4.5
   - uid: 709
     components:
     - type: Transform
+      parent: 1
       rot: 3.141592653589793 rad
       pos: 9.5,3.5
-      parent: 1
   - uid: 710
     components:
     - type: Transform
-      pos: 10.5,20.5
       parent: 1
+      pos: 10.5,20.5
   - uid: 711
     components:
     - type: Transform
+      parent: 1
       rot: 4.71238898038469 rad
       pos: 16.5,20.5
-      parent: 1
   - uid: 712
     components:
     - type: Transform
+      parent: 1
       rot: 1.5707963267948966 rad
       pos: 14.5,12.5
-      parent: 1
 - proto: WallWeaponCapacitorRechargerOmnidirectional
   entities:
-  - uid: 123
+  - uid: 713
     components:
     - type: Transform
-      pos: 9.5,14.5
       parent: 1
+      pos: 9.5,14.5
   - uid: 714
     components:
     - type: Transform
-      pos: 9.5,7.5
       parent: 1
+      pos: 9.5,7.5
 - proto: WarpPoint
   entities:
   - uid: 715
     components:
     - type: Transform
-      pos: 8.5,10.5
       parent: 1
+      pos: 8.5,10.5
 - proto: WeaponCapacitorRecharger
   entities:
   - uid: 716
     components:
     - type: Transform
-      pos: 5.5,14.5
       parent: 1
+      pos: 5.5,14.5
 - proto: WeaponLaserTurretL1Phalanx
   entities:
   - uid: 717
     components:
     - type: Transform
+      parent: 1
       rot: -1.5707963267948966 rad
       pos: 1.5,2.5
-      parent: 1
   - uid: 718
     components:
     - type: Transform
+      parent: 1
       rot: 1.5707963267948966 rad
       pos: 18.5,2.5
-      parent: 1
   - uid: 719
     components:
     - type: Transform
+      parent: 1
       rot: 1.5707963267948966 rad
       pos: 19.5,7.5
-      parent: 1
   - uid: 720
     components:
     - type: Transform
+      parent: 1
       rot: -1.5707963267948966 rad
       pos: 0.5,7.5
-      parent: 1
 - proto: WindoorSecurePlasma
   entities:
   - uid: 721
     components:
     - type: Transform
+      parent: 1
       rot: 4.71238898038469 rad
       pos: 15.5,11.5
-      parent: 1
   - uid: 722
     components:
     - type: Transform
+      parent: 1
       rot: 4.71238898038469 rad
       pos: 14.5,8.5
-      parent: 1
 ...


### PR DESCRIPTION
## About the PR
Changed the Shutters on The Erudite from Indestructible to Destructible

## Why / Balance
Grrr these shouldn't be on a ship

## Media
Guess which open version is indestructible
<img width="363" height="103" alt="image" src="https://github.com/user-attachments/assets/801fe596-0d56-49f9-b127-51aae42bf333" />

## Requirements
<!-- Confirm the following by placing an X in the brackets [X]: -->
- [x] I have read the guidelines and documentation relevant to this PR.
- [x] I have added media to this PR or it does not require an ingame showcase.
- [x] I can confirm this PR contains either no AI-generated content, or AI-generated content that meets our guidelines.
<!-- You should understand that not following the above may get your PR closed at maintainer’s discretion -->
<!-- When using AI, make sure you are already proficient in creating whatever content you are attempting to generate and that you already have experience contributing to SS14. This means using AI to enhance your preexisting workflow, not vibecoding. -->

## How to test
Buy Erudite, destroy Shutters with a hammer

## Breaking changes
Replaced indestructible shutters

**Changelog**
<!-- Add a Changelog entry to make players aware of new features or changes that could affect gameplay.
Make sure to read the guidelines and take this Changelog template out of the comment block in order for it to show up.
Changelog must have a :cl: symbol, so the bot recognizes the changes and adds them to the game's changelog.
Remove this symbol for non-player facing PRs.-->
:cl:
- tweak: Removed Erudite Indestructible shutters
