### PR TITLE
Domesticate Former Faction Gear Pass 1 : Also Upgrade Blood-Red Night Vision.

### DIFF
--- a/Resources/Locale/en-US/store/uplink-catalog.ftl
+++ b/Resources/Locale/en-US/store/uplink-catalog.ftl
@@ -340,7 +340,7 @@ uplink-hardsuit-syndie-name = Syndicate Hardsuit
 uplink-hardsuit-syndie-desc = The Syndicate's well known armored blood red hardsuit, capable of space walks and taking bullets.
 
 uplink-hardsuit-syndie-black-name = Midnight Operative Special Tacticool Suit
-uplink-hardsuit-syndie-black-desc = Following a crippling strike on gorlex paint factories, their supply of signature blood-red paint ran dry. This was a last-ditch rebrand attempt. Identical in stats to the blood-red.
+uplink-hardsuit-syndie-black-desc = Following a crippling strike on gorlex paint factories, their supply of signature blood-red paint ran dry. This was a last-ditch rebrand attempt. Identical armor-wise to the blood-red.
 
 uplink-syndie-raid-name = Syndicate Raid Suit
 uplink-syndie-raid-desc = A very durable and reasonably flexible suit of blood-red armor, reinforced against all common forms of damage but not capable of space walks. Comes with a sick helmet.

--- a/Resources/Locale/en-US/store/uplink-catalog.ftl
+++ b/Resources/Locale/en-US/store/uplink-catalog.ftl
@@ -340,7 +340,7 @@ uplink-hardsuit-syndie-name = Syndicate Hardsuit
 uplink-hardsuit-syndie-desc = The Syndicate's well known armored blood red hardsuit, capable of space walks and taking bullets.
 
 uplink-hardsuit-syndie-black-name = Midnight Operative Special Tacticool Suit
-uplink-hardsuit-syndie-black-desc = Following a crippling strike on gorlex paint factories, their supply of signature blood-red paint ran dry. This was a last-ditch rebrand attempt. Identical in stats to the blood-red.
+uplink-hardsuit-syndie-black-desc = Following a crippling strike on GorLex paint factories, their supply of signature blood-red ran dry. This was a last-ditch rebrand attempt.
 
 uplink-syndie-raid-name = Syndicate Raid Suit
 uplink-syndie-raid-desc = A very durable and reasonably flexible suit of blood-red armor, reinforced against all common forms of damage but not capable of space walks. Comes with a sick helmet.

--- a/Resources/Locale/en-US/store/uplink-catalog.ftl
+++ b/Resources/Locale/en-US/store/uplink-catalog.ftl
@@ -339,6 +339,9 @@ uplink-hardsuit-carp-desc = Looks like an ordinary carp suit, except fully space
 uplink-hardsuit-syndie-name = Syndicate Hardsuit
 uplink-hardsuit-syndie-desc = The Syndicate's well known armored blood red hardsuit, capable of space walks and taking bullets.
 
+uplink-hardsuit-syndie-black-name = Midnight Operative Special Tacticool Suit
+uplink-hardsuit-syndie-black-desc = Following a crippling strike on gorlex paint factories, their supply of signature blood-red paint ran dry. This was a last-ditch rebrand attempt. Identical in stats to the blood-red.
+
 uplink-syndie-raid-name = Syndicate Raid Suit
 uplink-syndie-raid-desc = A very durable and reasonably flexible suit of blood-red armor, reinforced against all common forms of damage but not capable of space walks. Comes with a sick helmet.
 

--- a/Resources/Locale/en-US/store/uplink-catalog.ftl
+++ b/Resources/Locale/en-US/store/uplink-catalog.ftl
@@ -340,7 +340,7 @@ uplink-hardsuit-syndie-name = Syndicate Hardsuit
 uplink-hardsuit-syndie-desc = The Syndicate's well known armored blood red hardsuit, capable of space walks and taking bullets.
 
 uplink-hardsuit-syndie-black-name = Midnight Operative Special Tacticool Suit
