### PR TITLE
AP Values Examine

### DIFF
--- a/Content.Shared/_Triad/Weapons/Ranged/Components/ProjectileAmmoPenetrationExamineComponent.cs
+++ b/Content.Shared/_Triad/Weapons/Ranged/Components/ProjectileAmmoPenetrationExamineComponent.cs
@@ -1,0 +1,6 @@
+using Robust.Shared.GameStates;
+
+namespace Content.Shared._Triad.Weapons.Ranged.Components;
+
+[RegisterComponent, NetworkedComponent]
+public sealed partial class ProjectileAmmoPenetrationExamineComponent : Component;

--- a/Content.Shared/_Triad/Weapons/Ranged/Systems/TriadGunSystem.Cartridges.cs
+++ b/Content.Shared/_Triad/Weapons/Ranged/Systems/TriadGunSystem.Cartridges.cs
@@ -1,0 +1,64 @@
+using Content.Shared.Damage.Events;
+using Content.Shared.Projectiles;
+using Content.Shared._Triad.Weapons.Ranged.Components;
+using Robust.Shared.Network;
+using Robust.Shared.Prototypes;
+using Content.Shared.Weapons.Ranged.Components;
+
+namespace Content.Shared._Triad.Weapons.Ranged.Systems;
+
+public sealed partial class TriadGunSystem : EntitySystem
+{
+    [Dependency] private IComponentFactory _componentFactory = default!;
+    [Dependency] private IPrototypeManager _prototype = default!;
+    [Dependency] private INetManager _net = default!;
+
+    [SubscribeLocalEvent]
+    private void OnCartridgeDamageExamine(Entity<ProjectileAmmoPenetrationExamineComponent> ent, ref DamageExamineEvent args)
+    {
+        // TODO - Predict
+        if (_net.IsClient)
+            return;
+
+        if (!TryComp<CartridgeAmmoComponent>(ent.Owner, out var cartridge))
+            return;
+
+        var ap = GetProjectileArmorPenetration(cartridge.Prototype);
+
+        var msg = args.Message;
+
+        if (ap == 0f)
+            return;
+
+        var dirtyPercent = Math.Abs(100 * ap);
+        var apPercent = Math.Round(dirtyPercent, 1, MidpointRounding.ToZero);
+
+        msg.AddMarkupOrThrow(Loc.GetString("damage-examine-ap"));
+        msg.PushNewline();
+
+        if (ap > 0)
+        {
+            msg.AddMarkupOrThrow(Loc.GetString("damage-ap-value", ("amount", apPercent)));
+        }
+        else // Negative numbers
+        {
+            msg.AddMarkupOrThrow(Loc.GetString("damage-ap-value-less-effective", ("amount", apPercent)));
+        }
+
+        msg.PushNewline();
+    }
+
+    private float GetProjectileArmorPenetration(EntProtoId proto)
+    {
+        if (!_prototype.TryIndex(proto, out var entityProto))
+            return 0f;
+
+        if (!entityProto.TryComp<ProjectileComponent>(out var projectile, _componentFactory))
+            return 0f;
+
+        if (projectile.IgnoreResistances)
+            return 1f;
+
+        return Math.Min(projectile.ArmorPenetration, 1);
+    }
+}

--- a/Resources/Locale/en-US/_Triad/damage/damage-examine.ftl
+++ b/Resources/Locale/en-US/_Triad/damage/damage-examine.ftl
@@ -1,0 +1,4 @@
+# Damage examines
+damage-examine-ap = It has the following [color=lightgreen]armor penetration[/color] rating:
+damage-ap-value = - It penetrates [color=yellow]{$amount}%[/color] of armor.
+damage-ap-value-less-effective = - It is resisted by armor [color=red]{$amount}%[/color] more.

--- a/Resources/Prototypes/Entities/Objects/Weapons/Guns/Ammunition/Cartridges/base_cartridge.yml
+++ b/Resources/Prototypes/Entities/Objects/Weapons/Guns/Ammunition/Cartridges/base_cartridge.yml
@@ -38,5 +38,6 @@
       path: /Audio/Weapons/Guns/Casings/casing_fall_2.ogg
       params:
         volume: -1
+  - type: ProjectileAmmoPenetrationExamine # Triad
   - type: StaticPrice
     price: 1


### PR DESCRIPTION
## About the PR
ahahha

## Why / Balance
So players can actually compare AP values without code diving

## Media
<img width="390" height="171" alt="image" src="https://github.com/user-attachments/assets/5bef3feb-1b16-4983-8bb6-7e969af475e0" />
<img width="390" height="171" alt="image" src="https://github.com/user-attachments/assets/b0ddfc82-8d7c-474d-8a0f-369b39a61f90" />
<img width="388" height="170" alt="image" src="https://github.com/user-attachments/assets/fd388ec2-766c-4b2d-abf4-05c2aadc04ac" />


## Requirements
<!-- Confirm the following by placing an X in the brackets [X]: -->
- [x] I have read the guidelines and documentation relevant to this PR.
- [x] I have added media to this PR or it does not require an ingame showcase.
- [x] I can confirm this PR contains either no AI-generated content, or AI-generated content that meets our guidelines.
<!-- You should understand that not following the above may get your PR closed at maintainer’s discretion -->
<!-- When using AI, make sure you are already proficient in creating whatever content you are attempting to generate and that you already have experience contributing to SS14. This means using AI to enhance your preexisting workflow, not vibecoding. -->

**Changelog**
:cl:
- add: Added armor-penetration values can now be seen on a cartridge's examine text