### PR TITLE
Adjustment of Pierce Plate

### DIFF
--- a/Resources/Prototypes/_Mono/Entities/Clothing/OuterClothing/Armor/armor_plates.yml
+++ b/Resources/Prototypes/_Mono/Entities/Clothing/OuterClothing/Armor/armor_plates.yml
@@ -47,9 +47,9 @@
     maxDurability: 50
     walkSpeedModifier: 0.95
     sprintSpeedModifier: 0.95
-    staminaDamageMultiplier: 1.0
+    staminaDamageMultiplier: 0.6
     absorptionRatios:
-      Piercing: 0.7
+      Piercing: 0.65
       Burn: 1.2
   - type: Damageable
     damageContainer: Inorganic


### PR DESCRIPTION
## About the PR
<!-- What did you change? -->
<!-- If this is a code change, summarize at high level how your new code works. This makes it easier to review. -->
Small adjustment to pierce plate damage absorption and stamina damage multiplier (0.6 stam damage from 1, 0.65 pierce absorption from 0.70) this PR is really in tandem to the 4 gauge adjustment so you can't get one shot stunned.
## Why / Balance
<!-- Discuss how this would affect game balance or explain why it was changed. Link any relevant discussions or issues. -->
Prevention of instant stuns when wearing a pierce plate, VERY slight nerf to protection values
## Media
<!-- Attach media if the PR makes ingame changes (clothing, items, features, etc). 
Small fixes/refactors are exempt. Media may be used in SS14 progress reports with credit. -->
Nah
## Requirements
<!-- Confirm the following by placing an X in the brackets [X]: -->
- [x] I have read the guidelines and documentation relevant to this PR.
- [x] I have added media to this PR or it does not require an ingame showcase.
- [x] I can confirm this PR contains either no AI-generated content, or AI-generated content that meets our guidelines.
<!-- You should understand that not following the above may get your PR closed at maintainer’s discretion -->
<!-- When using AI, make sure you are already proficient in creating whatever content you are attempting to generate and that you already have experience contributing to SS14. This means using AI to enhance your preexisting workflow, not vibecoding. -->

## How to test
<!-- Describe the way it can be tested -->
Spawn in pierce plate, put in hardsuit storage slot, shoot at with 4 gauge buckshot point blank, behold the still standing Urist
## Breaking changes
<!-- List any breaking changes, including namespaces, public class/method/field changes, prototype renames; and provide instructions for fixing them. -->

**Changelog**
<!-- Add a Changelog entry to make players aware of new features or changes that could affect gameplay.
Make sure to read the guidelines and take this Changelog template out of the comment block in order for it to show up.
Changelog must have a :cl: symbol, so the bot recognizes the changes and adds them to the game's changelog.
Remove this symbol for non-player facing PRs.-->
:cl:
- tweak: 5% reduction in pierce plate piercing absorbtion, 40% reduction in Stamina Damage multiplier (4 gauge buck won't one tap stun you now)

