### PR TITLE
Fix a Latch That Killed Biome Chunk Loading for a Whole Round

### DIFF
--- a/Content.Server/Parallax/BiomeSystem.cs
+++ b/Content.Server/Parallax/BiomeSystem.cs
@@ -148,54 +148,67 @@ public sealed partial class BiomeSystem : SharedBiomeSystem
             return;
         _updateTimer = 0f;
 
-        var biomes = AllEntityQuery<BiomeComponent>();
-
-        while (biomes.MoveNext(out var biome))
+        // Triad: the rest of this method has to run under a finally. CleanupUpdateCycle is the only thing
+        // that clears _activeChunks, and the _activeChunks.Add below is a Dictionary.Add that throws on a
+        // duplicate key, so any single throw escaping the body used to latch: the dictionary kept its
+        // entries, the next tick's Add threw on the duplicate, and that throw skipped cleanup as well.
+        // Biome chunk loading then stayed dead for the rest of the round and the pooled tile lists leaked
+        // (3037 errors over one 6m45s window on prod, ended only by the biome grid being deleted). With the
+        // finally, a transient throw anywhere under LoadChunks costs one tick of chunk loading instead,
+        // which is what the no-players early return already assumes.
+        try
         {
-            if (biome.LifeStage < ComponentLifeStage.Running)
-                continue;
+            var biomes = AllEntityQuery<BiomeComponent>();
 
-            _activeChunks.Add(biome, _tilePool.Get());
-            _markerChunks.GetOrNew(biome);
-        }
+            while (biomes.MoveNext(out var biome))
+            {
+                if (biome.LifeStage < ComponentLifeStage.Running)
+                    continue;
 
-        ProcessPlayerChunkRequests();
+                _activeChunks.Add(biome, _tilePool.Get());
+                _markerChunks.GetOrNew(biome);
+            }
 
-        // Early exit if no players around chunk
-        if (_handledEntities.Count == 0)
-        {
-            CleanupUpdateCycle();
-            return;
-        }
+            ProcessPlayerChunkRequests();
 
-        var loadBiomes = AllEntityQuery<BiomeComponent, MapGridComponent>();
+            // Early exit if no players around chunk
+            if (_handledEntities.Count == 0)
+            {
+                // Triad: CleanupUpdateCycle() moved to the finally below.
+                return;
+            }
 
-        _unloadTimer += frameTime;
-        var shouldUnload = _unloadTimer > UnloadInterval;
+            var loadBiomes = AllEntityQuery<BiomeComponent, MapGridComponent>();
 
-        while (loadBiomes.MoveNext(out var gridUid, out var biome, out var grid))
-        {
-            // If not MapInit don't run it.
-            if (biome.LifeStage < ComponentLifeStage.Running)
-                continue;
+            _unloadTimer += frameTime;
+            var shouldUnload = _unloadTimer > UnloadInterval;
 
-            if (!biome.Enabled)
-                continue;
+            while (loadBiomes.MoveNext(out var gridUid, out var biome, out var grid))
+            {
+                // If not MapInit don't run it.
+                if (biome.LifeStage < ComponentLifeStage.Running)
+                    continue;
 
-            // Only process biomes with active chunks
-            if (!_activeChunks.ContainsKey(biome))
-                continue;
+                if (!biome.Enabled)
+                    continue;
 
-            LoadChunks(biome, gridUid, grid, biome.Seed);
+                // Only process biomes with active chunks
+                if (!_activeChunks.ContainsKey(biome))
+                    continue;
+
+                LoadChunks(biome, gridUid, grid, biome.Seed);
+
+                if (shouldUnload)
+                    UnloadChunks(biome, gridUid, grid, biome.Seed);
+            }
 
             if (shouldUnload)
-                UnloadChunks(biome, gridUid, grid, biome.Seed);
+                _unloadTimer = 0f;
         }
-
-        if (shouldUnload)
-            _unloadTimer = 0f;
-
-        CleanupUpdateCycle();
+        finally
+        {
+            CleanupUpdateCycle();
+        }
     }
 
     private void CleanupUpdateCycle()

--- a/Content.Shared/Maps/TileSystem.cs
+++ b/Content.Shared/Maps/TileSystem.cs
@@ -59,8 +59,18 @@ public sealed partial class TileSystem : EntitySystem
                 return i;
         }
 
