### PR TITLE
Restrict Trade Terminal Gas Canisters to Air/Nitrogen/Water Vapor

### DIFF
--- a/Resources/Prototypes/Catalog/Cargo/cargo_atmospherics.yml
+++ b/Resources/Prototypes/Catalog/Cargo/cargo_atmospherics.yml
@@ -8,25 +8,27 @@
   category: cargoproduct-category-name-atmospherics
   group: market
 
-- type: cargoProduct
-  id: AtmosphericsOxygen
-  icon:
-    sprite: _NF/Structures/Storage/canister.rsi # Frontier: _NF
-    state: oxygen # Frontier blue<oxygen
-  product: OxygenCanister
-  cost: 1100
-  category: cargoproduct-category-name-atmospherics
-  group: market
+# Triad: removed - trade terminal canister purge, only water vapor/air/nitrogen kept buyable
+#- type: cargoProduct
+#  id: AtmosphericsOxygen
+#  icon:
+#    sprite: _NF/Structures/Storage/canister.rsi # Frontier: _NF
+#    state: oxygen # Frontier blue<oxygen
+#  product: OxygenCanister
+#  cost: 1100
+#  category: cargoproduct-category-name-atmospherics
+#  group: market
 
-- type: cargoProduct
-  id: AtmosphericsLiquidOxygen
-  icon:
-    sprite: _NF/Structures/Storage/canister.rsi # Frontier: _NF
-    state: oxygen_liquid # Frontier blue<oxygen_liquid
-  product: LiquidOxygenCanister
-  cost: 15000 # Mono - re-enable liquid gasses
-  category: cargoproduct-category-name-atmospherics
-  group: market
+# Triad: removed - trade terminal canister purge, only water vapor/air/nitrogen kept buyable
+#- type: cargoProduct
+#  id: AtmosphericsLiquidOxygen
+#  icon:
+#    sprite: _NF/Structures/Storage/canister.rsi # Frontier: _NF
+#    state: oxygen_liquid # Frontier blue<oxygen_liquid
+#  product: LiquidOxygenCanister
+#  cost: 15000 # Mono - re-enable liquid gasses
+#  category: cargoproduct-category-name-atmospherics
+#  group: market
 
 - type: cargoProduct
   id: AtmosphericsNitrogen
@@ -38,45 +40,49 @@
   category: cargoproduct-category-name-atmospherics
   group: market
 
-- type: cargoProduct
-  id: AtmosphericsLiquidNitrogen
-  icon:
-    sprite: _NF/Structures/Storage/canister.rsi # Frontier: _NF
-    state: nitrogen_liquid # Frontier red<nitrogen_liquid
-  product: LiquidNitrogenCanister
-  cost: 12500 # Mono - re-enable liquid gasses
-  category: cargoproduct-category-name-atmospherics
-  group: market
+# Triad: removed - trade terminal canister purge, only water vapor/air/nitrogen kept buyable
+#- type: cargoProduct
+#  id: AtmosphericsLiquidNitrogen
+#  icon:
+#    sprite: _NF/Structures/Storage/canister.rsi # Frontier: _NF
+#    state: nitrogen_liquid # Frontier red<nitrogen_liquid
+#  product: LiquidNitrogenCanister
+#  cost: 12500 # Mono - re-enable liquid gasses
+#  category: cargoproduct-category-name-atmospherics
+#  group: market
 
-- type: cargoProduct
-  id: AtmosphericsCarbonDioxide
-  icon:
-    sprite: _NF/Structures/Storage/canister.rsi # Frontier: _NF
-    state: carbon # Frontier black<carbon
-  product: CarbonDioxideCanister
-  cost: 8000
-  category: cargoproduct-category-name-atmospherics
-  group: market
+# Triad: removed - trade terminal canister purge, only water vapor/air/nitrogen kept buyable
+#- type: cargoProduct
+#  id: AtmosphericsCarbonDioxide
+#  icon:
+#    sprite: _NF/Structures/Storage/canister.rsi # Frontier: _NF
+#    state: carbon # Frontier black<carbon
+#  product: CarbonDioxideCanister
+#  cost: 8000
+#  category: cargoproduct-category-name-atmospherics
+#  group: market
 
-- type: cargoProduct
-  id: AtmosphericsLiquidCarbonDioxide
-  icon:
-    sprite: _NF/Structures/Storage/canister.rsi # Frontier: _NF
-    state: carbon_liquid # Frontier black<carbon_liquid
-  product: LiquidCarbonDioxideCanister
-  cost: 16000 # Mono - re-enable liquid gasses
-  category: cargoproduct-category-name-atmospherics
-  group: market
+# Triad: removed - trade terminal canister purge, only water vapor/air/nitrogen kept buyable
+#- type: cargoProduct
+#  id: AtmosphericsLiquidCarbonDioxide
+#  icon:
+#    sprite: _NF/Structures/Storage/canister.rsi # Frontier: _NF
+#    state: carbon_liquid # Frontier black<carbon_liquid
+#  product: LiquidCarbonDioxideCanister
+#  cost: 16000 # Mono - re-enable liquid gasses
+#  category: cargoproduct-category-name-atmospherics
+#  group: market
 
