### PR TITLE
Fix/Tritalk UI Lifecycle

### DIFF
--- a/Content.Client/CartridgeLoader/CartridgeLoaderBoundUserInterface.cs
+++ b/Content.Client/CartridgeLoader/CartridgeLoaderBoundUserInterface.cs
@@ -40,18 +40,35 @@ public abstract class CartridgeLoaderBoundUserInterface : BoundUserInterface
 
         var activeUI = _entManager.GetEntity(loaderUiState.ActiveUI);
 
+        // Triad begin: rebuild the cartridge UI only when the active program actually changes.
+        // Upstream ran RetrieveCartridgeUI (and therefore UIFragment.Setup) on every loader state, which built a
+        // fresh fragment, while the type-equality guard below then kept the OLD fragment attached. Every later
+        // cartridge state landed on the detached fragment, so the visible one froze mid-session, or came up blank
+        // on reopen. Any loader state resends this: the PDA light, inserting an ID or pen, a station rename.
+        if (_activeProgram == activeUI && _activeUiFragment is not null)
+            return;
+
         _activeProgram = activeUI;
 
         var ui = RetrieveCartridgeUI(activeUI);
         var comp = RetrieveCartridgeComponent(activeUI);
         var control = ui?.GetUIFragmentRoot();
 
-        //Prevent the same UI fragment from getting disposed and attached multiple times
-        if (_activeUiFragment?.GetType() == control?.GetType())
-            return;
+        // Triad: upstream guarded on fragment TYPE here, which is what orphaned the fragment. Program identity
+        // above is the real question, and it also lets two programs sharing a fragment type swap correctly.
+        ////Prevent the same UI fragment from getting disposed and attached multiple times
+        //if (_activeUiFragment?.GetType() == control?.GetType())
+        //    return;
+        // Triad end
 
-        if (_activeUiFragment is not null)
-            DetachCartridgeUI(_activeUiFragment);
+        var previousFragment = _activeUiFragment;
+        if (previousFragment is not null)
+            DetachCartridgeUI(previousFragment);
+
+        // Triad: publish the new fragment BEFORE announcing readiness, so the state the server sends back in
+        // answer to CartridgeUiReadyEvent has somewhere to land. Upstream assigned these afterwards.
+        _activeCartridgeUI = ui;
+        _activeUiFragment = control;
 
         if (control is not null && _activeProgram.HasValue)
         {
@@ -59,9 +76,9 @@ public abstract class CartridgeLoaderBoundUserInterface : BoundUserInterface
             SendCartridgeUiReadyEvent(_activeProgram.Value);
         }
 
-        _activeCartridgeUI = ui;
-        _activeUiFragment?.Dispose();
-        _activeUiFragment = control;
+        // Triad: disposed last, so the outgoing fragment tears down after the incoming one has claimed any
+        // registration they share.
+        previousFragment?.Dispose();
     }
 
     protected void ActivateCartridge(EntityUid cartridgeUid)

--- a/Content.Client/CartridgeLoader/Cartridges/NotekeeperUiFragment.xaml
+++ b/Content.Client/CartridgeLoader/Cartridges/NotekeeperUiFragment.xaml
@@ -5,6 +5,28 @@
         <ScrollContainer HorizontalExpand="True" VerticalExpand="True" HScrollEnabled="True">
             <BoxContainer Orientation="Vertical" Name="MessageContainer" HorizontalExpand="True" VerticalExpand="True"/>
         </ScrollContainer>
-        <LineEdit Name="Input" HorizontalExpand="True" SetHeight="32"/>
+        <!-- Triad: this was a bare, unstyled LineEdit with no placeholder, sitting against the dark panel with
+             nothing to say it was an input at all. On an empty notes list the whole app read as a blank screen,
+             so people reasonably assumed the program was broken. Placeholder text plus a submit button on the
+             end, matching TriTalk's message row, so the affordance is visible before you have any notes. -->
+        <BoxContainer Orientation="Horizontal" HorizontalExpand="True" Margin="0 2 0 0">
+            <LineEdit Name="Input"
+                      HorizontalExpand="True"
+                      SetHeight="32"
+                      PlaceHolder="{Loc notekeeper-input-placeholder}"
+                      StyleClasses="OpenRight"/>
+            <Button Name="AddNoteButton"
+                    MinSize="32 32"
+                    SetHeight="32"
+                    Disabled="True"
+                    StyleClasses="OpenLeft"
+                    ToolTip="{Loc notekeeper-add-note}">
+                <!-- plus.svg is 186x186 at 100% ink, so a 16px box renders a 16px glyph. -->
+                <TextureRect StyleClasses="ButtonSquare"
+                             TexturePath="/Textures/Interface/VerbIcons/plus.svg.192dpi.png"
+                             Stretch="KeepAspectCentered"
+                             SetSize="16 16"/>
+            </Button>
+        </BoxContainer>
     </BoxContainer>
 </cartridges:NotekeeperUiFragment>

--- a/Content.Client/CartridgeLoader/Cartridges/NotekeeperUiFragment.xaml.cs
+++ b/Content.Client/CartridgeLoader/Cartridges/NotekeeperUiFragment.xaml.cs
@@ -18,14 +18,30 @@ public sealed partial class NotekeeperUiFragment : BoxContainer
         HorizontalExpand = true;
         VerticalExpand = true;
 
-        Input.OnTextEntered += _ =>
-        {
-            AddNote(Input.Text);
-            OnNoteAdded?.Invoke(Input.Text);
-            Input.Clear();
-        };
+        // Triad: Enter and the button are the same action, and the button greys out until there is something
+        // worth submitting, matching how TriTalk's send row behaves.
+        Input.OnTextEntered += _ => SubmitNote();
+        AddNoteButton.OnPressed += _ => SubmitNote();
+        Input.OnTextChanged += args => AddNoteButton.Disabled = string.IsNullOrWhiteSpace(args.Text);
 
         UpdateState(new List<string>());
+    }
+
+    /// <summary>
+    ///     Triad: commits whatever is in the input box as a note. Was inlined in the OnTextEntered handler, which
+    ///     also meant it stored the raw text: a note of pure whitespace was accepted and became an invisible row.
+    /// </summary>
+    private void SubmitNote()
+    {
+        var note = Input.Text.Trim();
+        if (string.IsNullOrEmpty(note))
+            return;
+
+        AddNote(note);
+        OnNoteAdded?.Invoke(note);
+
+        Input.Clear();
+        AddNoteButton.Disabled = true;
     }
 
     public void UpdateState(List<string> notes)

--- a/Content.Client/PDA/PdaProgramItem.xaml
+++ b/Content.Client/PDA/PdaProgramItem.xaml
@@ -4,7 +4,14 @@
     <PanelContainer Name="Panel"/>
     <BoxContainer Orientation="Horizontal" HorizontalExpand="True" VerticalExpand="True">
         <BoxContainer Orientation="Vertical" VerticalExpand="True" MinWidth="60">
-            <AnimatedTextureRect HorizontalAlignment="Center" VerticalAlignment="Center" VerticalExpand="True" Name="Icon" Access="Public"/>
+            <!-- Triad: pinned to 32x32. This drew each program's icon at whatever its source RSI happened to be,
+                 and cartridge icons are borrowed from all over: Interface/Misc/program_icons.rsi and
+                 _DV/Misc/program_icons.rsi are 48x48, while the ones pointed at an object or a structure sprite
+                 (books, gps, health analyzer, mail, a server, an NFSD airlock) are 32x32. So the program list
+                 rendered some entries half again as large as the others. The list should not depend on every
+                 content author picking a matching RSI size, so the box is fixed here and the texture is scaled
+                 to fit it in PdaProgramItem's constructor. 32 keeps 9 of the 11 current icons pixel-perfect. -->
+            <AnimatedTextureRect HorizontalAlignment="Center" VerticalAlignment="Center" VerticalExpand="True" Name="Icon" Access="Public" SetSize="32 32"/>
         </BoxContainer>
         <BoxContainer Orientation="Vertical" VerticalExpand="True" HorizontalExpand="True" Margin="3 0 0 0">
             <Label Name="ProgramName" Access="Public" VerticalExpand="True" VerticalAlignment="Center" HorizontalAlignment="Left"/>