-uplink-hardsuit-syndie-black-desc = Following a crippling strike on GorLex paint factories, their supply of signature blood-red ran dry. This was a last-ditch rebrand attempt.
+uplink-hardsuit-syndie-black-desc = Following a crippling strike on Gorlex paint factories, their supply of signature blood-red ran dry. This was a last-ditch rebrand attempt.
 
 uplink-syndie-raid-name = Syndicate Raid Suit
 uplink-syndie-raid-desc = A very durable and reasonably flexible suit of blood-red armor, reinforced against all common forms of damage but not capable of space walks. Comes with a sick helmet.

--- a/Resources/Prototypes/Catalog/Fills/Backpacks/duffelbag.yml
+++ b/Resources/Prototypes/Catalog/Fills/Backpacks/duffelbag.yml
@@ -350,3 +350,19 @@
         amount: 2
       - id: SyndieTrickyBomb
         amount: 2
+
+# Triad : Domesticated PDV gear
+
+- type: entity
+  parent: ClothingBackpackDuffelSyndicateBundle
+  id: ClothingBackpackDuffelClothingOuterHardsuitAshenBundle
+  name: syndicate hardsuit bundle
+  description: "Contains the Syndicate's signature blood red hardsuit. Uh... wait.. where's the red?"
+  components:
+  - type: StorageFill
+    contents:
+    - id: ClothingOuterHardsuitAshen
+    - id: ClothingMaskGasSyndicate
+    - id: ClothingHandsGlovesCombat
+    - id: DoubleEmergencyOxygenTankFilled
+    - id: DoubleEmergencyNitrogenTankFilled

--- a/Resources/Prototypes/Catalog/uplink_catalog.yml
+++ b/Resources/Prototypes/Catalog/uplink_catalog.yml
@@ -1624,6 +1624,22 @@
   categories:
   - UplinkWearables
 
+  # Triad: Domesticated PDV equipment.
+
+- type: listing
+  id: UplinkHardsuitSyndieBlack
+  name: uplink-hardsuit-syndie-black-name
+  description: uplink-hardsuit-syndie-black-desc
+  icon: { sprite: _Mono/Clothing/OuterClothing/Hardsuits/syndicate.rsi, state: icon }
+  productEntity: ClothingBackpackDuffelClothingOuterHardsuitAshenBundle
+  discountCategory: veryRareDiscounts
+  discountDownTo:
+    Telecrystal: 30 # Mono
+  cost:
+    Telecrystal: 50 # Mono
+  categories:
+  - UplinkWearables
+
 - type: listing
   id: UplinkClothingOuterArmorRaid
   name: uplink-syndie-raid-name

--- a/Resources/Prototypes/Entities/Clothing/Head/hardsuit-helmets.yml
+++ b/Resources/Prototypes/Entities/Clothing/Head/hardsuit-helmets.yml
@@ -466,6 +466,15 @@
         Slash: 0.9
         Piercing: 0.9
         Heat: 0.9
+  - type: NightVision # Gen 2 monotubee # Triad: Improve blood-red night vision.
+    relayOverlay: true
+    goggleEffect: true
+    action: ActionToggleNightVision
+    viewCircleRadius: 400
+    viewCircleCount: 2
+    viewCircleSpacing: 280
+    phosphorColor: "#00FF00"
+    lightingColor: "#FFFFFF32"
 
 #Blood-red Medic Hardsuit
 - type: entity
@@ -491,6 +500,15 @@
         Slash: 0.9
         Piercing: 0.9
         Heat: 0.9
+  - type: NightVision # Gen 2 monotubee # Triad: Improve blood-red night vision.
+    relayOverlay: true
+    goggleEffect: true
+    action: ActionToggleNightVision
+    viewCircleRadius: 400
+    viewCircleCount: 2
+    viewCircleSpacing: 280
+    phosphorColor: "#00FF00"
+    lightingColor: "#FFFFFF32"
 
 #Syndicate Elite Hardsuit
 - type: entity