-        // Shouldn't happen
-        throw new InvalidOperationException($"Invalid weighted variantize tile pick for {tile.ID}!");
+        // Triad: this does happen. Same arithmetic as the weighted picks in SharedRandomExtensions,
+        // whose WeightedPickFallThrough carries the full explanation: Sum() accumulates floats in a
+        // double and casts back while `accumulated` is a running float, and `rand` is a float multiply
+        // that can round up onto the gap between them. This is the highest-volume weighted pick in the
+        // game and it runs inside BiomeSystem's chunk loader, so a throw here took biome loading down
+        // for the rest of the round until that loader was made exception safe. The variant the loop was
+        // reaching for is the last one.
+        // throw new InvalidOperationException($"Invalid weighted variantize tile pick for {tile.ID}!");
+        if (variants.Length == 0)
+            throw new InvalidOperationException($"Invalid weighted variantize tile pick for {tile.ID}: no placement variants!");
+
+        return (byte)(variants.Length - 1);
     }
 
     /// <summary>

--- a/Content.Shared/Random/Helpers/SharedRandomExtensions.cs
+++ b/Content.Shared/Random/Helpers/SharedRandomExtensions.cs
@@ -22,21 +22,61 @@ namespace Content.Shared.Random.Helpers
         // Only for a System.Random receiver: an IRobustRandom has NextFloat() of its own.
 
         /// <summary>
-        /// Returns a random float in [0, 1), matching the engine's obsolete
+        /// Returns a random float in [0, 1], matching the engine's obsolete
         /// <c>System.Random.NextFloat()</c> derivation exactly.
         /// </summary>
+        /// <remarks>
+        /// Triad: the interval is CLOSED at 1.0, despite what the engine's name suggests and what
+        /// this summary used to claim. <c>Next()</c> tops out at <c>int.MaxValue - 1</c>, which needs
+        /// more significant bits than a float mantissa holds and therefore widens UP to 2^31, while
+        /// the multiplier rounds to exactly 2^-31, so the product is exactly 1.0f for the top 63
+        /// draws (about 2.9e-8 of them). Callers that scale by a count and index, or that walk a
+        /// running total, have to tolerate landing on the endpoint. The arithmetic is deliberately
+        /// left alone: it is the engine's, verbatim, and seeded sequences depend on it.
+        /// </remarks>
         public static float NextFloatValue(this System.Random random)
         {
             return random.Next() * 4.6566128752458E-10f;
         }
 
         /// <summary>
-        /// Returns a random float in [<paramref name="minValue"/>, <paramref name="maxValue"/>),
+        /// Returns a random float in [<paramref name="minValue"/>, <paramref name="maxValue"/>],
         /// matching the engine's obsolete <c>System.Random.NextFloat(float, float)</c> derivation.
         /// </summary>
+        /// <remarks>
+        /// Triad: closed at <paramref name="maxValue"/> for the same reason as the overload above,
+        /// so a caller flooring this to get an integer in a range can see one past the top of it.
+        /// </remarks>
         public static float NextFloatValue(this System.Random random, float minValue, float maxValue)
         {
             return random.NextFloatValue() * (maxValue - minValue) + minValue;
+        }
+
+        // Triad: every weighted pick in this file walks a running float total and returns the first
+        // entry whose total reaches `rand`. That loop can finish having selected NOTHING, and each
+        // fall-through used to throw. Two independent float facts get it there:
+        //
+        //   - `Sum()` over floats accumulates in a double and casts back, while `accumulated` is a
+        //     running float, so for fractional weights the running total can finish just BELOW the
+        //     reported sum. 16 of the 295 weight lists in Prototypes do exactly that, among them the
+        //     planet ore and fauna tables.
+        //   - `rand` is itself a float multiply, so it can round UP onto or past that shortfall.
+        //     NextFloatValue() can also return exactly 1.0f (see its remarks), landing `rand`
+        //     squarely on the sum.
+        //
+        // Clamping the roll below 1.0 does not close this: 3 of those 16 lists still fall through at
+        // the largest float below 1.0, so the tail has to be handled here. Measured on prod at one
+        // occurrence in 14 days; it surfaced inside BiomeSystem's chunk loader, which before being
+        // made exception safe then lost biome loading for the rest of the round.
+        //
+        // The entry the loop was reaching for when it ran out is the last one, so hand that back.
+        // Only a genuinely empty table has no answer to give.
+        private static T WeightedPickFallThrough<T>(IReadOnlyCollection<T> keys, string what)
+        {
+            if (keys.Count == 0)
+                throw new InvalidOperationException($"Invalid weighted pick: {what} has no entries to pick from!");
+
+            return keys.Last();
         }
 
         public static string Pick(this IRobustRandom random, DatasetPrototype prototype)