--- a/Content.Client/PDA/PdaProgramItem.xaml.cs
+++ b/Content.Client/PDA/PdaProgramItem.xaml.cs
@@ -27,6 +27,15 @@ public sealed partial class PdaProgramItem : ContainerButton
     {
         RobustXamlLoader.Load(this);
         Panel.PanelOverride = _styleBox;
+
+        // Triad: scale each icon into the fixed box the XAML gives it, instead of drawing it at its source RSI's
+        // native size. Without this the 48x48 program-icon sheets rendered half again as big as the 32x32 object
+        // sprites the other cartridges borrow. KeepAspectCentered so a non-square icon letterboxes rather than
+        // being squashed. Set here rather than in XAML because both live on the inner DisplayRect.
+        // CanShrink is the load-bearing half: TextureRect measures at its texture's native size unless it is set,
+        // which would floor the control at 48 and quietly defeat the SetSize in the XAML.
+        Icon.DisplayRect.CanShrink = true;
+        Icon.DisplayRect.Stretch = TextureRect.StretchMode.KeepAspectCentered;
     }
 
     protected override void Draw(DrawingHandleScreen handle)

--- a/Content.Client/_DV/CartridgeLoader/Cartridges/NanoChatMessageBubble.xaml.cs
+++ b/Content.Client/_DV/CartridgeLoader/Cartridges/NanoChatMessageBubble.xaml.cs
@@ -23,13 +23,14 @@ public sealed partial class NanoChatMessageBubble : BoxContainer
 
     public void SetMessage(NanoChatMessage message, bool isOwnMessage)
     {
-        if (MessagePanel.PanelOverride is not StyleBoxFlat)
-            return;
-
-        // Configure message appearance
-        var style = (StyleBoxFlat)MessagePanel.PanelOverride;
-        style.BackgroundColor = isOwnMessage ? OwnMessageColor : OtherMessageColor;
-        style.BorderColor = BorderColor;
+        // Triad: this was a bail-out for the whole method, so a panel style that was not a StyleBoxFlat produced a
+        // blank bubble with no text and no alignment rather than an unstyled one. Only the tint depends on the
+        // cast, so only the tint is conditional on it.
+        if (MessagePanel.PanelOverride is StyleBoxFlat style)
+        {
+            style.BackgroundColor = isOwnMessage ? OwnMessageColor : OtherMessageColor;
+            style.BorderColor = BorderColor;
+        }
 
         // Set message content
         MessageText.Text = FormattedMessage.EscapeText(message.Content);

--- a/Content.Client/_DV/CartridgeLoader/Cartridges/NanoChatUi.cs
+++ b/Content.Client/_DV/CartridgeLoader/Cartridges/NanoChatUi.cs
@@ -16,6 +16,11 @@ public sealed partial class NanoChatUi : UIFragment
 
     public override void Setup(BoundUserInterface userInterface, EntityUid? fragmentOwner)
     {
+        // Triad: this UIFragment lives on the cartridge's client component, so it outlives the BoundUserInterface
+        // and Setup runs again on every reopen, binding to the new BUI. Tear the previous fragment down first so it
+        // cannot linger holding its typing-indicator registration or its popup windows.
+        _fragment?.Dispose();
+
         _fragment = new NanoChatUiFragment();
 
         _fragment.OnMessageSent += (type, number, content, job) =>

--- a/Content.Client/_DV/CartridgeLoader/Cartridges/NanoChatUiFragment.xaml
+++ b/Content.Client/_DV/CartridgeLoader/Cartridges/NanoChatUiFragment.xaml
@@ -26,11 +26,16 @@
                              MinSize="32 32"
                              Margin="8 0 0 0" />
                 -->
+                <!-- Triad: removed the TRITALK heading; the PDA program tab already names the app. The label
+                     also doubled as the flexible spacer pushing the number and buttons to the right edge, so a
+                     bare spacer stands in for it.
                 <Label Text="{Loc nano-chat-title}"
                        StyleClasses="LabelHeading"
                        HorizontalExpand="True"
                        Margin="8 0"
                        VerticalAlignment="Center" />
+                -->
+                <Control HorizontalExpand="True" />
                 <Label Name="OwnNumberLabel"
                        Text="#0000"
                        StyleClasses="LabelSubText"

--- a/Content.Client/_DV/CartridgeLoader/Cartridges/NanoChatUiFragment.xaml
+++ b/Content.Client/_DV/CartridgeLoader/Cartridges/NanoChatUiFragment.xaml
@@ -163,13 +163,23 @@
                            StyleClasses="LabelSubText"
                            Margin="0 0 4 2"
                            Visible="False" />
-                    <!-- Triad: typing indicator, shown just above the input row -->
-                    <Label Name="TypingIndicatorLabel"
-                           HorizontalAlignment="Left"
-                           StyleClasses="LabelSubText"
-                           FontColorOverride="#a0a0a0"
-                           Margin="4 0 4 2"
-                           Visible="False" />
+                    <!-- Triad: typing indicator, shown just above the input row. The slot holds its height whether
+                         or not anyone is typing: when the bare label toggled Visible it resized the message
+                         viewport, and since typing always precedes receiving, the shrink landed right before every
+                         incoming message and made the am-I-at-the-bottom check conclude the reader had scrolled
+                         up, so the view never followed received messages. A fixed slot keeps the viewport stable
+                         (and stops the message area jumping when someone starts typing). -->
+                    <Control Name="TypingIndicatorSlot"
+                             MinHeight="20"
+                             Visible="False">
+                        <Label Name="TypingIndicatorLabel"
+                               HorizontalAlignment="Left"
+                               VerticalAlignment="Bottom"
+                               StyleClasses="LabelSubText"
+                               FontColorOverride="#a0a0a0"
+                               Margin="4 0 4 2"
+                               Visible="False" />
+                    </Control>
                     <!-- Message input -->
                     <BoxContainer Name="MessageInputContainer"
                                   Orientation="Horizontal"

--- a/Content.Client/_DV/CartridgeLoader/Cartridges/NanoChatUiFragment.xaml
+++ b/Content.Client/_DV/CartridgeLoader/Cartridges/NanoChatUiFragment.xaml
@@ -130,6 +130,14 @@
                                   VerticalExpand="True"
                                   HorizontalExpand="True"
                                   Margin="0 0 0 4">
+                        <!-- Triad: names the contact whose thread is open. The contact name used to be written
+                             into CurrentChatName below, which is only visible when NO chat is selected, so it
+                             was never actually on screen. -->
+                        <Label Name="ChatHeaderLabel"
+                               HorizontalAlignment="Center"
+                               StyleClasses="LabelSubText"
+                               Margin="0 0 0 3"
+                               Visible="False" />
                         <Label Name="CurrentChatName"
                                Text="{Loc nano-chat-select-chat}"
                                HorizontalAlignment="Center"
@@ -139,8 +147,11 @@
                                          VerticalExpand="True"
                                          HorizontalExpand="True"
                                          Visible="False">
+                            <!-- Triad: SeparationOverride replaces the spacer Control that used to be appended
+                                 after every bubble, which also left a stray gap below the last one. -->
                             <BoxContainer Name="MessageList"
                                           Orientation="Vertical"
+                                          SeparationOverride="4"
                                           VerticalExpand="True"
                                           HorizontalExpand="True" />
                         </ScrollContainer>

--- a/Content.Client/_DV/CartridgeLoader/Cartridges/NanoChatUiFragment.xaml.cs
+++ b/Content.Client/_DV/CartridgeLoader/Cartridges/NanoChatUiFragment.xaml.cs
@@ -440,6 +440,9 @@ public sealed partial class NanoChatUiFragment : BoxContainer
         MessagesScroll.Visible = hasActiveChat;
         CurrentChatName.Visible = !hasActiveChat;
         MessageInputContainer.Visible = hasActiveChat;
+        // Triad: the slot reserves a constant-height row while a conversation is open; only the label inside
+        // toggles with actual typing. See the note in the XAML for why the height must not wobble.
+        TypingIndicatorSlot.Visible = hasActiveChat;
         DeleteChatButton.Visible = hasActiveChat;
         EditChatButton.Visible = hasActiveChat;
         DeleteChatButton.Disabled = !hasActiveChat;

--- a/Content.Client/_DV/CartridgeLoader/Cartridges/NanoChatUiFragment.xaml.cs
+++ b/Content.Client/_DV/CartridgeLoader/Cartridges/NanoChatUiFragment.xaml.cs
@@ -55,6 +55,18 @@ public sealed partial class NanoChatUiFragment : BoxContainer
     private CancellationTokenSource _deferredCts = new();
 
     /// <summary>
+    ///     Triad: how close to the end still counts as "reading the tail", in pixels, when deciding whether new
+    ///     messages should keep scrolling the view down.
+    /// </summary>
+    private const float ScrollBottomTolerance = 8f;
+
+    /// <summary>
+    ///     Triad: which chat the message list currently has bubbles for, so a rebuild can tell "same conversation,
+    ///     keep the player's place" from "different conversation, start at the newest message".
+    /// </summary>
+    private uint? _renderedChat;
+
+    /// <summary>
     ///     The chat the player is looking at: an unconfirmed selection if one is outstanding, otherwise the one
     ///     the server says is current.
     /// </summary>
@@ -316,8 +328,9 @@ public sealed partial class NanoChatUiFragment : BoxContainer
 
         value.Add(predictedMessage);
 
-        // Update UI with predicted message
-        UpdateMessages();
+        // Update UI with predicted message. Triad: sending always jumps to the newest message, even if the player
+        // was reading further up when they hit send.
+        UpdateMessages(forceScrollToBottom: true);
 
         // Triad: a sent message ends our own typing state
         StopTyping();
@@ -429,13 +442,21 @@ public sealed partial class NanoChatUiFragment : BoxContainer
         EditChatButton.Visible = hasActiveChat;
         DeleteChatButton.Disabled = !hasActiveChat;
 
+        // Triad: the placeholder and the header are two different things and upstream conflated them. It wrote the
+        // contact's name into CurrentChatName, which is visible only when NO chat is selected, so the name it went
+        // to the trouble of formatting could never appear on screen. CurrentChatName is the empty-state message
+        // now; ChatHeaderLabel names whoever you are reading.
+        CurrentChatName.Text = Loc.GetString("nano-chat-select-chat");
+
         if (activeChat != null && _recipients.TryGetValue(activeChat.Value, out var recipient))
         {
-            CurrentChatName.Text = recipient.Name + (string.IsNullOrEmpty(recipient.JobTitle) ? "" : $" ({recipient.JobTitle})");
+            ChatHeaderLabel.Text = recipient.Name +
+                                   (string.IsNullOrEmpty(recipient.JobTitle) ? "" : $" ({recipient.JobTitle})");
+            ChatHeaderLabel.Visible = true;
         }
         else
         {
-            CurrentChatName.Text = Loc.GetString("nano-chat-select-chat");
+            ChatHeaderLabel.Visible = false;
         }
     }
 
@@ -443,9 +464,18 @@ public sealed partial class NanoChatUiFragment : BoxContainer
     ///     Rebuilds the message view from <see cref="_messages"/>. See <see cref="UpdateChatList"/> for why this
     ///     no longer takes the collection as a parameter.
     /// </summary>
-    private void UpdateMessages()
+    private void UpdateMessages(bool forceScrollToBottom = false)
     {
+        // Triad: work out where we are BEFORE tearing the list down, while the old layout is still measurable.
+        // Rebuilding resets the scroll, and this method runs on every state -- a mute toggle, a contact rename, a
+        // message in some other conversation -- so unconditionally scrolling to the bottom yanked you out of the
+        // backlog whenever anything at all happened. Follow the tail only if you were already reading the tail.
+        var chatChanged = ActiveChat != _renderedChat;
+        var stickToBottom = forceScrollToBottom || chatChanged || IsScrolledToBottom();
+        var previousScroll = MessagesScroll.GetScrollValue();
+
         MessageList.RemoveAllChildren();
+        _renderedChat = ActiveChat;
 
         if (ActiveChat is not uint activeChat || !_messages.TryGetValue(activeChat, out var chatMessages))
             return;
@@ -454,25 +484,33 @@ public sealed partial class NanoChatUiFragment : BoxContainer
         {
             var messageBubble = new NanoChatMessageBubble();
             messageBubble.SetMessage(message, message.SenderId == _ownNumber);
-            MessageList.AddChild(messageBubble);
-
-            // Add spacing between messages
-            MessageList.AddChild(new Control { MinSize = new Vector2(0, 4) });
+            MessageList.AddChild(messageBubble); // Spacing comes from MessageList's SeparationOverride.
         }
 
         MessageList.InvalidateMeasure();
         MessagesScroll.InvalidateMeasure();
 
-        ScrollToBottom();
+        RestoreScroll(previousScroll, stickToBottom);
     }
 
     /// <summary>
-    ///     Triad: pins the message view to the bottom. Deferred a frame because setting the scroll value
-    ///     right after InvalidateMeasure() reads against the OLD (pre-layout) content height -- most visibly
-    ///     wrong when the typing indicator label above the input box is also changing visibility at the same
-    ///     moment, which shrinks/grows the scroll viewport out from under an immediate scroll call.
+    ///     Triad: whether the message view is scrolled to (or within a few pixels of) the end.
     /// </summary>
-    private void ScrollToBottom()
+    private bool IsScrolledToBottom()
+    {
+        // The furthest we can scroll is however much taller the content is than the window onto it.
+        var maxScroll = MathF.Max(0f, MessageList.Height - MessagesScroll.Height);
+        return MessagesScroll.GetScrollValue().Y >= maxScroll - ScrollBottomTolerance;
+    }
+
+    /// <summary>
+    ///     Triad: re-applies the reading position after the message list is rebuilt, either pinned to the end or
+    ///     back where the player had it. Deferred a frame because setting the scroll value right after
+    ///     InvalidateMeasure() reads against the OLD (pre-layout) content height -- most visibly wrong when the
+    ///     typing indicator label above the input box is also changing visibility at the same moment, which
+    ///     shrinks/grows the scroll viewport out from under an immediate scroll call.
+    /// </summary>
+    private void RestoreScroll(Vector2 previous, bool toBottom)
     {
         Timer.Spawn(TimeSpan.Zero,
             () =>
@@ -480,7 +518,7 @@ public sealed partial class NanoChatUiFragment : BoxContainer
                 if (Disposed)
                     return;
 
-                MessagesScroll.SetScrollValue(new Vector2(0, float.MaxValue));
+                MessagesScroll.SetScrollValue(toBottom ? new Vector2(previous.X, float.MaxValue) : previous);
             },
             _deferredCts.Token);
     }