@@ -521,6 +539,15 @@
         Slash: 0.9
         Piercing: 0.9
         Heat: 0.9
+  - type: NightVision # Gen 2 monotubee # Triad: Improve blood-red night vision.
+    relayOverlay: true
+    goggleEffect: true
+    action: ActionToggleNightVision
+    viewCircleRadius: 400
+    viewCircleCount: 2
+    viewCircleSpacing: 280
+    phosphorColor: "#00FF00"
+    lightingColor: "#FFFFFF32"
 
 #Syndicate Commander Hardsuit
 - type: entity
@@ -546,6 +573,15 @@
         Slash: 0.9
         Piercing: 0.9
         Heat: 0.9
+  - type: NightVision # Gen 2 monotubee # Triad: Improve blood-red night vision.
+    relayOverlay: true
+    goggleEffect: true
+    action: ActionToggleNightVision
+    viewCircleRadius: 400
+    viewCircleCount: 2
+    viewCircleSpacing: 280
+    phosphorColor: "#00FF00"
+    lightingColor: "#FFFFFF32"
 
 #Cybersun Juggernaut Hardsuit
 - type: entity
@@ -568,6 +604,15 @@
         Slash: 0.9
         Piercing: 0.9
         Heat: 0.9
+  - type: NightVision # Gen 2 monotubee # Triad: Improve blood-red night vision.
+    relayOverlay: true
+    goggleEffect: true
+    action: ActionToggleNightVision
+    viewCircleRadius: 400
+    viewCircleCount: 2
+    viewCircleSpacing: 280
+    phosphorColor: "#00FF00"
+    lightingColor: "#FFFFFF32"
 
 #Wizard Hardsuit
 - type: entity

--- a/Resources/Prototypes/_Mono/Entities/Clothing/Head/Hardsuits/phaethon_dynasty.yml
+++ b/Resources/Prototypes/_Mono/Entities/Clothing/Head/Hardsuits/phaethon_dynasty.yml
@@ -1,8 +1,8 @@
 - type: entity
-  parent: [ClothingHeadHelmetHardsuitSyndie, ShowSecurityIcons]
+  parent: [ClothingHeadHelmetHardsuitSyndie]
   id: ClothingHeadHelmetHardsuitAshen
-  name: PDV CV-32 combat hardsuit helmet
-  description: A combat hardsuit helmet designed by the Phaethon Dynasty. A basic monotube night vision system is installed.
+  name: midnight operative special tacticool helmet
+  description: Man, it doesn't even have the signature eye placement.
   categories: [ HideSpawnMenu ]
   components:
   - type: Sprite

--- a/Resources/Prototypes/_Mono/Entities/Clothing/Head/Hardsuits/scaf_pirate.yml
+++ b/Resources/Prototypes/_Mono/Entities/Clothing/Head/Hardsuits/scaf_pirate.yml
@@ -1,8 +1,8 @@
 - type: entity
   parent: [ClothingHeadHardsuitBase, ClothingHeadSuitWithLightBase]
   id: ClothingHeadHelmetHardsuitPirateScaf
-  name: Painted SCAF hardsuit helmet
-  description: A SCAF suit painted in a tan color scheme. Identical to a conventional SCAF suit.
+  name: SCRUFF hardsuit helmet
+  description: Easier on the neck than a standard SCAF suit, but less protective.
   categories: [ HideSpawnMenu ]
   components:
   - type: BreathMask
@@ -10,7 +10,7 @@
     sprite: _Mono/Clothing/Head/Hardsuits/scaf_pirate.rsi
   - type: Clothing
     sprite: _Mono/Clothing/Head/Hardsuits/scaf_pirate.rsi
