### PR TITLE
Adds a Recipe for the TFA Banner

### DIFF
--- a/Resources/Prototypes/_Triad/Entities/Structures/Decoration/banners.yml
+++ b/Resources/Prototypes/_Triad/Entities/Structures/Decoration/banners.yml
@@ -20,3 +20,6 @@
   - type: Sprite
     sprite: _Triad/Structure/Decoration/banner.rsi
     state: tfa-banner
+  - type: Construction
+    graph: TriadBannersGraph
+    node: BannerTFANode

--- a/Resources/Prototypes/_Triad/Recipes/Construction/Graphs/furniture/triadbanners.yml
+++ b/Resources/Prototypes/_Triad/Recipes/Construction/Graphs/furniture/triadbanners.yml
@@ -16,9 +16,34 @@
             - material: Cloth
               amount: 2
               doAfter: 1
+        - to: BannerTDFNode
+          completed:
+            - !type:SnapToGrid { }
+          steps:
+            - material: Steel
+              amount: 2
+              doAfter: 1
+            - material: Cloth
+              amount: 2
+              doAfter: 1
 
     - node: BannerTDFNode
       entity: BannerTdf
+      edges:
+      - to: start
+        completed:
+        - !type:SpawnPrototype
+          prototype: SheetSteel1
+          amount: 2
+        - !type:SpawnPrototype
+          prototype: MaterialCloth1
+          amount: 2
+        steps:
+        - tool: Screwing
+          doAfter: 1
+
+    - node: BannerTFANode
+      entity: BannerTfa
       edges:
       - to: start
         completed:

--- a/Resources/Prototypes/_Triad/Recipes/Construction/Graphs/furniture/triadbanners.yml
+++ b/Resources/Prototypes/_Triad/Recipes/Construction/Graphs/furniture/triadbanners.yml
@@ -16,7 +16,7 @@
             - material: Cloth
               amount: 2
               doAfter: 1
-        - to: BannerTDFNode
+        - to: BannerTFANode
           completed:
             - !type:SnapToGrid { }
           steps:

--- a/Resources/Prototypes/_Triad/Recipes/Construction/furniture.yml
+++ b/Resources/Prototypes/_Triad/Recipes/Construction/furniture.yml
@@ -16,6 +16,23 @@
     - !type:TileNotBlocked
 
 - type: construction
+  id: BannerTfa
+  name: TFA banner
+  description: A banner proudly displaying the logo of the Triad Frontier Association. May Triad prosper.
+  graph: TriadBannersGraph
+  startNode: start
+  targetNode: BannerTFANode
+  category: construction-category-furniture
+  icon:
+    sprite: _Triad/Structure/Decoration/banner.rsi
+    state: tfa-banner
+  objectType: Structure
+  placementMode: SnapgridCenter
+  canBuildInImpassable: false
+  conditions:
+    - !type:TileNotBlocked
+
+- type: construction
   id: Handrail
   name: handrail
   graph: TriadSeat


### PR DESCRIPTION
## About the PR
This PR makes TFA banners buildable the same way TDF banners are

## Why / Balance
You can build TDF banners, so why not TFA banners?

## Media
<img width="406" height="162" alt="image" src="https://github.com/user-attachments/assets/eb4deeab-8d97-4386-9437-9c2380bbe796" />

## Requirements
<!-- Confirm the following by placing an X in the brackets [X]: -->
- [X] I have read the guidelines and documentation relevant to this PR.
- [X] I have added media to this PR or it does not require an ingame showcase.
- [X] I can confirm this PR contains either no AI-generated content, or AI-generated content that meets our guidelines.

## How to test
1. Get 2 steel and 2 cloth
2. Search for "banner" in the Construction menu
3. Build the TFA banner

**Changelog**
:cl: Minerva
- add: TFA banners are now buildable.