--- a/Content.Client/_DV/CartridgeLoader/Cartridges/NanoChatUiFragment.xaml.cs
+++ b/Content.Client/_DV/CartridgeLoader/Cartridges/NanoChatUiFragment.xaml.cs
@@ -192,8 +192,10 @@ public sealed partial class NanoChatUiFragment : BoxContainer
         };
         MessageInput.OnTextChanged += args =>
         {
-            var length = args.Text.Length;
-            var isValid = !string.IsNullOrWhiteSpace(args.Text) &&
+            // Triad: measure what would actually be sent, so the button state and the character count agree with
+            // SendMessage's own limit check instead of counting whitespace SendMessage trims away.
+            var length = args.Text.Trim().Length;
+            var isValid = length > 0 &&
                           length <= NanoChatMessage.MaxContentLength &&
                           ActiveChat != null;
 
@@ -305,13 +307,13 @@ public sealed partial class NanoChatUiFragment : BoxContainer
         if (activeChat == null || string.IsNullOrWhiteSpace(MessageInput.Text))
             return;
 
-        var messageContent = MessageInput.Text;
-        if (!string.IsNullOrWhiteSpace(messageContent))
-        {
-            messageContent = messageContent.Trim();
-            if (messageContent.Length > NanoChatMessage.MaxContentLength)
-                messageContent = messageContent[..NanoChatMessage.MaxContentLength];
-        }
+        // Triad: refuse an over-long message rather than silently truncating it. SendButton is disabled past the
+        // limit, but MessageInput.OnTextEntered calls straight in here, so pressing Enter sent a quietly clipped
+        // message while the UI was saying it was too long. The server truncates too, as the backstop for input it
+        // cannot trust; this is the half that has to agree with what the player is being shown.
+        var messageContent = MessageInput.Text.Trim();
+        if (messageContent.Length > NanoChatMessage.MaxContentLength)
+            return;
 
         // Add predicted message
         var predictedMessage = new NanoChatMessage(

--- a/Content.Client/_DV/CartridgeLoader/Cartridges/NanoChatUiFragment.xaml.cs
+++ b/Content.Client/_DV/CartridgeLoader/Cartridges/NanoChatUiFragment.xaml.cs
@@ -1,5 +1,8 @@
 using System.Linq;
 using System.Numerics;
+// Triad: aliased rather than a plain `using System.Threading`, which would make `Timer` ambiguous against
+// Robust.Shared.Timing.Timer.
+using CancellationTokenSource = System.Threading.CancellationTokenSource;
 using Content.Client._DV.NanoChat;
 using Content.Shared._DV.CartridgeLoader.Cartridges;
 using Content.Shared.Access.Components; // Triad: CCVars.MaxNameLength/MaxIdJobLength do not exist here
@@ -44,6 +47,25 @@ public sealed partial class NanoChatUiFragment : BoxContainer
     private int _typingGeneration; // invalidates stale auto-clear timers when a fresher pulse arrives
     // Triad end
 
+    /// <summary>
+    ///     Triad: cancels work scheduled through Timer.Spawn when this fragment leaves the screen. Those callbacks
+    ///     capture the fragment and touch its controls, so without this a PDA closed inside the delay window ends
+    ///     up poking disposed controls.
+    /// </summary>
+    private CancellationTokenSource _deferredCts = new();
+
+    /// <summary>
+    ///     The chat the player is looking at: an unconfirmed selection if one is outstanding, otherwise the one
+    ///     the server says is current.
+    /// </summary>
+    /// <remarks>
+    ///     Triad: this was spelled out as <c>_pendingChat ?? _currentChat</c> at six call sites, and three others
+    ///     (mute, edit, the send-button enable) read <see cref="_currentChat"/> on its own. Those three acted on
+    ///     the previously selected chat when used in the window between clicking a contact and the server
+    ///     confirming it, so muting or renaming right after a click hit the wrong conversation.
+    /// </remarks>
+    private uint? ActiveChat => _pendingChat ?? _currentChat;
+
     public event Action<NanoChatUiMessageType, uint?, string?, string?>? OnMessageSent;
 
     public NanoChatUiFragment()
@@ -55,9 +77,25 @@ public sealed partial class NanoChatUiFragment : BoxContainer
         _editChatPopup = new(MaxNameLength, MaxIdJobLength);
         SetupEventHandlers();
 
-        // Triad: register so the client-side NanoChatSystem can hand us typing-indicator pushes
+        // Triad: held here, but we only hand ourselves to it once we are actually on screen. See EnteredTree.
         _nanoChatSystem = EntitySystem.Get<NanoChatSystem>();
+    }
+
+    // Triad begin: tie the typing-indicator registration and every escapable resource to time-on-screen rather
+    // than to construction. A fragment that is built and never attached must not capture the registration, and one
+    // that leaves the screen must not keep a floating popup, a pending timer, or an unsent "still typing" state.
+    protected override void EnteredTree()
+    {
+        base.EnteredTree();
+
         _nanoChatSystem.RegisterFragment(this);
+    }
+
+    protected override void ExitedTree()
+    {
+        base.ExitedTree();
+
+        Teardown();
     }
 
     protected override void Dispose(bool disposing)
@@ -67,10 +105,29 @@ public sealed partial class NanoChatUiFragment : BoxContainer
         if (!disposing)
             return;
 
-        // Triad: typing indicator cleanup
+        Teardown();
+    }
+
+    /// <summary>
+    ///     Releases everything that can outlive the control: the typing state the server still thinks we are in,
+    ///     our typing-push registration, any deferred callback, and the popup windows. The popups are top-level
+    ///     controls rather than children of this fragment, so nothing else would ever close them.
+    ///     Safe to call more than once, since a detach is normally followed by a dispose.
+    /// </summary>
+    private void Teardown()
+    {
         StopTyping();
         _nanoChatSystem.UnregisterFragment(this);
+
+        // Cancel pending deferred work and arm a fresh token, so a fragment that gets re-attached still works.
+        _deferredCts.Cancel();
+        _deferredCts.Dispose();
+        _deferredCts = new CancellationTokenSource();
+
+        _newChatPopup.Close();
+        _editChatPopup.Close();
     }