-  # Triad : thermal vision removed, pairity with SCAF
+  # Triad : thermal vision removed, no longer faction-locked
   - type: PointLight
     radius: 8 # Triad : pairity with SCAF
     color: green
@@ -19,10 +19,11 @@
     lowPressureMultiplier: 1000
   - type: Armor
     modifiers:
-      coefficients: # Triad : pairity with SCAF
-        Blunt: 0.9
-        Slash: 0.9
-        Piercing: 0.8
+      coefficients:
+        Blunt: 0.95
+        Slash: 0.95
+        Piercing: 0.95
+        Heat: 0.95
   - type: HideLayerClothing
     slots:
     - Hair

--- a/Resources/Prototypes/_Mono/Entities/Clothing/Head/Hardsuits/scaf_pirate.yml
+++ b/Resources/Prototypes/_Mono/Entities/Clothing/Head/Hardsuits/scaf_pirate.yml
@@ -1,32 +1,28 @@
 - type: entity
-  parent: [ClothingHeadHardsuitBase, BaseFactionGearPDVT2, ShowSecurityIcons, ClothingHeadSuitWithLightBase]
+  parent: [ClothingHeadHardsuitBase, ClothingHeadSuitWithLightBase]
   id: ClothingHeadHelmetHardsuitPirateScaf
-  name: PDV SCAF hardsuit helmet
-  description: An old SCAF suit painted in an PDV tan color scheme. Has been outfitted with a thermal pulse scanner.
+  name: Painted SCAF hardsuit helmet
+  description: A SCAF suit painted in a tan color scheme. Identical to a conventional SCAF suit.
   categories: [ HideSpawnMenu ]
   components:
+  - type: BreathMask
   - type: Sprite
     sprite: _Mono/Clothing/Head/Hardsuits/scaf_pirate.rsi
   - type: Clothing
     sprite: _Mono/Clothing/Head/Hardsuits/scaf_pirate.rsi
-  - type: ThermalVision
-    flashDurationMultiplier: 2
-    pulseTime: 3
-    isEquipment: true
-    toggleAction: PulseThermalVision
+  # Triad : thermal vision removed, pairity with SCAF
   - type: PointLight
-    radius: 5
+    radius: 8 # Triad : pairity with SCAF
     color: green
   - type: PressureProtection
-    highPressureMultiplier: 0.08
+    highPressureMultiplier: 0.525 # Triad : pairity with SCAF
     lowPressureMultiplier: 1000
   - type: Armor
     modifiers:
-      coefficients:
-        Blunt: 0.95
-        Slash: 0.95
-        Piercing: 0.95
-        Heat: 0.95
+      coefficients: # Triad : pairity with SCAF
+        Blunt: 0.9
+        Slash: 0.9
+        Piercing: 0.8
   - type: HideLayerClothing
     slots:
     - Hair

--- a/Resources/Prototypes/_Mono/Entities/Clothing/OuterClothing/Hardsuits/phaethon_dynasty.yml
+++ b/Resources/Prototypes/_Mono/Entities/Clothing/OuterClothing/Hardsuits/phaethon_dynasty.yml
@@ -46,10 +46,10 @@
     - RogueHardsuit
 
 - type: entity
-  parent: [ ClothingOuterHardsuitSyndie, BaseFactionGearPDVT2 ]
+  parent: [ ClothingOuterHardsuitSyndie] # Triad - domesticated PDV
   id: ClothingOuterHardsuitAshen
-  name: PDV CV-32 combat hardsuit
-  description: A combat hardsuit designed by the Phaethon Dynasty. A heavier but still general-purpose hardsuit, effective but not stellar against most damage types.
+  name: midnight operative special tacticool suit
+  description: Following a crippling strike on gorlex paint factories, their supply of signature blood-red paint ran dry. This was a last-ditch rebrand attempt. Identical in stats to the blood-red.
   components:
   - type: Sprite
     sprite: _Mono/Clothing/OuterClothing/Hardsuits/syndicate.rsi

