### PR TITLE
Snap Construction Ghost Rotation to a Cardinal Before It Is Built

### DIFF
--- a/Content.Client/Construction/ConstructionSystem.cs
+++ b/Content.Client/Construction/ConstructionSystem.cs
@@ -223,6 +223,18 @@ namespace Content.Client.Construction
             // Setting the WORLD rotation instead is correct for any parent, and reduces to the old behaviour when
             // the camera is aligned to the grid.
             _transformSystem.SetWorldRotation(ghost.Value, dir.ToAngle() - _eyeManager.CurrentEye.Rotation);
+
+            // Triad: the eye term above is only a whole number of quarter turns once InputMoverComponent's
+            // RelativeRotation has finished lerping towards TargetRelativeRotation (LerpTime is 1s, re-armed every
+            // time the player traverses on or off a grid). Placed mid-lerp, the line above leaves a fraction of a
+            // turn in the ghost's LocalRotation, and nothing downstream removes it: TryStartConstruction puts that
+            // value on the wire and the server passes it to SpawnAttachedTo verbatim, so the fraction is baked into
+            // the finished structure permanently. Snap to the parent's nearest cardinal, which is the only thing
+            // the placement manager can produce anyway (Rotate() cycles East/South/West/North) and what the server's
+            // own placement conditions already assume when they call GetCardinalDir().
+            var ghostXform = EntityManager.GetComponent<TransformComponent>(ghost.Value);
+            _transformSystem.SetLocalRotation(ghost.Value, ghostXform.LocalRotation.GetCardinalDir().ToAngle(), ghostXform);
+
             _ghosts.Add(comp.GhostId, ghost.Value);
             var sprite = EntityManager.GetComponent<SpriteComponent>(ghost.Value);
             _spriteSystem.SetColor((ghost.Value, sprite), new Color(48, 255, 48, 128));

--- a/Content.IntegrationTests/Tests/_Triad/Construction/ConstructionGhostRotationTest.cs
+++ b/Content.IntegrationTests/Tests/_Triad/Construction/ConstructionGhostRotationTest.cs
@@ -148,16 +148,17 @@ public sealed class ConstructionGhostRotationTest : InteractionTest
     /// <summary>
     /// The camera offset is only a cardinal once its lerp settles, so mid-lerp the ghost's local rotation carries
     /// a fraction of a turn. Building during that window bakes the fraction into the structure permanently, where
-    /// the pre-fix code always wrote an exact cardinal. Nothing snaps the angle between the ghost and the spawn:
-    /// the server passes it to <c>SpawnAttachedTo</c> as-is and only the placement <c>conditions</c> ever call
-    /// <c>GetCardinalDir</c>.
+    /// the pre-fix code always wrote an exact cardinal. Nothing used to snap the angle between the ghost and the
+    /// spawn: the server passed it to <c>SpawnAttachedTo</c> as-is, and the placement <c>conditions</c> were the
+    /// only thing that ever called <c>GetCardinalDir</c>.
     ///
-    /// Known to fail, and deliberately kept: it reproduces at 3° off the nearest cardinal. Closing it means
-    /// snapping the angle before it goes on the wire, which belongs in the follow-up patch rather than in a triage
-    /// change. Un-ignore it there; it is the acceptance test for that fix.
+    /// This is the acceptance test for the snap that closes that gap, and it reproduces at 3° off the nearest
+    /// cardinal. <c>TrySpawnGhost</c> now reduces the ghost's <c>LocalRotation</c> to the parent's nearest cardinal
+    /// after setting its world rotation, and <c>TryStartStructureConstruction</c> reduces the angle again before it
+    /// reaches <c>SpawnAttachedTo</c>, so neither a camera caught mid-lerp nor a modified client can write a
+    /// fraction of a turn onto a permanent structure.
     /// </summary>
     [Test]
-    [Ignore("Known gap, fails at 3° off cardinal. Fix is the cardinal snap in the follow-up patch; un-ignore then.")]
     public async Task GhostStaysCardinalWhileTheCameraIsStillLerping()
     {
         var proto = ProtoMan.Index<ConstructionPrototype>(DiagonalWall);

--- a/Content.Server/Construction/ConstructionSystem.Initial.cs
+++ b/Content.Server/Construction/ConstructionSystem.Initial.cs
@@ -600,13 +600,18 @@ namespace Content.Server.Construction
             }
 
 
+            // Triad: `angle` is the client ghost's LocalRotation and reaches SpawnAttachedTo unmodified, which writes
+            // it straight to the structure's LocalRotation. Construction is tile-aligned and the conditions checked
+            // above already reduce this value with GetCardinalDir(), so snap here too rather than trusting the wire:
+            // it keeps a mid-lerp camera from baking a fraction of a turn into a permanent structure, and stops a
+            // modified client sending an arbitrary angle.
             if (await Construct(user,
                     (ack + constructionPrototype.GetHashCode()).ToString(),
                     constructionGraph,
                     edge,
                     targetNode,
                     location,
-                    constructionPrototype.CanRotate ? angle : Angle.Zero) is not {Valid: true} structure)
+                    constructionPrototype.CanRotate ? angle.GetCardinalDir().ToAngle() : Angle.Zero) is not {Valid: true} structure)
             {
                 Cleanup();
                 return false;


### PR DESCRIPTION
## About the PR

Construction ghosts could bake a fraction of a turn into the built structure if you placed while the camera was still lerping. Snaps the angle to the nearest cardinal on the client and again server-side, and un-ignores the acceptance test that was already written for it.

## Why / Balance

#493 set the ghost's world rotation through the eye, fixing a real screen-space vs grid-local frame bug, but left the eye term in the value that goes on the wire. That term carries `InputMoverComponent.RelativeRotation`, which lerps over a one second window re-armed on every grid traversal. Settled it is a whole quarter turn and nothing looks wrong; mid-lerp it is a fraction, and nothing removed it before `SpawnAttachedTo` wrote it onto the structure permanently.

That is the "structures build skewed on rotated ships" report, and it explains why it tracked where the player was standing: moving is what leaves the camera mid-settle.

The client snaps so the preview matches what gets built. The server snaps because it is authoritative and the placement conditions above it already assume a cardinal. `GetCardinalDir()` rather than `GetDir()` because `PlacementManager.Rotate()` only cycles East, South, West, North.

## Media

No visible change with a settled camera. Only shows mid-lerp, where structures used to land a few degrees off the hull.

## Requirements

- [x] I have read the guidelines and documentation relevant to this PR.
- [ ] I have added media to this PR or it does not require an ingame showcase.
- [x] I can confirm this PR contains either no AI-generated content, or AI-generated content that meets our guidelines.

## How to test

`ConstructionGhostRotationTest`, 15 cases covering arbitrary ship angles and map positions. `GhostStaysCardinalWhileTheCameraIsStillLerping` is the acceptance case and was ignored until this PR.

In game: board a ship at an odd angle and build something rotatable while walking, so the camera is still settling. Placements should sit flush regardless of when you click.

## Breaking changes

None.

**Changelog**

:cl:
- fix: Structures built on rotating ships no longer come out slightly crooked if you build while the camera is still settling.