+    // Triad end
 
     private void SetupEventHandlers()
     {
@@ -92,15 +149,15 @@ public sealed partial class NanoChatUiFragment : BoxContainer
 
         MuteChatButton.OnPressed += _ =>
         {
-            if (_currentChat is not uint currentChat)
+            if (ActiveChat is not uint activeChat) // Triad: was _currentChat, see ActiveChat
                 return;
 
             // Remove if muted, otherwise add
-            if (!_mutedChats.Remove(currentChat))
-                _mutedChats.Add(currentChat);
+            if (!_mutedChats.Remove(activeChat))
+                _mutedChats.Add(activeChat);
 
             UpdateMuteChatButton();
-            OnMessageSent?.Invoke(NanoChatUiMessageType.ToggleMuteChat, currentChat, null, null);
+            OnMessageSent?.Invoke(NanoChatUiMessageType.ToggleMuteChat, activeChat, null, null);
         };
 
         MuteButton.OnPressed += _ =>
@@ -126,7 +183,7 @@ public sealed partial class NanoChatUiFragment : BoxContainer
             var length = args.Text.Length;
             var isValid = !string.IsNullOrWhiteSpace(args.Text) &&
                           length <= NanoChatMessage.MaxContentLength &&
-                          (_currentChat != null || _pendingChat != null);
+                          ActiveChat != null;
 
             SendButton.Disabled = !isValid;
 
@@ -143,7 +200,7 @@ public sealed partial class NanoChatUiFragment : BoxContainer
             // Triad: typing indicator
             if (string.IsNullOrEmpty(args.Text))
                 StopTyping();
-            else if ((_pendingChat ?? _currentChat) is uint activeChat)
+            else if (ActiveChat is uint activeChat)
                 SendTypingPulse(activeChat);
             // End Triad
         };
@@ -191,41 +248,48 @@ public sealed partial class NanoChatUiFragment : BoxContainer
         Down,
     };
 