--- a/Resources/Prototypes/_Mono/Entities/Clothing/OuterClothing/Hardsuits/phaethon_dynasty.yml
+++ b/Resources/Prototypes/_Mono/Entities/Clothing/OuterClothing/Hardsuits/phaethon_dynasty.yml
@@ -23,9 +23,10 @@
         Piercing: 0.55
         Heat: 0.7
         Radiation: 0.5
-        Caustic: 0.9
+        Caustic: 0.8 # Triad
+        Shock: 0.9 # Triad
   - type: StaminaDamageResistance # Mono - Stamres
-    coefficient: 0.3
+    coefficient: 0.45 # Triad
   - type: ClothingSpeedModifier
     walkModifier: 0.95
     sprintModifier: 0.95

--- a/Resources/Prototypes/_Mono/Entities/Clothing/OuterClothing/Hardsuits/phaethon_dynasty.yml
+++ b/Resources/Prototypes/_Mono/Entities/Clothing/OuterClothing/Hardsuits/phaethon_dynasty.yml
@@ -1,8 +1,8 @@
 - type: entity
   parent: [ ClothingOuterHardsuitBase] # Triad - removed PDV ties
   id: ClothingOuterHardsuitPirateScaf
-  name: Painted SCAF hardsuit
-  description: A SCAF suit painted in a tan color scheme. Identical to a conventional SCAF suit.
+  name: SCRUFF hardsuit
+  description: A variant of the classic SCAF suit designed for arid climates. Lighter and more comfortable, but less protective.
   components:
   - type: Sprite
     sprite: _Mono/Clothing/OuterClothing/Hardsuits/scaf_pirate.rsi
@@ -17,18 +17,18 @@
     damageCoefficient: 0.35
   - type: Armor
     modifiers:
-      coefficients: # Triad - values made to match default SCAF suit
-        Blunt: 0.5
-        Slash: 0.5
-        Piercing: 0.45
-        Heat: 0.55
+      coefficients:
+        Blunt: 0.65
+        Slash: 0.65
+        Piercing: 0.55
+        Heat: 0.7
         Radiation: 0.5
-        Caustic: 0.65
+        Caustic: 0.9
   - type: StaminaDamageResistance # Mono - Stamres
-    coefficient: 0.45
+    coefficient: 0.3
   - type: ClothingSpeedModifier
-    walkModifier: 0.825
-    sprintModifier: 0.825
+    walkModifier: 0.95
+    sprintModifier: 0.95
   - type: HeldSpeedModifier
   - type: ToggleableClothing # Goobstation - Modsuits change - Mono - this is a solution for helmet attachment/cover to not fit on hardsuits
     requiredSlot: outerclothing
@@ -49,7 +49,7 @@
   parent: [ ClothingOuterHardsuitSyndie] # Triad - domesticated PDV
   id: ClothingOuterHardsuitAshen
   name: midnight operative special tacticool suit
-  description: Following a crippling strike on gorlex paint factories, their supply of signature blood-red paint ran dry. This was a last-ditch rebrand attempt. Identical in stats to the blood-red.
+  description: Following a crippling strike on GorLex paint factories, their supply of signature blood-red ran dry. This was a last-ditch rebrand attempt.
   components:
   - type: Sprite
     sprite: _Mono/Clothing/OuterClothing/Hardsuits/syndicate.rsi

--- a/Resources/Prototypes/_Mono/Entities/Clothing/OuterClothing/Hardsuits/phaethon_dynasty.yml
+++ b/Resources/Prototypes/_Mono/Entities/Clothing/OuterClothing/Hardsuits/phaethon_dynasty.yml
@@ -49,7 +49,7 @@
   parent: [ ClothingOuterHardsuitSyndie] # Triad - domesticated PDV
   id: ClothingOuterHardsuitAshen
   name: midnight operative special tacticool suit
