### PR TITLE
TDF Loadout and Vendor Improvements

### DIFF
--- a/Resources/Prototypes/_Triad/Catalog/VendingMachines/Inventories/tdfdrobe.yml
+++ b/Resources/Prototypes/_Triad/Catalog/VendingMachines/Inventories/tdfdrobe.yml
@@ -18,11 +18,11 @@
     ClothingMaskGasSecurity: 15
     ClothingMaskGasSwatTdf: 10
     ClothingShoesBootsCombat: 15
+    ClothingShoesBootsMagSecurity: 3
     ClothingHeadHelmetMercenaryBlack: 20
     ClothingHeadHatBeretTdf: 10
-    ClothingOuterArmorBasicSlim: 15
-    ClothingOuterArmorBasic: 15
-    ClothingShoesBootsMagSecurity: 3
+    ClothingOuterArmorBPVestLight: 15
+    ClothingOuterArmorBPVestMedium: 15
     ClothingEyesGlassesSunglasses: 3
     ClothingEyesHudSecurityTdf: 10
     ClothingEyesHudMedSec: 2

--- a/Resources/Prototypes/_Triad/Catalog/VendingMachines/Inventories/tdfdrobe.yml
+++ b/Resources/Prototypes/_Triad/Catalog/VendingMachines/Inventories/tdfdrobe.yml
@@ -16,6 +16,7 @@
     ClothingNeckIFFOrange: 30
     ClothingHeadsetTdf: 15
     ClothingMaskGasSecurity: 15
+    ClothingMaskGasSwatTdf: 10
     ClothingShoesBootsCombat: 15
     ClothingHeadHelmetMercenaryBlack: 20
     ClothingHeadHatBeretTdf: 10
@@ -25,6 +26,7 @@
     ClothingEyesGlassesSunglasses: 3
     ClothingEyesHudSecurityTdf: 10
     ClothingEyesHudMedSec: 2
+    NFPouchNfsd: 10
     ClothingBeltTdf: 10
     ClothingBeltMilitaryWebbingTdf: 10
     ClothingBeltMilitaryWebbingMedTdf: 3

--- a/Resources/Prototypes/_Triad/Catalog/VendingMachines/Inventories/tdfdrobe.yml
+++ b/Resources/Prototypes/_Triad/Catalog/VendingMachines/Inventories/tdfdrobe.yml
@@ -27,5 +27,4 @@
     ClothingEyesHudMedSec: 2
     ClothingBeltTdf: 10
     ClothingBeltMilitaryWebbingTdf: 10
-    ClothingBeltWebbingsBigBase: 12 # TODO TDF variant
     ClothingBeltMilitaryWebbingMedTdf: 3

--- a/Resources/Prototypes/_Triad/Entities/Clothing/Belt/belts.yml
+++ b/Resources/Prototypes/_Triad/Entities/Clothing/Belt/belts.yml
@@ -117,9 +117,9 @@
     damageCoefficient: 0.5
 
 - type: entity
-  parent: ClothingBeltMilitaryWebbing
+  parent: ClothingBeltWebbingsBigBase
   id: ClothingBeltMilitaryWebbingTdf
-  name: TDF chest rig
+  name: TDF large chest rig
   description: A set of tactical webbing worn by TDF members. Very yellow.. or gold.
   components:
   - type: Tag # Ignore Chameleon tags
@@ -141,7 +141,7 @@
     sprite: _Triad/Clothing/Belt/tdfwebbingmed.rsi
   - type: Clothing
     sprite: _Triad/Clothing/Belt/tdfwebbingmed.rsi
-    
+
 - type: entity
   parent: NFClothingBeltStorageBase
   id: MLA79Harness

--- a/Resources/Prototypes/_Triad/Entities/Clothing/Belt/belts.yml
+++ b/Resources/Prototypes/_Triad/Entities/Clothing/Belt/belts.yml
@@ -130,9 +130,9 @@
     sprite: _Triad/Clothing/Belt/tdfwebbing.rsi
 
 - type: entity
-  parent: ClothingBeltMilitaryWebbingMed
+  parent: ClothingBeltWebbingsBigBase
   id: ClothingBeltMilitaryWebbingMedTdf
-  name: TDF medical chest rig
+  name: TDF large medical chest rig
   description: A set of tactical webbing worn by TDF medics.
   components:
   - type: Tag # Ignore Chameleon tags
@@ -141,6 +141,8 @@
     sprite: _Triad/Clothing/Belt/tdfwebbingmed.rsi
   - type: Clothing
     sprite: _Triad/Clothing/Belt/tdfwebbingmed.rsi