@@ -71,8 +111,9 @@ namespace Content.Shared.Random.Helpers
                 }
             }
 
-            // Shouldn't happen
-            throw new InvalidOperationException($"Invalid weighted pick for {prototype.ID}!");
+            // Triad: this does happen, see WeightedPickFallThrough.
+            // throw new InvalidOperationException($"Invalid weighted pick for {prototype.ID}!");
+            return WeightedPickFallThrough(picks.Keys, prototype.ID);
         }
 
         public static string Pick(this IWeightedRandomPrototype prototype, IRobustRandom? random = null)
@@ -94,8 +135,9 @@ namespace Content.Shared.Random.Helpers
                 }
             }
 
-            // Shouldn't happen
-            throw new InvalidOperationException($"Invalid weighted pick for {prototype.ID}!");
+            // Triad: this does happen, see WeightedPickFallThrough.
+            // throw new InvalidOperationException($"Invalid weighted pick for {prototype.ID}!");
+            return WeightedPickFallThrough(picks.Keys, prototype.ID);
         }
 
         public static T Pick<T>(this IRobustRandom random, Dictionary<T, float> weights)
@@ -116,7 +158,9 @@ namespace Content.Shared.Random.Helpers
                 }
             }
 
-            throw new InvalidOperationException("Invalid weighted pick");
+            // Triad: see WeightedPickFallThrough.
+            // throw new InvalidOperationException("Invalid weighted pick");
+            return WeightedPickFallThrough(weights.Keys, $"a {typeof(T).Name} weight table");
         }
 
         public static T PickAndTake<T>(this IRobustRandom random, Dictionary<T, float> weights)
@@ -157,7 +201,10 @@ namespace Content.Shared.Random.Helpers
                 }
             }
 
-            throw new InvalidOperationException("Invalid weighted pick");
+            // Triad: this is the overload GroupSelector uses, and the one that threw on prod out of
+            // BiomeSystem's chunk loader. See WeightedPickFallThrough.
+            // throw new InvalidOperationException("Invalid weighted pick");
+            return WeightedPickFallThrough(weights.Keys, $"a {typeof(T).Name} weight table");
         }
 
         public static (string reagent, FixedPoint2 quantity) Pick(this WeightedRandomFillSolutionPrototype prototype, IRobustRandom? random = null)
@@ -181,8 +228,12 @@ namespace Content.Shared.Random.Helpers
                 }
             }
 
-            // Shouldn't happen
-            throw new InvalidOperationException($"Invalid weighted pick for {prototype.ID}!");
+            // Triad: this loop accumulates 1f per reagent against an integer count, so unlike the
+            // others it is exact and only an empty Reagents list reaches here. Routed through
+            // WeightedPickFallThrough anyway, for the clearer message and so the whole file behaves
+            // one way.
+            // throw new InvalidOperationException($"Invalid weighted pick for {prototype.ID}!");
+            return (WeightedPickFallThrough(randomFill.Reagents, prototype.ID), randomFill.Quantity);
         }
 
         public static RandomFillSolution PickRandomFill(this WeightedRandomFillSolutionPrototype prototype, IRobustRandom? random = null)
@@ -212,8 +263,9 @@ namespace Content.Shared.Random.Helpers
                 }
             }
 
-            // Shouldn't happen
-            throw new InvalidOperationException($"Invalid weighted pick for {prototype.ID}!");
+            // Triad: see WeightedPickFallThrough.
+            // throw new InvalidOperationException($"Invalid weighted pick for {prototype.ID}!");
+            return WeightedPickFallThrough(picks.Keys, prototype.ID);
         }
 
         /// <inheritdoc cref="HashCodeCombine(IReadOnlyCollection{int})"/>