-  description: Following a crippling strike on GorLex paint factories, their supply of signature blood-red ran dry. This was a last-ditch rebrand attempt.
+  description: Following a crippling strike on Gorlex paint factories, their supply of signature blood-red ran dry. This was a last-ditch rebrand attempt.
   components:
   - type: Sprite
     sprite: _Mono/Clothing/OuterClothing/Hardsuits/syndicate.rsi

--- a/Resources/Prototypes/_Mono/Entities/Clothing/OuterClothing/Hardsuits/phaethon_dynasty.yml
+++ b/Resources/Prototypes/_Mono/Entities/Clothing/OuterClothing/Hardsuits/phaethon_dynasty.yml
@@ -1,8 +1,8 @@
 - type: entity
-  parent: [ ClothingOuterHardsuitBase, BaseFactionGearPDVT2 ]
+  parent: [ ClothingOuterHardsuitBase] # Triad - removed PDV ties
   id: ClothingOuterHardsuitPirateScaf
-  name: PDV SCAF hardsuit
-  description: An old SCAF suit painted in an PDV tan color scheme. The armor feels degraded, but lighter.
+  name: Painted SCAF hardsuit
+  description: A SCAF suit painted in a tan color scheme. Identical to a conventional SCAF suit.
   components:
   - type: Sprite
     sprite: _Mono/Clothing/OuterClothing/Hardsuits/scaf_pirate.rsi
@@ -14,21 +14,21 @@
     highPressureMultiplier: 0.05
     lowPressureMultiplier: 1000
   - type: ExplosionResistance
-    damageCoefficient: 0.45
+    damageCoefficient: 0.35
   - type: Armor
     modifiers:
-      coefficients:
-        Blunt: 0.65
-        Slash: 0.65
-        Piercing: 0.55
-        Heat: 0.7
+      coefficients: # Triad - values made to match default SCAF suit
+        Blunt: 0.5
+        Slash: 0.5
+        Piercing: 0.45
+        Heat: 0.55
         Radiation: 0.5
-        Caustic: 0.9
+        Caustic: 0.65
   - type: StaminaDamageResistance # Mono - Stamres
-    coefficient: 0.3
+    coefficient: 0.45
   - type: ClothingSpeedModifier
-    walkModifier: 0.95
-    sprintModifier: 0.95
+    walkModifier: 0.825
+    sprintModifier: 0.825
   - type: HeldSpeedModifier
   - type: ToggleableClothing # Goobstation - Modsuits change - Mono - this is a solution for helmet attachment/cover to not fit on hardsuits
     requiredSlot: outerclothing

--- a/Resources/Prototypes/_NF/Entities/Markers/Spawners/syndicate.yml
+++ b/Resources/Prototypes/_NF/Entities/Markers/Spawners/syndicate.yml
@@ -89,6 +89,7 @@
       rarePrototypes:
         - Telecrystal25 # Triad
         - ClothingBackpackDuffelSyndicateHardsuitBundle
+        - ClothingBackpackDuffelClothingOuterHardsuitAshenBundle
         - ClothingBackpackDuffelSyndicateMedicHardsuitBundle
         - PinpointerSyndicatePOI
         - PinpointerSyndicatePOI

--- a/Resources/Prototypes/_NF/Entities/Objects/Tools/blueprints/blueprints_armory.yml
+++ b/Resources/Prototypes/_NF/Entities/Objects/Tools/blueprints/blueprints_armory.yml
@@ -27,3 +27,4 @@
   - type: Blueprint
     providedRecipes:
     - ClothingOuterHardsuitScaf
+    - ClothingOuterHardsuitPirateScaf