+    /// <summary>
+    ///     Moves the selection one contact along, optionally skipping to the next one with unread messages.
+    /// </summary>
+    /// <remarks>
+    ///     Triad: rewritten as a bounded walk. Upstream looped until the index came back around to its starting
+    ///     value, but that starting value was <c>Count</c> when no chat was selected and <c>-1</c> when the
+    ///     selected chat was not in the contact list, and a wrapped index can never equal either. So
+    ///     "cycle to next unread" with nothing unread never terminated and hung the client outright. Easy to hit:
+    ///     a PDA with no conversation selected and the unread keybind pressed.
+    /// </remarks>
     private void CycleChannel(CycleDirection direction, bool onlyUnread)
     {
         if (_recipients.Count == 0)
             return;
 
-        var orderedRecipients = _recipients.OrderBy(r => r.Value.Name).Select(r => r.Key).ToArray();
-        var currentChatIndex = (direction, _currentChat) switch
-        {
-            (CycleDirection.Up, null) => _recipients.Count,
-            (CycleDirection.Down, null) => 0,
-            (_, uint currentChat) => Array.IndexOf(orderedRecipients, currentChat),
-            _ => 0
-        };
-        var newChatIndex = currentChatIndex;
+        var ordered = _recipients.OrderBy(r => r.Value.Name).Select(r => r.Key).ToArray();
 
-        do
+        // -1 when nothing is selected, so the first step lands on either end of the list depending on direction.
+        var index = ActiveChat is uint activeChat ? Array.IndexOf(ordered, activeChat) : -1;
+        var step = direction == CycleDirection.Up ? -1 : 1;
+
+        // At most one full lap: every contact gets considered exactly once, then we stop.
+        for (var i = 0; i < ordered.Length; i++)
         {
-            newChatIndex = direction switch
+            index += step;
+
+            if (index < 0)
+                index = ordered.Length - 1;
+            else if (index >= ordered.Length)
+                index = 0;
+
+            if (!onlyUnread || _recipients[ordered[index]].HasUnread)
             {
-                CycleDirection.Up => newChatIndex - 1,
-                CycleDirection.Down => newChatIndex + 1,
-                _ => currentChatIndex,
-            };
-            if (newChatIndex < 0)
-                newChatIndex = _recipients.Count - 1;
-            else if (newChatIndex >= _recipients.Count)
-                newChatIndex = 0;
-        } while (onlyUnread && newChatIndex != currentChatIndex && !_recipients[orderedRecipients[newChatIndex]].HasUnread);
-
-        SelectChat(orderedRecipients[newChatIndex]);
+                SelectChat(ordered[index]);
+                return;
+            }
+        }
     }
 
     private void SendMessage()
     {
-        var activeChat = _pendingChat ?? _currentChat;
+        var activeChat = ActiveChat;
         if (activeChat == null || string.IsNullOrWhiteSpace(MessageInput.Text))
             return;
 
@@ -253,7 +317,7 @@ public sealed partial class NanoChatUiFragment : BoxContainer
         value.Add(predictedMessage);
 
         // Update UI with predicted message
-        UpdateMessages(_messages);
+        UpdateMessages();
 
         // Triad: a sent message ends our own typing state
         StopTyping();
@@ -268,8 +332,9 @@ public sealed partial class NanoChatUiFragment : BoxContainer
 
     private void SelectChat(uint number)
     {
-        // Don't reselect the same chat
-        if (_currentChat == number && _pendingChat == null)
+        // Don't reselect the chat we are already on. Triad: compares against ActiveChat, so clicking a chat whose
+        // selection is still in flight no longer re-sends the same request.
+        if (ActiveChat == number)
             return;
 
         // Triad: switching threads stops any typing signal we were sending to the old one
@@ -282,7 +347,7 @@ public sealed partial class NanoChatUiFragment : BoxContainer
         {
             recipient.HasUnread = false;
             _recipients[number] = recipient;
-            UpdateChatList(_recipients);
+            UpdateChatList();
         }
 
         OnMessageSent?.Invoke(NanoChatUiMessageType.SelectChat, number, null, null);
@@ -291,7 +356,7 @@ public sealed partial class NanoChatUiFragment : BoxContainer
 
     private void DeleteCurrentChat()
     {
-        var activeChat = _pendingChat ?? _currentChat;
+        var activeChat = ActiveChat;
         if (activeChat == null)
             return;
 
@@ -301,10 +366,10 @@ public sealed partial class NanoChatUiFragment : BoxContainer
 
     private void BeginEditChat()
     {
-        if (_currentChat is not uint currentChat)
+        // Triad: was keyed on _currentChat (see ActiveChat) and indexed _recipients directly, which threw
+        // KeyNotFoundException for a selected chat that is not in the contact list.
+        if (ActiveChat is not uint activeChat || !_recipients.TryGetValue(activeChat, out var recipient))
             return;
-
-        var recipient = _recipients[currentChat];
 
         _editChatPopup.ClearInputs();
         _editChatPopup.SetNumberInput(recipient.Number.ToString());
@@ -313,19 +378,26 @@ public sealed partial class NanoChatUiFragment : BoxContainer
         _editChatPopup.OpenCentered();
     }
 
-    private void UpdateChatList(Dictionary<uint, NanoChatRecipient> recipients)
+    /// <summary>
+    ///     Rebuilds the contact list from <see cref="_recipients"/>.
+    /// </summary>
+    /// <remarks>
+    ///     Triad: took the dictionary as a parameter and assigned it to the field, which is how the fragment ended
+    ///     up holding (and predicting onto) the networked state's own collection. The field is now the single
+    ///     source and <see cref="UpdateState"/> owns filling it.
+    /// </remarks>
+    private void UpdateChatList()
     {
         ChatList.RemoveAllChildren();
-        _recipients = recipients;
 
-        NoChatsLabel.Visible = recipients.Count == 0;
+        NoChatsLabel.Visible = _recipients.Count == 0;
         if (NoChatsLabel.Parent != ChatList)
         {
             NoChatsLabel.Parent?.RemoveChild(NoChatsLabel);
             ChatList.AddChild(NoChatsLabel);
         }
 
-        foreach (var (number, recipient) in recipients.OrderBy(r => r.Value.Name))
+        foreach (var (number, recipient) in _recipients.OrderBy(r => r.Value.Name))
         {
             var entry = new NanoChatEntry(MaxNameLength, MaxIdJobLength);
             // For pending chat selection, always show it as selected even if unconfirmed
@@ -338,7 +410,7 @@ public sealed partial class NanoChatUiFragment : BoxContainer
 
     private void UpdateCurrentChat()
     {
-        var activeChat = _pendingChat ?? _currentChat;
+        var activeChat = ActiveChat;
         var hasActiveChat = activeChat != null;
 
         // Triad: a stale indicator from the previous thread shouldn't follow us to this one
@@ -367,13 +439,15 @@ public sealed partial class NanoChatUiFragment : BoxContainer
         }
     }
 
-    private void UpdateMessages(Dictionary<uint, List<NanoChatMessage>> messages)
+    /// <summary>
+    ///     Rebuilds the message view from <see cref="_messages"/>. See <see cref="UpdateChatList"/> for why this
+    ///     no longer takes the collection as a parameter.
+    /// </summary>
+    private void UpdateMessages()
     {
-        _messages = messages;
         MessageList.RemoveAllChildren();
 
-        var activeChat = _pendingChat ?? _currentChat;
-        if (activeChat == null || !messages.TryGetValue(activeChat.Value, out var chatMessages))
+        if (ActiveChat is not uint activeChat || !_messages.TryGetValue(activeChat, out var chatMessages))
             return;
 
         foreach (var message in chatMessages)
@@ -400,7 +474,15 @@ public sealed partial class NanoChatUiFragment : BoxContainer
     /// </summary>
     private void ScrollToBottom()
     {
-        Timer.Spawn(TimeSpan.Zero, () => MessagesScroll.SetScrollValue(new Vector2(0, float.MaxValue)));
+        Timer.Spawn(TimeSpan.Zero,
+            () =>
+            {
+                if (Disposed)
+                    return;
+
+                MessagesScroll.SetScrollValue(new Vector2(0, float.MaxValue));
+            },
+            _deferredCts.Token);
     }
 
     // Triad begin: typing indicator
@@ -440,8 +522,7 @@ public sealed partial class NanoChatUiFragment : BoxContainer
     /// </summary>
     public void SetTyping(uint senderNumber, bool typing)
     {
-        var activeChat = _pendingChat ?? _currentChat;
-        if (activeChat != senderNumber)
+        if (ActiveChat != senderNumber)
             return;
 
         _typingGeneration++;
@@ -459,14 +540,16 @@ public sealed partial class NanoChatUiFragment : BoxContainer
         var generation = _typingGeneration;
         // Triad: 2x the sender's resend interval -- tolerates one dropped pulse before clearing, without
         // lingering long enough to look stale once they've actually stopped.
-        Timer.Spawn(TimeSpan.FromSeconds(1), () =>
-        {
-            if (generation != _typingGeneration)
-                return; // A fresher pulse (or an explicit stop) already landed; don't clobber it.
+        Timer.Spawn(TimeSpan.FromSeconds(1),
+            () =>
+            {
+                if (Disposed || generation != _typingGeneration)
+                    return; // A fresher pulse (or an explicit stop) already landed; don't clobber it.
 
-            _typingFrom = null;
-            UpdateTypingIndicator();
-        });
+                _typingFrom = null;
+                UpdateTypingIndicator();
+            },
+            _deferredCts.Token);
     }
 
     private void UpdateTypingIndicator()
@@ -492,7 +575,7 @@ public sealed partial class NanoChatUiFragment : BoxContainer
     private void UpdateMuteChatButton()
     {
         if (BellMutedIconContact != null)
-            BellMutedIconContact.Visible = _currentChat is uint currentChat && _mutedChats.Contains(currentChat);
+            BellMutedIconContact.Visible = ActiveChat is uint activeChat && _mutedChats.Contains(activeChat); // Triad: was _currentChat
     }
 
     private void UpdateListNumber()
@@ -515,7 +598,14 @@ public sealed partial class NanoChatUiFragment : BoxContainer
         _notificationsMuted = state.NotificationsMuted;
         _listNumber = state.ListNumber;
         _canList = state.CanList; // Triad
-        _mutedChats = state.MutedChats;
+
+        // Triad: copy out of the state rather than aliasing it. This fragment predicts into these collections
+        // (sent messages, read flags, mute toggles) and the engine caches the state object it handed us, replaying
+        // it into the next BUI -- so predicting onto it wrote fiction into what the client later treats as truth.
+        _mutedChats = new HashSet<uint>(state.MutedChats);
+        _recipients = new Dictionary<uint, NanoChatRecipient>(state.Recipients);
+        _messages = state.Messages.ToDictionary(chat => chat.Key, chat => new List<NanoChatMessage>(chat.Value));
+
         OwnNumberLabel.Text = $"#{state.OwnNumber:D4}";
         UpdateMuteButton();
         UpdateListNumber();
@@ -527,23 +617,18 @@ public sealed partial class NanoChatUiFragment : BoxContainer
             ? Loc.GetString("nano-chat-max-recipients")
             : Loc.GetString("nano-chat-new-chat");
 
-        // First handle pending chat resolution if we have one
-        if (_pendingChat != null)
-        {
-            if (_pendingChat == state.CurrentChat)
-                _currentChat = _pendingChat; // Server confirmed our selection
+        // Triad: hold a pending selection until the server actually confirms it, or until the chat stops existing.
+        // Upstream cleared it on the very next state whatever that state said, so any unrelated update landing in
+        // the gap (an incoming message, a mute toggle) snapped the view back to the previously selected chat.
+        if (_pendingChat is { } pendingChat && (state.CurrentChat == pendingChat || !_recipients.ContainsKey(pendingChat)))
+            _pendingChat = null;
 
-            _pendingChat = null; // Clear pending either way
-        }
-
-        // No pending chat or it was just cleared, update current directly
-        if (_pendingChat == null)
-            _currentChat = state.CurrentChat;
+        _currentChat = state.CurrentChat;
 
         UpdateCurrentChat();
         UpdateMuteChatButton();
-        UpdateChatList(state.Recipients);
-        UpdateMessages(state.Messages);
+        UpdateChatList();
+        UpdateMessages();
         LookupView.UpdateContactList(state);
     }
 }

--- a/Content.Client/_DV/NanoChat/NanoChatSystem.cs
+++ b/Content.Client/_DV/NanoChat/NanoChatSystem.cs
@@ -6,7 +6,15 @@ namespace Content.Client._DV.NanoChat;
 
 public sealed class NanoChatSystem : SharedNanoChatSystem
 {
-    // Triad: only one PDA UI can be open locally at a time, so there is never more than one live listener.
+    /// <summary>
+    ///     The fragment currently attached to the UI tree, if any. Only one PDA UI can be open locally at a time,
+    ///     so there is never more than one on-screen listener.
+    /// </summary>
+    /// <remarks>
+    ///     Triad: registration is driven by the fragment entering and leaving the UI tree, NOT by its constructor.
+    ///     A fragment that was built but never attached must not capture this slot, or typing pushes get delivered
+    ///     to a control nobody can see.
+    /// </remarks>
     private NanoChatUiFragment? _activeFragment;
 
     public override void Initialize()
@@ -22,6 +30,8 @@ public sealed class NanoChatSystem : SharedNanoChatSystem
 
     public void UnregisterFragment(NanoChatUiFragment fragment)
     {
+        // Identity-checked: during a swap the incoming fragment may register before the outgoing one detaches,
+        // and the straggler must not clear the live registration.
         if (_activeFragment == fragment)
             _activeFragment = null;
     }

--- a/Content.Server/CartridgeLoader/CartridgeLoaderSystem.cs
+++ b/Content.Server/CartridgeLoader/CartridgeLoaderSystem.cs
@@ -319,10 +319,13 @@ public sealed partial class CartridgeLoaderSystem : SharedCartridgeLoaderSystem
         if (!HasProgram(loaderUid, cartridgeUid, loader))
             return;
 
+        // Triad: registration is re-run on every PDA reopen (via CartridgeUiReadyEvent), so bail if we already
+        // hold it. Upstream re-raised CartridgeActivatedEvent and appended a duplicate entry each time.
+        if (!loader.BackgroundPrograms.Add(cartridgeUid))
+            return;
+
         if (loader.ActiveProgram != cartridgeUid)
             RaiseLocalEvent(cartridgeUid, new CartridgeActivatedEvent(loaderUid));
-
-        loader.BackgroundPrograms.Add(cartridgeUid);
     }
 
     /// <summary>
@@ -336,10 +339,13 @@ public sealed partial class CartridgeLoaderSystem : SharedCartridgeLoaderSystem
         if (!HasProgram(loaderUid, cartridgeUid, loader))
             return;
 
+        // Triad: mirror of RegisterBackgroundProgram, so an unregister for something never registered is a no-op
+        // rather than a stray CartridgeDeactivatedEvent.
+        if (!loader.BackgroundPrograms.Remove(cartridgeUid))
+            return;
+
         if (loader.ActiveProgram != cartridgeUid)
             RaiseLocalEvent(cartridgeUid, new CartridgeDeactivatedEvent(loaderUid));
-
-        loader.BackgroundPrograms.Remove(cartridgeUid);
     }
 
     public void SendNotification(EntityUid loaderUid, string header, string message, CartridgeLoaderComponent? loader = default!)

--- a/Content.Server/_DV/CartridgeLoader/Cartridges/NanoChatCartridgeComponent.cs
+++ b/Content.Server/_DV/CartridgeLoader/Cartridges/NanoChatCartridgeComponent.cs
@@ -1,4 +1,5 @@
 using Content.Shared.Radio;
+using Robust.Shared.Audio; // Triad: send tones
 using Robust.Shared.Prototypes;
 
 namespace Content.Server._DV.CartridgeLoader.Cartridges;
@@ -17,4 +18,36 @@ public sealed partial class NanoChatCartridgeComponent : Component
     /// </summary>
     [DataField]
     public ProtoId<RadioChannelPrototype> RadioChannel = "Common";
+
+    // Triad begin: send tones.
+    // Both play to the SENDER ONLY, on purpose. Receiving a message already rings the PDA out loud for the whole
+    // room, so making sends audible to bystanders would put two public noises on every exchange, and it would
+    // leak "this person just texted someone" as a stealth signal. That is a balance decision, not polish, so it
+    // stays local until someone decides otherwise: widen the filter in HandleSendMessage if that day comes.
+
+    /// <summary>
+    ///     Played to the sender when a message goes out.
+    /// </summary>
+    /// <remarks>
+    ///     Pulled well below the volume everything else uses for this file (the fax plays it at 0, the hand
+    ///     teleporter and the contraband permit chip at -2). Those are room sounds you hear across a distance for
+    ///     a one-off event; this one plays point blank into the sender's own ears, several times a conversation.
+    /// </remarks>
+    [DataField]
+    public SoundSpecifier? SendSound = new SoundPathSpecifier("/Audio/Machines/high_tech_confirm.ogg")
+    {
+        Params = AudioParams.Default.WithVolume(-8f),
+    };
+
+    /// <summary>
+    ///     Played to the sender when a message could not be delivered, so the failure is audible without having
+    ///     to go back and read the bubble for the "Failed to deliver" line. Kept a couple of dB above
+    ///     <see cref="SendSound"/>, since a failure is the one worth looking up for.
+    /// </summary>
+    [DataField]
+    public SoundSpecifier? SendFailedSound = new SoundPathSpecifier("/Audio/Machines/buzz-two.ogg")
+    {
+        Params = AudioParams.Default.WithVolume(-6f),
+    };
+    // Triad end
 }

--- a/Content.Server/_DV/CartridgeLoader/Cartridges/NanoChatCartridgeSystem.cs
+++ b/Content.Server/_DV/CartridgeLoader/Cartridges/NanoChatCartridgeSystem.cs
@@ -15,6 +15,7 @@ using Content.Shared.Radio.Components;
 using Content.Shared.Silicons.Borgs.Components;
 using Content.Shared.Silicons.StationAi;
 using Robust.Server.Containers;
+using Robust.Shared.Audio.Systems; // Triad: send tones
 using Robust.Shared.Player;
 using Robust.Shared.Prototypes;
 using Robust.Shared.Timing;
@@ -31,6 +32,7 @@ public sealed class NanoChatCartridgeSystem : EntitySystem
     [Dependency] private readonly SharedUserInterfaceSystem _ui = default!;
     [Dependency] private readonly RadioSystem _radio = default!;
     [Dependency] private readonly ContainerSystem _container = default!; // Triad: typing indicator session lookup
+    [Dependency] private readonly SharedAudioSystem _audio = default!; // Triad: send tones
 
     private EntityQuery<PdaComponent> _pdaQuery;
     private EntityQuery<NanoChatCardComponent> _cardQuery;
@@ -523,6 +525,11 @@ public sealed class NanoChatCartridgeSystem : EntitySystem
 
         // Update delivery status
         message = message with { DeliveryFailed = deliveryFailed };
+
+        // Triad: tell the sender, and only the sender, how that went. See the fields for why it stays local.
+        _audio.PlayEntity(deliveryFailed ? cartridge.Comp.SendFailedSound : cartridge.Comp.SendSound,
+            msg.Actor,
+            GetEntity(msg.LoaderUid));
 
         // Store message in sender's outbox under recipient's number
         _nanoChat.AddMessage((card, card.Comp), msg.RecipientNumber.Value, message);

--- a/Content.Server/_DV/CartridgeLoader/Cartridges/NanoChatCartridgeSystem.cs
+++ b/Content.Server/_DV/CartridgeLoader/Cartridges/NanoChatCartridgeSystem.cs
@@ -80,7 +80,7 @@ public sealed class NanoChatCartridgeSystem : EntitySystem
         if (!GetCardEntity(ent, out var nanoChatCard))
             return;
 
-        _nanoChat.SetClosed(nanoChatCard.Value.AsNullable(), !HasComp<NanoChatCartridgeComponent>(args.NewActiveProgram));
+        SetVisible(nanoChatCard.Value, HasComp<NanoChatCartridgeComponent>(args.NewActiveProgram));
     }
 
     private void OnUiOpened(Entity<CartridgeLoaderComponent> ent, ref BoundUIOpenedEvent args)