+  - type: ExplosionResistance
+    damageCoefficient: 0.1
 
 - type: entity
   parent: NFClothingBeltStorageBase


### PR DESCRIPTION
## About the PR
<!-- What did you change? -->
<!-- If this is a code change, summarize at high level how your new code works. This makes it easier to review. -->
1. Reparented TDF **webbings** from the basic webbing to the large webbing: extra storage, extra slowdown. Removed the now-irrelevant generic grey webbing from the TDFDrobe.
2. **Pouches & SWAT masks** have been added to the TDFDrobe.
3. Fixed armor in TDFDrobe: previously it was stocked with armor vests and slim armor vests, now is stocked with light bulletproof vest and medium bulletproof vest to match TDF loadouts.

## Why / Balance
<!-- Discuss how this would affect game balance or explain why it was changed. Link any relevant discussions or issues. -->
WEBBING: I see a lot of TDF members running the grey large webbing over their TDF webbing or belt, because its larger and fills the niche they need. It seems silly to me that players are forced to use the color-clashing, dare I say _dripless_ grey large webbing, when TDF already has two options! The belt stays as the small, nimble option, while the visually larger and bulkier webbing option becomes a larger, but less maneuverable choice.
POUCHES AND SWAT MASKS: Both can be obtained by using the Knight shuttle, or by being a senior enforcer/chief enforcer respectively, so theres no harm in just making them purchasable. I would even add them to the loadouts of all TDF, if loadout code wasn't miserable to work with and the junior/full enforcer loadouts weren't somewhere I cannot seem to find them.

## Media
<!-- Attach media if the PR makes ingame changes (clothing, items, features, etc). 
Small fixes/refactors are exempt. Media may be used in SS14 progress reports with credit. -->
<img width="482" height="111" alt="image" src="https://github.com/user-attachments/assets/d626aa6f-075a-45eb-bc4d-534510ca4a8b" />
A todo this PR is able to resolve!
<img width="728" height="685" alt="image" src="https://github.com/user-attachments/assets/8326b88e-8750-4495-be3c-449ad74f0662" />
<img width="727" height="685" alt="image" src="https://github.com/user-attachments/assets/065e8e4c-eac8-4f71-a1e6-cb3f26d0011e" />
<img width="794" height="684" alt="image" src="https://github.com/user-attachments/assets/06eca568-9ac5-4bd4-a1d5-e32127035246" />
<img width="759" height="678" alt="image" src="https://github.com/user-attachments/assets/0ce38d70-0a97-452e-b576-96d05d85f036" />
<img width="455" height="201" alt="image" src="https://github.com/user-attachments/assets/948ac5ec-c192-4a6d-b30e-58628058e4fd" />
<img width="393" height="955" alt="image" src="https://github.com/user-attachments/assets/2b1c643b-3fee-4da9-901b-07be82801dee" />

## Requirements
<!-- Confirm the following by placing an X in the brackets [X]: -->
- [x] I have read the guidelines and documentation relevant to this PR.
- [x] I have added media to this PR or it does not require an ingame showcase.
- [x] I can confirm this PR contains either no AI-generated content, or AI-generated content that meets our guidelines.
<!-- You should understand that not following the above may get your PR closed at maintainer’s discretion -->
<!-- When using AI, make sure you are already proficient in creating whatever content you are attempting to generate and that you already have experience contributing to SS14. This means using AI to enhance your preexisting workflow, not vibecoding. -->

## How to test
<!-- Describe the way it can be tested -->
Go into the game, spawn VendingMachineTdfDrobe, scroll to the bottom, spawn the belt & webbing, and be amazed!

## Breaking changes
<!-- List any breaking changes, including namespaces, public class/method/field changes, prototype renames; and provide instructions for fixing them. -->

**Changelog**
<!-- Add a Changelog entry to make players aware of new features or changes that could affect gameplay.
Make sure to read the guidelines and take this Changelog template out of the comment block in order for it to show up.
Changelog must have a :cl: symbol, so the bot recognizes the changes and adds them to the game's changelog.
Remove this symbol for non-player facing PRs.-->
:cl:Nox38
- tweak: R&D's new, updated pattern of TDF webbing allows more storage, at the cost of mobility.
- tweak: TDFDrobes have finally been restocked with pouches and SWAT gas masks.
- tweak: A previous logistical error resulted in TDFDrobes being stocked with station security armor vests. TDF logistics has rectified this.