--- a/Resources/Prototypes/_NF/Recipes/Lathes/Packs/Deprecated/mercenary_techfab.yml
+++ b/Resources/Prototypes/_NF/Recipes/Lathes/Packs/Deprecated/mercenary_techfab.yml
@@ -143,6 +143,7 @@
   - ClothingOuterHardsuitMercenary
   - ClothingOuterHardsuitPrivateSecurity
   - ClothingOuterHardsuitScaf
+  - ClothingOuterHardsuitPirateScaf # Triad : PDV scafsuit now normal tech
   - ClothingModsuitMercenaryPowerCell # Mono edit
   - ClothingShoesBootsMagSecurity
   - ClothingShoesBootsMagMercenary

--- a/Resources/Prototypes/_NF/Recipes/Lathes/clothing-eva.yml
+++ b/Resources/Prototypes/_NF/Recipes/Lathes/clothing-eva.yml
@@ -331,6 +331,13 @@
   parent: NFBaseHardSuitArmoredRecipe
   result: ClothingOuterHardsuitScaf
 
+# Triad : Make pdv scafsuit generic and accessible
+
+- type: latheRecipe
+  id: ClothingOuterHardsuitPirateScaf
+  parent: NFBaseHardSuitArmoredRecipe
+  result: ClothingOuterHardsuitPirateScaf
+
 - type: latheRecipe
   id: ClothingOuterHardsuitEngineeringWhite
   parent: NFBaseHardSuitArmoredRecipe

--- a/Resources/Prototypes/_NF/Research/arsenal.yml
+++ b/Resources/Prototypes/_NF/Research/arsenal.yml
@@ -120,6 +120,7 @@
   recipeUnlocks:
   - ClothingModsuitMercenaryPowerCell # Mono edit
   - ClothingOuterHardsuitScaf
+  - ClothingOuterHardsuitPirateScaf
   - BlueprintClothingOuterHardsuitScaf
   technologyPrerequisites:
   - HardsuitsArmored


### PR DESCRIPTION
## About the PR
<!-- What did you change? -->
<!-- If this is a code change, summarize at high level how your new code works. This makes it easier to review. -->

I am YAML warrior 1293012 billion lines changed

Changed descriptions, stats, and obtain-ability of PDV SCAF and PDV CV-32 hardsuits.