@@ -92,8 +92,36 @@ public sealed class NanoChatCartridgeSystem : EntitySystem
             return;
 
         if (nanoChatCard.Value.Comp.IsClosed)
-            _nanoChat.SetClosed(nanoChatCard.Value.AsNullable(), !HasComp<NanoChatCartridgeComponent>(ent.Comp.ActiveProgram));
+            SetVisible(nanoChatCard.Value, HasComp<NanoChatCartridgeComponent>(ent.Comp.ActiveProgram));
+    }
 
+    /// <summary>
+    ///     Triad: records whether TriTalk is the program the player can currently see, and marks the thread on
+    ///     screen as read when it becomes visible.
+    /// </summary>
+    /// <remarks>
+    ///     Messages arriving while the PDA is shut now flag the selected chat as unread as well (see
+    ///     <see cref="HandleUnreadNotification"/>), so without clearing it here the badge would survive being
+    ///     looked at. The client cannot do this for us: its SelectChat early-returns on the already-selected chat,
+    ///     so reopening straight into that thread sends no read marker.
+    /// </remarks>
+    private void SetVisible(Entity<NanoChatCardComponent> card, bool visible)
+    {
+        _nanoChat.SetClosed(card.AsNullable(), !visible);
+
+        if (!visible)
+            return;
+
+        if (_nanoChat.GetCurrentChat(card.AsNullable()) is not uint currentChat)
+            return;
+
+        if (_nanoChat.GetRecipient(card.AsNullable(), currentChat) is not { } recipient || !recipient.HasUnread)
+            return;
+
+        // Deliberately no UpdateUIForCard here. Both callers are followed by the loader publishing its own state,
+        // the client rebuilding the fragment and answering with CartridgeUiReadyEvent, which pushes this state
+        // anyway. Writing one here would race the loader's state for the single slot they share under PdaUiKey.
+        _nanoChat.SetRecipient(card.AsNullable(), currentChat, recipient with { HasUnread = false });
     }
 
     private void OnUiClosed(Entity<CartridgeLoaderComponent> ent, ref BoundUIClosedEvent args)