--- a/Content.Tests/Shared/_Triad/WeightedPickFallThroughTest.cs
+++ b/Content.Tests/Shared/_Triad/WeightedPickFallThroughTest.cs
@@ -1,0 +1,129 @@
+using System;
+using System.Collections.Generic;
+using System.Linq;
+using Content.Shared.Random.Helpers;
+using NUnit.Framework;
+
+namespace Content.Tests.Shared._Triad;
+
+// The weighted picks in SharedRandomExtensions walk a running float total and return the first entry
+// whose total reaches the roll. That loop could select nothing and fall through to a throw, which on
+// prod escaped through BiomeSystem's chunk loader once in fourteen days and, because that loader was
+// not exception safe, killed biome chunk loading for the rest of the round.
+//
+// Two independent float facts combine to get there:
+//   - Enumerable.Sum over floats accumulates in a double and casts back, while the loop's total is a
+//     running float, so for fractional weights the running total can finish just BELOW the sum it is
+//     being compared against.
+//   - NextFloatValue() can return exactly 1.0f, which lands the roll exactly on that sum.
+//
+// Clamping the roll below 1.0 does not close the gap, so the fall-through itself has to be handled.
+[TestFixture]
+[TestOf(typeof(SharedRandomExtensions))]
+public sealed class WeightedPickFallThroughTest
+{
+    /// <summary>
+    /// Always returns the largest value <see cref="Random.Next()"/> can produce. int.MaxValue - 1
+    /// needs more significant bits than a float mantissa holds, so it widens UP to 2^31 and cancels
+    /// NextFloatValue's 2^-31 multiplier exactly, making the roll land on the sum.
+    /// </summary>
+    private sealed class TopDrawRandom : Random
+    {
+        public override int Next() => int.MaxValue - 1;
+    }
+
+    /// <summary>
+    /// MonoPlanetmapOreSand's child weights, copied from Prototypes/_Mono/Planets/ore.yml. This is
+    /// the table family the prod failure came out of, reached via BiomeSystem's entity spawning.
+    /// </summary>
+    private static readonly float[] OreSandWeights =
+        { 0.67f, 0.04f, 0.12f, 0.042f, 0.025f, 0.025f, 0.0075f, 0.01f };
+
+    private static Dictionary<string, float> OreSandTable()
+    {
+        var table = new Dictionary<string, float>();
+
+        for (var i = 0; i < OreSandWeights.Length; i++)
+        {
+            table.Add($"entry{i}", OreSandWeights[i]);
+        }
+
+        return table;
+    }
+
+    [Test]
+    public void NextFloatValueIsClosedAtOne()
+    {
+        // NextFloatValue's remarks document a closed interval. If this ever starts coming back below
+        // 1, the endpoint half of the bug is gone and only the Sum() shortfall remains.
+        Assert.That(new TopDrawRandom().NextFloatValue(), Is.EqualTo(1.0f));
+    }
+
+    [Test]
+    public void RunningFloatTotalFallsShortOfReportedSum()
+    {
+        // The precondition, asserted against shipped weights rather than assumed. Sum() accumulates
+        // in a double; the pick loop does not.
+        var reported = OreSandWeights.Sum();
+
+        var running = 0f;
+        foreach (var weight in OreSandWeights)
+        {
+            running += weight;
+        }
+
+        Assert.That(running, Is.LessThan(reported),
+            "the running float total is expected to finish below Sum()'s value for these weights");
+    }
+
+    [Test]
+    public void TopDrawPicksLastEntryInsteadOfThrowing()
+    {
+        // The regression. Before the fall-through was handled this threw InvalidOperationException
+        // out of GroupSelector, through map init, and into the biome chunk loader.
+        var table = OreSandTable();
+
+        var pick = SharedRandomExtensions.Pick(table, new TopDrawRandom());
+
+        Assert.That(pick, Is.EqualTo($"entry{OreSandWeights.Length - 1}"));
+    }
+
+    [Test]
+    public void EmptyTableStillThrows()
+    {
+        // A table with nothing in it has no answer to give, so this one keeps throwing.
+        var table = new Dictionary<string, float>();
+
+        Assert.That(() => SharedRandomExtensions.Pick(table, new TopDrawRandom()),
+            Throws.InstanceOf<InvalidOperationException>());
+    }
+
+    [Test]
+    public void OrdinaryDrawsStayInsideTheTable()
+    {
+        // Control: the happy path is unchanged and every draw is a real key.
+        var table = OreSandTable();
+        var random = new Random(1234);
+
+        for (var i = 0; i < 10_000; i++)
+        {
+            Assert.That(table.ContainsKey(SharedRandomExtensions.Pick(table, random)));
+        }
+    }
+
+    [Test]
+    public void EveryEntryIsReachable()
+    {
+        // Control: guarding the tail must not collapse the distribution onto one entry.
+        var table = OreSandTable();
+        var random = new Random(5678);
+        var seen = new HashSet<string>();
+
+        for (var i = 0; i < 200_000; i++)
+        {
+            seen.Add(SharedRandomExtensions.Pick(table, random));
+        }
+
+        Assert.That(seen, Is.EquivalentTo(table.Keys));
+    }
+}