PDV SCAF has been renamed to the Painted SCAF hardsuit. Its stats were changed to match the regular SCAF suit.
It is no longer contraband.
It is researchable at the same node as SCAF suits. 
The SCAF suit blueprint also allows you to make painted SCAF suits.
The thermal goggles were removed.
Sec hud removed.
Loot pools NOT updated (I didn't think of it and besides its not a huge deal since you can literally get a blueprint to craft it.)

PDV CV-32 has been renamed to the "Midnight Operative Special Tacticool Suit" (MOSTS) 
It is not researchable
its stats are identical to a regular nukie suit
it is obtainable in uplink, surplus crates, contravend, and syndicate dead drops, (i THINK that's all the places the original can spawn, with the exception of suits that are explicitly mapped in.)
Sec hud removed.
Thermals removed.

Also, I noticed that the PDV CV32, despite being a clone of the bloodred (originally categorized as ashen republic elite suit or some shit idr), had binocular night vision. Apparenly, the nukie suits don't have this, and instead have the regular monocular shitscope. I changed it so that all syndicate suits, including juggernaut, stealth, and elite, have binocular night vision. To me this makes sense, given the syndie suits were designed for use in combat within an enclosed space. 

## Why / Balance
<!-- Discuss how this would affect game balance or explain why it was changed. Link any relevant discussions or issues. -->

Balance should be identical to existing SCAF suit and nukie suit. This is solely to improve drip. Hardsuits are the most important fashion element on a fork like this, given people wear them like 90% of the time. We have a wealth of currently unused assets designed for old factions that are not compatible with the style of the new factions. Some assets, e.g. PDV mechs, are feasibly altered to fit the TIC's aesthetic, but the hardsuits are not.  

## Media
<!-- Attach media if the PR makes ingame changes (clothing, items, features, etc). 
Small fixes/refactors are exempt. Media may be used in SS14 progress reports with credit. -->

<img width="454" height="351" alt="image" src="https://github.com/user-attachments/assets/b57c28c9-b2c7-4aaa-9c47-0bd94b1e3920" />

Painted SCAF Suit

<img width="414" height="429" alt="image" src="https://github.com/user-attachments/assets/5ce80cb8-bc2b-453a-864a-7ae6c16c7065" />

Painted SCAF suit stats

<img width="496" height="709" alt="image" src="https://github.com/user-attachments/assets/8b56f132-932a-44bf-ac0c-12da5abc0a1c" />

Painted SCAF suit in tech tree

<img width="750" height="655" alt="image" src="https://github.com/user-attachments/assets/b0b3bb77-385e-468b-bd5a-5371e0235115" />

Painted SCAF suit being available when SCAF blueprint is installed 

<img width="905" height="822" alt="image" src="https://github.com/user-attachments/assets/4daccd87-341b-4b1c-a674-7d1490d2fdf9" />

Midnight Operative Special Tactical Suit (MOSTS) in contravend


<img width="573" height="499" alt="image" src="https://github.com/user-attachments/assets/89a0cb2d-cb54-4231-952b-943c07c8eb00" />


MOSTS as it appears in duffel, externally the same as a regular bundle sans description.

<img width="551" height="420" alt="image" src="https://github.com/user-attachments/assets/acbc97b5-07d3-4a75-b51c-d91eda12c1fe" />

MOSTS suit in bag with description


<img width="488" height="314" alt="image" src="https://github.com/user-attachments/assets/e1613af2-f77b-4425-8708-cdfae71a6b16" />

MOSTS Suit helmet descriptor

<img width="228" height="231" alt="image" src="https://github.com/user-attachments/assets/908598be-9463-4502-8c5d-ca853c1318f8" />

MOSTS suit appearance

<img width="1303" height="940" alt="image" src="https://github.com/user-attachments/assets/f07fbf22-12c1-4e68-bfd6-98cd76e3a084" />

Nukie night vision (updated)

## Requirements
<!-- Confirm the following by placing an X in the brackets [X]: -->
- [X] I have read the guidelines and documentation relevant to this PR.
- [X] I have added media to this PR or it does not require an ingame showcase.
- [X] I can confirm this PR contains either no AI-generated content, or AI-generated content that meets our guidelines.
<!-- You should understand that not following the above may get your PR closed at maintainer’s discretion -->
<!-- When using AI, make sure you are already proficient in creating whatever content you are attempting to generate and that you already have experience contributing to SS14. This means using AI to enhance your preexisting workflow, not vibecoding. -->

## How to test
<!-- Describe the way it can be tested -->

Attempt to research and then create a painted SCAF suit
Attempt to print a painted SCAF suit from a blueprint

Attempt to acquire a MOSTS suit via uplink
Attempt to acquire a MOSTS suit via surplus crate
Attempt to acquire a MOSTS suit via dead drop

Toggle night vision on while wearing any blood-red variant suit

## Breaking changes
<!-- List any breaking changes, including namespaces, public class/method/field changes, prototype renames; and provide instructions for fixing them. -->

**Changelog**
<!-- Add a Changelog entry to make players aware of new features or changes that could affect gameplay.
Make sure to read the guidelines and take this Changelog template out of the comment block in order for it to show up.
Changelog must have a :cl: symbol, so the bot recognizes the changes and adds them to the game's changelog.
Remove this symbol for non-player facing PRs.-->
:cl:
- add: Added the SCRUFF hardsuit, a lighter version of the SCAF suit in desert camo. It has less protection, but is much faster
- tweak: Blood-red and related suit night vision upgraded to binocular, to be more in-line with similar tiered combat suits.
- add: Added the midnight operator tacticool suit to the uplink. Reskin of the bloodred hardsuit.
