### PR TITLE
Switch publish.yml From Push-Triggered to a Daily 5PM Eastern Cron

### DIFF
--- a/.github/workflows/publish.yml
+++ b/.github/workflows/publish.yml
@@ -11,18 +11,19 @@ name: Publish
 on:
   workflow_dispatch:
   # Frontier: re-enabled autopublish bawk
-  # Triad: Frontier's autopublish is a daily cron; Monolith dropped the cron and kept
-  # only the comment, which is what we inherited. Push trigger instead: restart cadence
-  # is capped by round end either way, so publishing per merge costs no extra restarts
-  # and keeps the newest main staged for the next boundary.
-  push:
-    branches: [ main ]
-    # Triad: skip the changelog bot's Resources/Changelog-only commit. It lands ~30s after
-    # every merge, and because this group never cancels, the two publishes serialized: ~21m of
-    # packaging and two CDN versions per PR. Tradeoff accepted deliberately: Triad.yml is
-    # shipped content, so a PR's in-game changelog entry now ships with the NEXT merge's
-    # publish rather than its own.
-    paths-ignore: [ 'Resources/Changelog/**' ]
+  # Triad: Frontier's autopublish is a daily cron; Monolith dropped the cron and kept only
+  # the comment, which is what we inherited. We tried push-triggered publish next (one
+  # build per merge), but restart cadence is capped by round end regardless of how often
+  # we publish, so the extra builds bought nothing except runner time and a race: the
+  # changelog bot's trailing commit had to be path-ignored to stop it queuing a second
+  # publish, which meant a changelog entry with no code merge after it just sat unpublished
+  # until someone remembered to dispatch this manually. Back to a cron: one build a day
+  # picks up everything merged since the last tick, atomically, no race to reason about.
+  # Cron is UTC-only with no DST awareness, so two entries cover 5PM Eastern year-round;
+  # the "Skip if wrong DST cron entry" step below picks the correct one and no-ops the other.
+  schedule:
+    - cron: '0 21 * * *' # 5PM EDT (UTC-4), roughly second Sunday in March - first Sunday in November
+    - cron: '0 22 * * *' # 5PM EST (UTC-5), the rest of the year
 
 # Triad: no cancel-in-progress on purpose, though upstream sets it. Cancelling between
 # publish/start and publish/finish strands a half-open version on Robust.Cdn that 409s
@@ -40,9 +41,29 @@ jobs:
       should_publish: ${{ steps.check.outputs.should_publish }}
 
     steps:
+    - name: Skip if wrong DST cron entry
+      id: season
+      run: |
+        # Only the schedule entry matching today's actual Eastern offset should proceed;
+        # the other is a deliberate no-op. workflow_dispatch always proceeds.
+        if [ "${{ github.event_name }}" != "schedule" ]; then
+          echo "proceed=true" >> "$GITHUB_OUTPUT"
+          exit 0
+        fi
+        offset=$(TZ="America/New_York" date +%z)
+        if { [ "${{ github.event.schedule }}" = "0 21 * * *" ] && [ "$offset" = "-0400" ]; } \
+          || { [ "${{ github.event.schedule }}" = "0 22 * * *" ] && [ "$offset" = "-0500" ]; }; then
+          echo "proceed=true" >> "$GITHUB_OUTPUT"
+        else
+          echo "proceed=false" >> "$GITHUB_OUTPUT"
+          echo "::notice::Skipping: '${{ github.event.schedule }}' is the wrong DST cron entry for today (current Eastern offset $offset)."
+        fi
+      shell: bash
+
     # Keep this URL in step with ROBUST_CDN_URL/FORK_ID in Tools/publish_multi_request.py.
     - name: Check whether this commit is already published
       id: check
+      if: steps.season.outputs.proceed == 'true'
       run: |
         # Assign-then-override rather than `|| echo`: curl emits %{http_code} once per
         # retry attempt, so a fallback inside the substitution concatenates onto it.


### PR DESCRIPTION
## About the PR
Switches `publish.yml` from push-triggered to a daily cron at 5PM Eastern. Two schedule entries (21:00 UTC / 22:00 UTC) cover the DST switch, with a guard step that skips whichever one doesn't match today's actual Eastern offset. `workflow_dispatch` stays for anything that needs to ship same-day.

## Why / Balance
Push-triggered publish only bought build-per-merge freshness that restart cadence never used (restarts are gated on round end regardless of publish frequency). Its `paths-ignore` hack on the changelog bot's trailing commit meant a changelog entry with no code merge after it just sat unpublished until someone manually dispatched this workflow — which is exactly what happened today with #497 and #499. One daily build removes the race entirely: it picks up whatever's on `main` at cron time, atomically.

## Media
N/A — CI-only change, no in-game surface.

## How to test
Can't exercise the `schedule` trigger locally. Verified the season-guard logic by hand (workflow_dispatch always proceeds; a `schedule` event only proceeds if `github.event.schedule` matches the cron entry whose offset matches `TZ=America/New_York date +%z` at run time) and confirmed the existing preflight → build gating still short-circuits correctly when the guard step is skipped. Worth watching the first real cron fire.

## Breaking changes
None.