### PR DESCRIPTION
## About the PR
Makes `BiomeSystem.Update` exception safe, and stops the weighted picks in `SharedRandomExtensions` and `TileSystem.PickVariant` throwing when their loop selects nothing.

Two commits, in causal order: the second is the trigger, the first is why one trigger cost a whole round.

## Why / Balance
`CleanupUpdateCycle` is the only thing that clears `_activeChunks`, and the `_activeChunks.Add` near the top of `Update` is a `Dictionary.Add` that throws on a duplicate key. Cleanup wasn't in a `finally`, so any throw under `LoadChunks` left the dictionary populated, the next tick's `Add` threw on the duplicate, and that throw skipped cleanup too. Self-sustaining: biome chunk loading stayed dead for the rest of the round and the pooled tile lists leaked. Prod logged 3037 errors in one 6m45s window on 2026-08-17, and it was seen in game the same day. It stopped only because the biome grid got deleted, not because anything recovered.

The trigger was `Invalid weighted pick`, and it is **not** bad prototype data. Every live `GroupSelector` in `Resources/Prototypes` has a non-empty `children` list (0 of 295 empty), no weight reaching an entity table is negative or non-finite (768 lines), and maps never override these. It's float arithmetic:

- `Enumerable.Sum` over floats accumulates in a **double** and casts back, while `accumulated` is a running **float**, so a fractional-weight list can finish just below the sum it's compared against. 16 of 295 lists do, including `_Mono/Planets/ore.yml` and `fauna.yml`, which are the tables this stack came through.
- `NextFloatValue()` can return **exactly 1.0f**, landing the roll on that sum. `Next()` tops out at `int.MaxValue - 1`, which needs more significant bits than a float mantissa holds and so widens *up* to 2^31, while the multiplier rounds to exactly 2^-31. Top 63 draws, about 2.9e-8, matching one occurrence in 14 days of logs.

Clamping the roll below 1.0 looks like the fix and isn't: 3 of those 16 lists still fall through at the largest float below 1.0, because the roll is itself a float multiply that can round up past the shortfall. `NextFloatValue`'s arithmetic is also left alone deliberately, since it reproduces the engine's obsolete extension bit-for-bit and seeded worldgen, dungeon gen, parallax and tile variants depend on that. Its summary claimed a half-open interval on both overloads, so that's corrected too.

So the fall-through is handled in a shared `WeightedPickFallThrough` returning the entry the loop was reaching for. Only a genuinely empty table still throws. Applied to all five fall-throughs in the file rather than just the one that fired, plus `TileSystem.PickVariant`, which has identical arithmetic, is the highest-volume weighted pick in the game, and also runs inside the biome chunk loader.

## Media
No ingame visual change. Both are error-path fixes.

## Requirements
- [x] I have read the guidelines and documentation relevant to this PR.
- [ ] I have added media to this PR or it does not require an ingame showcase.
- [x] I can confirm this PR contains either no AI-generated content, or AI-generated content that meets our guidelines.

## How to test
Six unit tests in `Content.Tests/Shared/_Triad/WeightedPickFallThroughTest.cs`, on the real `MonoPlanetmapOreSand` weights: two assert the preconditions (running total falls short of `Sum`, top draw is exactly 1.0), one is the regression, one keeps the empty-table throw, two are controls that the distribution is unchanged and every entry still reachable.

`dotnet test Content.Tests --filter FullyQualifiedName~WeightedPickFallThroughTest`

Verified by stashing the fix: 1 failed / 5 passed without it, 6 passed with it. Full `Content.Tests` run is 609 passed, 0 failed, 1 skipped.

The latch half has no test. It needs a throw injected into `LoadChunks` on a live biome, which the unit harness can't reach; it was verified by reading the prod stacks and the arithmetic (3037 errors at the ~7.5/s update rate is 404s, matching the observed span exactly, which is what a per-tick latch looks like).

## Breaking changes
None. No signature or prototype changes. Behaviour changes only where the old code threw.

**Changelog**
:cl:
- fix: Planet terrain and creatures no longer stop loading in for the rest of the round after a single hiccup.