@@ -659,16 +687,23 @@ public sealed class NanoChatCartridgeSystem : EntitySystem
     {
         // Get sender name from contacts or fall back to number
         var recipients = _nanoChat.GetRecipients((recipient, recipient.Comp));
-        var senderName = recipients.TryGetValue(message.SenderId, out var senderRecipient)
-            ? senderRecipient.Name
-            : $"#{message.SenderId:D4}";
+        var hasSenderContact = recipients.TryGetValue(message.SenderId, out var senderRecipient);
+        var senderName = hasSenderContact ? senderRecipient.Name : $"#{message.SenderId:D4}";
         var hasSelectedCurrentChat = _nanoChat.GetCurrentChat((recipient, recipient.Comp)) == senderNumber;
 
-        // Update unread status
-        if (!hasSelectedCurrentChat)
+        // Triad: flag the unread regardless of which chat is selected. CurrentChat is never cleared when the PDA
+        // closes (the client never sends CloseChat, so whoever you last spoke to stays "selected" all round), and
+        // DeliverMessageToRecipient only calls this method when the card is closed OR the thread is not selected.
+        // So the one case upstream's !hasSelectedCurrentChat guard skipped was exactly "a reply from the person you
+        // were last talking to, while the PDA is shut" -- the single most common message in the game. This flag
+        // drives the contact badge, the unread-cycling keybind and the unread count in the notification body, all
+        // three of which read empty because of it.
+        if (hasSenderContact)
+        {
             _nanoChat.SetRecipient((recipient, recipient.Comp),
                 message.SenderId,
                 senderRecipient with { HasUnread = true });
+        }
 
         // Temporary local to avoid trouble with read-only access; Contains doesn't modify the collection
         HashSet<uint> mutedChats = recipient.Comp.MutedChats;

--- a/Content.Server/_DV/CartridgeLoader/Cartridges/NanoChatCartridgeSystem.cs
+++ b/Content.Server/_DV/CartridgeLoader/Cartridges/NanoChatCartridgeSystem.cs
@@ -322,7 +322,9 @@ public sealed class NanoChatCartridgeSystem : EntitySystem
     /// </summary>
     private void HandleSelectChat(Entity<NanoChatCardComponent> card, NanoChatUiMessageEvent msg)
     {
-        if (msg.RecipientNumber == null)
+        // Triad: HandleNewChat already refused your own number, but selecting and sending did not, so a thread
+        // with yourself could still be opened and written to. The UI is not the guard; the client picks the number.
+        if (msg.RecipientNumber == null || msg.RecipientNumber == card.Comp.Number)
             return;
 
         _nanoChat.SetCurrentChat((card, card.Comp), msg.RecipientNumber);
@@ -499,7 +501,10 @@ public sealed class NanoChatCartridgeSystem : EntitySystem
         Entity<NanoChatCardComponent> card,
         NanoChatUiMessageEvent msg)
     {
-        if (msg.RecipientNumber == null || msg.Content == null || card.Comp.Number == null)
+        // Triad: refuse messaging your own number, same reason as HandleSelectChat. Without this the delivery
+        // sweep happily found your own card and posted the message straight back to you.
+        if (msg.RecipientNumber == null || msg.Content == null || card.Comp.Number == null ||
+            msg.RecipientNumber == card.Comp.Number)
             return;
 
         if (!EnsureRecipientExists(card, msg.RecipientNumber.Value))
@@ -822,6 +827,10 @@ public sealed class NanoChatCartridgeSystem : EntitySystem
     {
         List<NanoChatRecipient>? contacts;
 
+        // Triad: the directory should not list the card doing the looking. Upstream swept every registered card
+        // including your own, so you could pick yourself out of the lookup and open a thread with yourself.
+        var selfNumber = _cardQuery.TryComp(ent.Comp.Card, out var ownCard) ? ownCard.Number : null;
+
         if (CanSend(ent) && _radio.HasActiveServer(Transform(ent).MapID, ent.Comp.RadioChannel))
         {
             contacts = [];
@@ -831,7 +840,8 @@ public sealed class NanoChatCartridgeSystem : EntitySystem
             {
                 // Triad: Registered gate added. The directory is a register of legally issued IDs, so a card only
                 // appears if it was handed to a player at spawn. Spares, console printouts and forged cards are out.
-                if (nanoChatCard.Registered && nanoChatCard.ListNumber && nanoChatCard.Number is uint nanoChatNumber && idCardComponent.FullName is string fullName)
+                if (nanoChatCard.Registered && nanoChatCard.ListNumber && nanoChatCard.Number is uint nanoChatNumber && idCardComponent.FullName is string fullName
+                    && nanoChatNumber != selfNumber) // Triad: never list yourself
                 {
                     contacts.Add(new NanoChatRecipient(nanoChatNumber, fullName));
                 }

--- a/Content.Shared/CartridgeLoader/CartridgeLoaderComponent.cs
+++ b/Content.Shared/CartridgeLoader/CartridgeLoaderComponent.cs
@@ -24,10 +24,15 @@ public sealed partial class CartridgeLoaderComponent : Component
     public EntityUid? ActiveProgram = default;
 
     /// <summary>
-    /// The list of programs running in the background, listening to certain events
+    /// The set of programs running in the background, listening to certain events
     /// </summary>
+    /// <remarks>
+    /// Triad: was a List, which let a program register itself more than once (nothing ever unregisters, and
+    /// every PDA reopen re-runs registration). Duplicates delivered every relayed event once per copy, and a
+    /// single Remove only pulled one of them. Membership is the only question asked of this, so it is a set.
+    /// </remarks>
     [ViewVariables]
-    public readonly List<EntityUid> BackgroundPrograms = new();
+    public readonly HashSet<EntityUid> BackgroundPrograms = new();
 
     /// <summary>
     /// The maximum amount of programs that can be installed on the cartridge loader entity

--- a/Content.Shared/_DV/CartridgeLoader/Cartridges/NanoChatUiState.cs
+++ b/Content.Shared/_DV/CartridgeLoader/Cartridges/NanoChatUiState.cs
@@ -1,3 +1,4 @@
+using System.Linq;
 using Robust.Shared.Serialization;
 
 namespace Content.Shared._DV.CartridgeLoader.Cartridges;
@@ -32,9 +33,13 @@ public sealed class NanoChatUiState : BoundUserInterfaceState
         bool listNumber,
         bool canList = false) // Triad
     {
-        Recipients = recipients;
-        Messages = messages;
-        MutedChats = mutedChats;
+        // Triad: snapshot the collections instead of aliasing them. Callers hand us the card component's live
+        // dictionaries, and this state object outlives the call: the UI system retains it, replays it into the
+        // next BoundUserInterface, and compares it against the following state to decide whether anything
+        // changed. Sharing the references let later card mutations rewrite a state that had already been sent.
+        Recipients = new Dictionary<uint, NanoChatRecipient>(recipients);
+        Messages = messages.ToDictionary(chat => chat.Key, chat => new List<NanoChatMessage>(chat.Value));
+        MutedChats = new HashSet<uint>(mutedChats);
         Contacts = contacts;
         CurrentChat = currentChat;
         OwnNumber = ownNumber;

--- a/Resources/Locale/en-US/cartridge-loader/cartridges.ftl
+++ b/Resources/Locale/en-US/cartridge-loader/cartridges.ftl
@@ -2,6 +2,8 @@ device-pda-slot-component-slot-name-cartridge = Cartridge
 
 default-program-name = Program
 notekeeper-program-name = Notekeeper
+notekeeper-input-placeholder = Write a note...
+notekeeper-add-note = Add note
 news-read-program-name = Station news
 
 crew-manifest-program-name = Crew manifest


### PR DESCRIPTION
## About the PR

Went looking for why TriTalk comes up blank after you close and reopen the PDA. The cause was in the shared cartridge loader rather than TriTalk itself, and fixing it shook loose a stack of other UI bugs sitting behind it. All rolled up here, along with a couple of PDA papercuts I hit on the way.

## Why / Balance

`CartridgeLoaderBoundUserInterface.UpdateState` called `RetrieveCartridgeUI` on every loader state. That runs `UIFragment.Setup` and builds a fresh fragment, and then the guard underneath compared fragment *types*, saw a match and bailed out, so the old fragment stayed attached while every later cartridge state went to the new orphaned one. Toggling the PDA light triggers it. So does inserting an ID or a pen. The guard now asks whether the active program actually changed, which is what it was trying to ask in the first place.

Also on the loader: `BackgroundPrograms` was a `List` that accepted duplicates and raised a `CartridgeActivatedEvent` for each one, ratcheting up over a round because a single unregister only removed one entry. It's a `HashSet` now and register/unregister are idempotent. The new fragment gets published before `CartridgeUiReadyEvent` goes out, too, so the server's reply has somewhere to land.

TriTalk had plenty of its own:

- The fragment held the networked state's dictionaries and predicted into them. The engine caches that object and replays it into the next BUI, so prediction was writing fiction into what the client later treats as truth.
- Unread skipped setting `HasUnread` when the message was for your selected chat, which is exactly the closed-PDA case. Hence the permanent zero.
- The typing indicator resized the message viewport when it toggled. Typing happens right before a message lands, so the at-the-bottom check ran against a viewport about 21px short and decided you'd scrolled up. Received messages never followed the tail, sent ones did.
- `CycleChannel` looped until the index came back to its start, but that start is `Count` with nothing selected and `-1` for a chat that isn't in the list, and a wrapped index can't hit either. The unread keybind with no chat open hung the client.
- Mute, edit and the send-button enable read `_currentChat` while everything else read the pending selection, so they acted on the wrong conversation in the gap between clicking a contact and the server confirming it.
- Rebuilding the message list scrolled to the bottom on every state, including states about some other conversation entirely.
- The contact's name was written into a label that's only visible when nothing is selected, so it could never actually show up.
- Enter went straight past the disabled send button and shipped a truncated message while the UI was saying it was too long.
- You could add yourself to your own contacts and message yourself.
- Editing a contact that isn't in the list threw `KeyNotFoundException`.
- Added a quiet tone on send, and a different one when delivery fails. Doubles as the "did that actually leave the PDA" signal that wasn't there before.

PDA side, the app button icons drew at whatever size their RSI canvas happened to be so they came out uneven down the list, and the Notekeeper input was a bare `LineEdit` on a dark panel with no placeholder, which is why an empty notes list read as a broken app.

## Media

I forgor, Just imagine TT but like better here.

## Requirements

- [x] I have read the guidelines and documentation relevant to this PR.
- [ ] I have added media to this PR or it does not require an ingame showcase.
- [x] I can confirm this PR contains either no AI-generated content, or AI-generated content that meets our guidelines.

## How to test

Two PDAs with TriTalk cards. Open the app, close the PDA, leave it a moment and reopen: chats and your real number should come back instead of a blank screen and `#0000`. Have the other PDA message you while yours is shut, and the badge should show a count. Sit at the bottom of a thread and watch a message arrive, it should follow down; scroll up into the backlog and it should hold your place instead.

Then the quick ones: send something and listen for the tone, check your own name isn't in the lookup directory, and press the unread-cycle keybind with no conversation selected (that used to hang the client). Open the PDA app list to see the icons line up, and Notekeeper to see the input actually looks like an input.

## Breaking changes

`CartridgeLoaderComponent.BackgroundPrograms` is now a `HashSet<EntityUid>` instead of a `List<EntityUid>`. Nothing in the tree indexes it by position.

**Changelog**
:cl:
- fix: TriTalk no longer comes up blank or frozen after you close and reopen your PDA.
- fix: TriTalk's unread badge counts messages that arrived while the app was closed, instead of always showing zero.
- fix: The message view follows messages you receive, not just ones you send, and no longer yanks you out of the backlog when something unrelated updates.
- fix: TriTalk names the contact whose conversation you have open.
- fix: You can no longer add yourself as a TriTalk contact or message yourself.
- fix: Pressing Enter on an over-long TriTalk message no longer sends a silently truncated version.
- fix: Using the TriTalk unread-cycle keybind with no conversation open no longer freezes the game.
- add: TriTalk plays a tone when a message sends, and a different one if delivery fails.
- fix: PDA app buttons draw their icons at the same size.
- tweak: The Notekeeper's note box has placeholder text and an add button, so it actually looks like somewhere you can type.