-- type: cargoProduct
-  id: AtmosphericsStorage
-  icon:
-    sprite: _NF/Structures/Storage/canister.rsi # Frontier: _NF
-    state: storage # Frontier yellow<storage
-  product: StorageCanister
-  cost: 1010 # No gases in it so it's cheaper
-  category: cargoproduct-category-name-atmospherics
-  group: market
+# Triad: removed - trade terminal canister purge, only water vapor/air/nitrogen kept buyable
+#- type: cargoProduct
+#  id: AtmosphericsStorage
+#  icon:
+#    sprite: _NF/Structures/Storage/canister.rsi # Frontier: _NF
+#    state: storage # Frontier yellow<storage
+#  product: StorageCanister
+#  cost: 1010 # No gases in it so it's cheaper
+#  category: cargoproduct-category-name-atmospherics
+#  group: market
 
 # Triad changes - Feroxi use water vapor. Block uncommented.
 - type: cargoProduct
@@ -90,15 +96,16 @@
   group: market
 # End Triad
 
-- type: cargoProduct
-  id: AtmosphericsPlasma # Mono - Make plasma canisters buyable again
-  icon:
-    sprite: _NF/Structures/Storage/canister.rsi # Frontier: _NF
-    state: plasma # Frontier orange<plasma
-  product: PlasmaCanister
-  cost: 7000 # Mono - Gas sell prices
-  category: cargoproduct-category-name-atmospherics
-  group: market
+# Triad: removed - trade terminal canister purge, only water vapor/air/nitrogen kept buyable
+#- type: cargoProduct
+#  id: AtmosphericsPlasma # Mono - Make plasma canisters buyable again
+#  icon:
+#    sprite: _NF/Structures/Storage/canister.rsi # Frontier: _NF
+#    state: plasma # Frontier orange<plasma
+#  product: PlasmaCanister
+#  cost: 7000 # Mono - Gas sell prices
+#  category: cargoproduct-category-name-atmospherics
+#  group: market
 
 #- type: cargoProduct
 #  name: "tritium canister"

--- a/Resources/Prototypes/_Mono/Catalogs/Cargo/cargo_atmospherics.yml
+++ b/Resources/Prototypes/_Mono/Catalogs/Cargo/cargo_atmospherics.yml
@@ -1,12 +1,13 @@
-- type: cargoProduct
-  id: AtmosphericsBZ
-  icon:
-    sprite: _NF/Structures/Storage/canister.rsi # Frontier: _NF
-    state: mono_bz
-  product: BZCanister
-  cost: 75000 # NO MORE BZ PROFITS
-  category: cargoproduct-category-name-atmospherics
-  group: market
+# Triad: removed - trade terminal canister purge, only water vapor/air/nitrogen kept buyable
+#- type: cargoProduct
+#  id: AtmosphericsBZ
+#  icon:
+#    sprite: _NF/Structures/Storage/canister.rsi # Frontier: _NF
+#    state: mono_bz
+#  product: BZCanister
+#  cost: 75000 # NO MORE BZ PROFITS
+#  category: cargoproduct-category-name-atmospherics
+#  group: market
 
 - type: cargoProduct
   id: AtmosphericsTEGCrate


### PR DESCRIPTION
## About the PR
Cuts the trade terminal's atmospherics listing down to three canisters: air, nitrogen, water vapor. Everything else that was purchasable there — oxygen, both liquefied variants, carbon dioxide, storage, plasma, BZ — is gone from the market. The entries are commented out with `# Triad:` markers rather than deleted, so a future Mono/upstream merge surfaces the conflict instead of silently reintroducing them.

## Why / Balance
Nine buyable canister types on one console was more surface area than we want. Air, nitrogen, and water vapor cover what ships actually need; the rest were either redundant with those three or too strong to leave sitting behind a credit sink (plasma, BZ). No changes to canisters themselves, filling, or gas mechanics — this is a market-availability cut only.

## Media
<img width="952" height="361" alt="image" src="https://github.com/user-attachments/assets/a4291112-afbb-4719-9753-7df1c7e78a0a" />

You know what you did.


## Requirements
- [x] I have read the guidelines and documentation relevant to this PR.
- [x] I have added media to this PR or it does not require an ingame showcase.
- [x] I can confirm this PR contains either no AI-generated content, or AI-generated content that meets our guidelines.

## How to test
Open a shipyard/cargo trade console, check the Atmospherics category. Only Air, Nitrogen, and Water Vapor canisters list; the other eight are gone.

## Breaking changes
None for players. The removed `cargoProduct` ids (`AtmosphericsOxygen`, `AtmosphericsLiquidOxygen`, `AtmosphericsLiquidNitrogen`, `AtmosphericsCarbonDioxide`, `AtmosphericsLiquidCarbonDioxide`, `AtmosphericsStorage`, `AtmosphericsPlasma`, `AtmosphericsBZ`) no longer resolve, so anything referencing them by id elsewhere would break — but nothing in the tree does.

**Changelog**
:cl:
- remove: Removed oxygen, liquid oxygen, liquid nitrogen, carbon dioxide, liquid carbon dioxide, storage, plasma, and BZ canisters from the trade terminal. Air, nitrogen, and water vapor canisters remain purchasable.
