### PR TITLE
Fix/Ship Save Serialization

### DIFF
--- a/Content.IntegrationTests/Tests/_Triad/Shipyard/FlatpackerSaveTest.cs
+++ b/Content.IntegrationTests/Tests/_Triad/Shipyard/FlatpackerSaveTest.cs
@@ -14,21 +14,21 @@ using Robust.Shared.EntitySerialization;
 using Robust.Shared.EntitySerialization.Systems;
 using Robust.Shared.GameObjects;
 using Robust.Shared.Map;
+using Robust.Shared.Prototypes;
 
 namespace Content.IntegrationTests.Tests._Triad.Shipyard;
 
 /// <summary>
-/// Establishes whether the flatpacker is actually unsaveable, or merely listed as unsaveable.
+/// Guards the flatpacker's re-enablement for ship saving.
 ///
-/// It carries SavingContraband, so the ship save deletes it before serializing. It has carried some
-/// form of that exclusion since HardLight PR #876 (2026-04-07), where it was added to a list captioned
-/// "obvious non-ship entities" under the heading "Uplinks and bundled items", inside a commit about an
-/// unrelated MindContainer bug. It was migrated to the component by 227d5f6ab5, whose own comment says
-/// the list mixes entries that are "illegal to own" with entries "causing problems with ship saving"
-/// and does not say which any given entry is. No technical reason is recorded anywhere.
+/// It was excluded with no technical justification on record. It entered the exclusion list in
+/// HardLight PR #876 (2e07876006, 2026-04-07) captioned "obvious non-ship entities", under the heading
+/// "Uplinks and bundled items", next to mercenary uplinks and criminal-records computers, inside a
+/// commit about an unrelated MindContainer bug. 227d5f6ab5 migrated it to the SavingContraband
+/// component, and that commit's own comment concedes the list mixes entries that are "illegal to own"
+/// with entries "causing problems with ship saving" without recording which any entry is.
 ///
-/// So this asks the machine directly: strip the marker, put the thing in the messiest realistic state
-/// it can reach, and run the real save path over it.
+/// Asking the machine settled it: it saves and loads fine. These tests keep it that way.
 /// </summary>
 [TestFixture]
 [TestOf(typeof(ShipyardGridSaveSystem))]
@@ -39,43 +39,30 @@ public sealed class FlatpackerSaveTest
     private const string SiloProtoId = "MachineMaterialSilo";
 
     /// <summary>
-    /// The flatpacker is deleted by the purge before serialization even starts, and this pins the
-    /// mechanism: the SavingContraband test in IsInvalidEntity runs BEFORE the anchored and
-    /// static-body checks that would otherwise preserve a machine, so being anchored does not save it.
+    /// The machine and its board must BOTH stay un-marked. The board carried its own SavingContraband
+    /// from the same commit, and because the contraband test in IsInvalidEntity precedes the
+    /// IsInsidePersistentStorage check that preserves a machine's slot contents, re-marking only the
+    /// board is enough to bring back a flatpacker that saves and loads with an empty slot.
+    ///
+    /// That ordering is deliberate and correct, not a defect: a deny rule has to beat the keep rules,
+    /// or contraband could be smuggled by anchoring it or dropping it in a machine. Which is exactly
+    /// why the marker must not be on things that are not contraband.
     /// </summary>
     [Test]
-    public async Task FlatpackerIsPurgedFromShipSavesToday()
+    public async Task NeitherFlatpackerNorItsBoardIsSaveContraband()
     {
         await using var pair = await PoolManager.GetServerClient();
         var server = pair.Server;
-        var entMan = server.EntMan;
-        var saveSystem = entMan.System<ShipyardGridSaveSystem>();
-
-        var map = await pair.CreateTestMap();
-
-        EntityUid flatpacker = default;
-        await server.WaitPost(() => flatpacker = SpawnAnchored(entMan, FlatpackerProtoId, map));
+        var protoMan = server.ResolveDependency<IPrototypeManager>();
 
         await server.WaitAssertion(() =>
         {
             Assert.Multiple(() =>
             {
-                Assert.That(entMan.HasComponent<SavingContrabandComponent>(flatpacker), Is.True,
-                    "Fixture: the flatpacker is expected to carry the marker. If this fails it has already been re-enabled.");
-                Assert.That(entMan.GetComponent<TransformComponent>(flatpacker).Anchored, Is.True,
-                    "Fixture: anchored, which is what would normally preserve a machine through the purge.");
-            });
-        });
-
-        await server.WaitAssertion(() =>
-        {
-            Assert.That(saveSystem.TryBuildShipSaveYaml(map.Grid.Owner, out var yaml, out _), Is.True);
-            Assert.Multiple(() =>
-            {
-                Assert.That(entMan.Deleted(flatpacker), Is.True,
-                    "The marker should delete it despite being anchored: the contraband test precedes the anchor test.");
-                Assert.That(yaml, Does.Not.Contain(FlatpackerProtoId),
-                    "A purged flatpacker must not appear in the save.");
+                Assert.That(HasContraband(protoMan, FlatpackerProtoId), Is.False,
+                    $"{FlatpackerProtoId} is marked SavingContraband again, so it is purged from every ship save.");
+                Assert.That(HasContraband(protoMan, BoardProtoId), Is.False,
+                    $"{BoardProtoId} is marked SavingContraband again, so a saved flatpacker loads with an empty board slot.");
             });
         });
 
@@ -83,14 +70,12 @@ public sealed class FlatpackerSaveTest
     }
 
     /// <summary>
-    /// The actual question. With the marker removed, a flatpacker holding a board, carrying stored
-    /// materials, mid-pack, and pointed at an ore silo on another grid is saved and loaded back. Every
-    /// one of those is a state the machine reaches in normal play, and the ore silo link is the one
-    /// with real teeth: it is an EntityUid DataField that can point off the grid, the same shape that
-    /// made DeviceLinkSource the top cause of failed saves.
+    /// The round trip, in the messiest realistic state the machine reaches: a board in the slot, stored
+    /// materials, mid-pack, and an ore silo link pointing off the grid. Every one of those is normal
+    /// play. The silo link is the one with teeth, and it is covered in its own right by OreSiloSaveTest.
     /// </summary>
     [Test]
-    public async Task FlatpackerSavesCleanlyOnceTheMarkerIsRemoved()
+    public async Task LoadedFlatpackerSurvivesSaveAndLoad()
     {
         await using var pair = await PoolManager.GetServerClient();
         var server = pair.Server;
@@ -107,31 +92,19 @@ public sealed class FlatpackerSaveTest
         {
             flatpacker = SpawnAnchored(entMan, FlatpackerProtoId, map);
 
-            // Re-enabling the flatpacker means deleting the SavingContraband lines from its prototype.
-            // Doing it at runtime keeps the test honest about what the change would actually be.
-            entMan.RemoveComponent<SavingContrabandComponent>(flatpacker);
-
-            // A board sitting in the slot, which is how the machine spends most of its working life.
-            // The board carries its OWN marker and needs its own removal; see the test below.
             board = entMan.SpawnEntity(BoardProtoId, map.GridCoords);
-            entMan.RemoveComponent<SavingContrabandComponent>(board);
-            var slot = containers.GetContainer(flatpacker, "board_slot");
-            containers.Insert(board, slot);
+            containers.Insert(board, containers.GetContainer(flatpacker, "board_slot"));
 
-            // Stored materials.
             materials.TryChangeMaterialAmount(flatpacker, "Steel", 900);
             materials.TryChangeMaterialAmount(flatpacker, "Glass", 300);
 
-            // Mid-pack, so the runtime packing state is non-default when the writer sees it.
-            var creator = entMan.GetComponent<FlatpackCreatorComponent>(flatpacker);
-
-            // An ore silo on the map rather than the grid: a live EntityUid the save set cannot contain.
             silo = entMan.SpawnEntity(SiloProtoId, new MapCoordinates(new Vector2(6, 6), map.MapId));
 
-            // These four members are [Access]-restricted to their owning systems. Reaching past that is
-            // the point here: the test has to put the component into a state the writer will see, and
-            // going through the systems would mean driving a real pack job and a real silo link.
+            // Packing state and the silo link are [Access]-restricted to their owning systems. Driving
+            // them through those systems would mean running a real pack job and a real link handshake;
+            // the state is what matters here, not how it got there.
 #pragma warning disable RA0002
+            var creator = entMan.GetComponent<FlatpackCreatorComponent>(flatpacker);
             creator.Packing = true;
             creator.PackEndTime = System.TimeSpan.FromMinutes(5);
             entMan.EnsureComponent<OreSiloClientComponent>(flatpacker).Silo = silo;
@@ -143,12 +116,11 @@ public sealed class FlatpackerSaveTest
         {
             Assert.Multiple(() =>
             {
-                Assert.That(entMan.GetComponent<TransformComponent>(silo).GridUid, Is.Not.EqualTo(map.Grid.Owner),
-                    "Fixture: the silo must be off the grid for the reference to be the interesting kind.");
+                Assert.That(entMan.Deleted(flatpacker), Is.False, "Fixture: the flatpacker was already gone.");
                 Assert.That(containers.GetContainer(flatpacker, "board_slot").ContainedEntities, Is.Not.Empty,
                     "Fixture: the board did not go into the slot.");
-                Assert.That(entMan.GetComponent<MaterialStorageComponent>(flatpacker).Storage, Is.Not.Empty,
-                    "Fixture: no materials were stored.");
+                Assert.That(entMan.GetComponent<TransformComponent>(silo).GridUid, Is.Not.EqualTo(map.Grid.Owner),
+                    "Fixture: the silo must be off-grid for the link to be the interesting kind.");
             });
         });
 
@@ -157,10 +129,14 @@ public sealed class FlatpackerSaveTest
         {
             Assert.That(saveSystem.TryBuildShipSaveYaml(map.Grid.Owner, out yaml, out _), Is.True,
                 "The save refused the grid outright.");
-            Assert.That(entMan.Deleted(flatpacker), Is.False,
-                "Without the marker the flatpacker should survive the purge: it is anchored and static-bodied.");
-            Assert.That(yaml, Does.Contain(FlatpackerProtoId),
-                "The flatpacker should be present in the save now that it is not contraband.");
+            Assert.Multiple(() =>
+            {
+                Assert.That(entMan.Deleted(flatpacker), Is.False,
+                    "The flatpacker should survive the purge: it is anchored, static-bodied and no longer contraband.");
+                Assert.That(entMan.Deleted(board), Is.False,
+                    "The board should survive inside the machine slot.");
+                Assert.That(yaml, Does.Contain(FlatpackerProtoId), "The flatpacker should be in the save.");
+            });
         });
 
         await server.WaitAssertion(() =>
@@ -188,55 +164,12 @@ public sealed class FlatpackerSaveTest
         await pair.CleanReturnAsync();
     }
 
-    /// <summary>
-    /// The gotcha for anyone re-enabling this: FlatpackerMachineCircuitboard carries its own
-    /// SavingContraband, declared in the same commit with the same examine text. Un-marking only the
-    /// machine gets you a flatpacker that saves and loads with an empty board slot, because the
-    /// contraband test in IsInvalidEntity precedes the IsInsidePersistentStorage check that would
-    /// otherwise preserve a machine's slot contents. Re-enabling the flatpacker means un-marking both.
-    /// </summary>
-    [Test]
-    public async Task BoardIsPurgedSeparatelyWhenOnlyTheMachineIsUnmarked()
+    private static bool HasContraband(IPrototypeManager protoMan, string protoId)
     {
-        await using var pair = await PoolManager.GetServerClient();
-        var server = pair.Server;
-        var entMan = server.EntMan;
-        var saveSystem = entMan.System<ShipyardGridSaveSystem>();
-        var containers = entMan.System<SharedContainerSystem>();
+        Assert.That(protoMan.TryIndex<EntityPrototype>(protoId, out var proto), Is.True,
+            $"Prototype {protoId} does not exist, so this guard is testing nothing.");
 
-        var map = await pair.CreateTestMap();
-
-        EntityUid flatpacker = default, board = default;
-        await server.WaitPost(() =>
-        {
-            flatpacker = SpawnAnchored(entMan, FlatpackerProtoId, map);
-            entMan.RemoveComponent<SavingContrabandComponent>(flatpacker);
-
-            // Deliberately left marked.
-            board = entMan.SpawnEntity(BoardProtoId, map.GridCoords);
-            containers.Insert(board, containers.GetContainer(flatpacker, "board_slot"));
-        });
-
-        await server.WaitAssertion(() =>
-        {
-            Assert.That(entMan.HasComponent<SavingContrabandComponent>(board), Is.True,
-                "Fixture: the board is expected to carry its own marker.");
-        });
-
-        await server.WaitAssertion(() =>
-        {
-            Assert.That(saveSystem.TryBuildShipSaveYaml(map.Grid.Owner, out _, out _), Is.True);
-            Assert.Multiple(() =>
-            {
-                Assert.That(entMan.Deleted(flatpacker), Is.False, "The un-marked machine should survive.");
-                Assert.That(entMan.Deleted(board), Is.True,
-                    "The board should still be purged out of the slot on its own marker.");
-                Assert.That(containers.GetContainer(flatpacker, "board_slot").ContainedEntities, Is.Empty,
-                    "Which leaves the surviving flatpacker with an empty slot.");
-            });
-        });
-
-        await pair.CleanReturnAsync();
+        return proto!.Components.ContainsKey("SavingContraband");
     }
 
     /// <summary>

--- a/Content.IntegrationTests/Tests/_Triad/Shipyard/FlatpackerSaveTest.cs
+++ b/Content.IntegrationTests/Tests/_Triad/Shipyard/FlatpackerSaveTest.cs
@@ -2,6 +2,8 @@
 //
 // SPDX-License-Identifier: AGPL-3.0-or-later
 
+#nullable enable
+
 using System.Linq;
 using System.Numerics;
 using Content.Server._Triad.Shipyard;

--- a/Content.IntegrationTests/Tests/_Triad/Shipyard/FlatpackerSaveTest.cs
+++ b/Content.IntegrationTests/Tests/_Triad/Shipyard/FlatpackerSaveTest.cs
@@ -1,0 +1,256 @@
+// SPDX-FileCopyrightText: 2026 Triad Sector contributors
+//
+// SPDX-License-Identifier: AGPL-3.0-or-later
+
+using System.Linq;
+using System.Numerics;
+using Content.Server._Triad.Shipyard;
+using Content.Shared._Triad.Shipyard.Save.Contraband;
+using Content.Shared.Construction.Components;
+using Content.Shared.Materials;
+using Content.Shared.Materials.OreSilo;
+using Robust.Shared.Containers;
+using Robust.Shared.EntitySerialization;
+using Robust.Shared.EntitySerialization.Systems;
+using Robust.Shared.GameObjects;
+using Robust.Shared.Map;
+
+namespace Content.IntegrationTests.Tests._Triad.Shipyard;
+
+/// <summary>
+/// Establishes whether the flatpacker is actually unsaveable, or merely listed as unsaveable.
+///
+/// It carries SavingContraband, so the ship save deletes it before serializing. It has carried some
+/// form of that exclusion since HardLight PR #876 (2026-04-07), where it was added to a list captioned
+/// "obvious non-ship entities" under the heading "Uplinks and bundled items", inside a commit about an
+/// unrelated MindContainer bug. It was migrated to the component by 227d5f6ab5, whose own comment says
+/// the list mixes entries that are "illegal to own" with entries "causing problems with ship saving"
+/// and does not say which any given entry is. No technical reason is recorded anywhere.
+///
+/// So this asks the machine directly: strip the marker, put the thing in the messiest realistic state
+/// it can reach, and run the real save path over it.
+/// </summary>
+[TestFixture]
+[TestOf(typeof(ShipyardGridSaveSystem))]
+public sealed class FlatpackerSaveTest
+{
+    private const string FlatpackerProtoId = "MachineFlatpacker";
+    private const string BoardProtoId = "FlatpackerMachineCircuitboard";
+    private const string SiloProtoId = "MachineMaterialSilo";
+
+    /// <summary>
+    /// The flatpacker is deleted by the purge before serialization even starts, and this pins the
+    /// mechanism: the SavingContraband test in IsInvalidEntity runs BEFORE the anchored and
+    /// static-body checks that would otherwise preserve a machine, so being anchored does not save it.
+    /// </summary>
+    [Test]
+    public async Task FlatpackerIsPurgedFromShipSavesToday()
+    {
+        await using var pair = await PoolManager.GetServerClient();
+        var server = pair.Server;
+        var entMan = server.EntMan;
+        var saveSystem = entMan.System<ShipyardGridSaveSystem>();
+
+        var map = await pair.CreateTestMap();
+
+        EntityUid flatpacker = default;
+        await server.WaitPost(() => flatpacker = SpawnAnchored(entMan, FlatpackerProtoId, map));
+
+        await server.WaitAssertion(() =>
+        {
+            Assert.Multiple(() =>
+            {
+                Assert.That(entMan.HasComponent<SavingContrabandComponent>(flatpacker), Is.True,
+                    "Fixture: the flatpacker is expected to carry the marker. If this fails it has already been re-enabled.");
+                Assert.That(entMan.GetComponent<TransformComponent>(flatpacker).Anchored, Is.True,
+                    "Fixture: anchored, which is what would normally preserve a machine through the purge.");
+            });
+        });
+
+        await server.WaitAssertion(() =>
+        {
+            Assert.That(saveSystem.TryBuildShipSaveYaml(map.Grid.Owner, out var yaml, out _), Is.True);
+            Assert.Multiple(() =>
+            {
+                Assert.That(entMan.Deleted(flatpacker), Is.True,
+                    "The marker should delete it despite being anchored: the contraband test precedes the anchor test.");
+                Assert.That(yaml, Does.Not.Contain(FlatpackerProtoId),
+                    "A purged flatpacker must not appear in the save.");
+            });
+        });
+
+        await pair.CleanReturnAsync();
+    }
+
+    /// <summary>
+    /// The actual question. With the marker removed, a flatpacker holding a board, carrying stored
+    /// materials, mid-pack, and pointed at an ore silo on another grid is saved and loaded back. Every
+    /// one of those is a state the machine reaches in normal play, and the ore silo link is the one
+    /// with real teeth: it is an EntityUid DataField that can point off the grid, the same shape that
+    /// made DeviceLinkSource the top cause of failed saves.
+    /// </summary>
+    [Test]
+    public async Task FlatpackerSavesCleanlyOnceTheMarkerIsRemoved()
+    {
+        await using var pair = await PoolManager.GetServerClient();
+        var server = pair.Server;
+        var entMan = server.EntMan;
+        var saveSystem = entMan.System<ShipyardGridSaveSystem>();
+        var containers = entMan.System<SharedContainerSystem>();
+        var materials = entMan.System<SharedMaterialStorageSystem>();
+        var mapLoader = entMan.System<MapLoaderSystem>();
+
+        var map = await pair.CreateTestMap();
+
+        EntityUid flatpacker = default, board = default, silo = default;
+        await server.WaitPost(() =>
+        {
+            flatpacker = SpawnAnchored(entMan, FlatpackerProtoId, map);
+
+            // Re-enabling the flatpacker means deleting the SavingContraband lines from its prototype.
+            // Doing it at runtime keeps the test honest about what the change would actually be.
+            entMan.RemoveComponent<SavingContrabandComponent>(flatpacker);
+
+            // A board sitting in the slot, which is how the machine spends most of its working life.
+            // The board carries its OWN marker and needs its own removal; see the test below.
+            board = entMan.SpawnEntity(BoardProtoId, map.GridCoords);
+            entMan.RemoveComponent<SavingContrabandComponent>(board);
+            var slot = containers.GetContainer(flatpacker, "board_slot");
+            containers.Insert(board, slot);
+
+            // Stored materials.
+            materials.TryChangeMaterialAmount(flatpacker, "Steel", 900);
+            materials.TryChangeMaterialAmount(flatpacker, "Glass", 300);
+
+            // Mid-pack, so the runtime packing state is non-default when the writer sees it.
+            var creator = entMan.GetComponent<FlatpackCreatorComponent>(flatpacker);
+
+            // An ore silo on the map rather than the grid: a live EntityUid the save set cannot contain.
+            silo = entMan.SpawnEntity(SiloProtoId, new MapCoordinates(new Vector2(6, 6), map.MapId));
+
+            // These four members are [Access]-restricted to their owning systems. Reaching past that is
+            // the point here: the test has to put the component into a state the writer will see, and
+            // going through the systems would mean driving a real pack job and a real silo link.
+#pragma warning disable RA0002
+            creator.Packing = true;
+            creator.PackEndTime = System.TimeSpan.FromMinutes(5);
+            entMan.EnsureComponent<OreSiloClientComponent>(flatpacker).Silo = silo;
+            entMan.EnsureComponent<OreSiloComponent>(silo).Clients.Add(flatpacker);
+#pragma warning restore RA0002
+        });
+
+        await server.WaitAssertion(() =>
+        {
+            Assert.Multiple(() =>
+            {
+                Assert.That(entMan.GetComponent<TransformComponent>(silo).GridUid, Is.Not.EqualTo(map.Grid.Owner),
+                    "Fixture: the silo must be off the grid for the reference to be the interesting kind.");
+                Assert.That(containers.GetContainer(flatpacker, "board_slot").ContainedEntities, Is.Not.Empty,
+                    "Fixture: the board did not go into the slot.");
+                Assert.That(entMan.GetComponent<MaterialStorageComponent>(flatpacker).Storage, Is.Not.Empty,
+                    "Fixture: no materials were stored.");
+            });
+        });
+
+        string? yaml = null;
+        await server.WaitAssertion(() =>
+        {
+            Assert.That(saveSystem.TryBuildShipSaveYaml(map.Grid.Owner, out yaml, out _), Is.True,
+                "The save refused the grid outright.");
+            Assert.That(entMan.Deleted(flatpacker), Is.False,
+                "Without the marker the flatpacker should survive the purge: it is anchored and static-bodied.");
+            Assert.That(yaml, Does.Contain(FlatpackerProtoId),
+                "The flatpacker should be present in the save now that it is not contraband.");
+        });
+
+        await server.WaitAssertion(() =>
+        {
+            var opts = new MapLoadOptions { MergeMap = map.MapId, Offset = new Vector2(100, 100) };
+            Assert.That(mapLoader.TryLoadGeneric(new System.IO.StringReader(yaml!), "flatpacker-save-test", out var loaded, opts),
+                Is.True, "The saved ship did not load back.");
+
+            var loadedFlatpackers = loaded!.Entities
+                .Where(e => entMan.HasComponent<FlatpackCreatorComponent>(e))
+                .ToList();
+
+            Assert.That(loadedFlatpackers, Has.Count.EqualTo(1), "Exactly one flatpacker should come back.");
+
+            var uid = loadedFlatpackers[0];
+            Assert.Multiple(() =>
+            {
+                Assert.That(entMan.GetComponent<MaterialStorageComponent>(uid).Storage["Steel"], Is.EqualTo(900),
+                    "Stored materials should survive the round trip.");
+                Assert.That(containers.GetContainer(uid, "board_slot").ContainedEntities, Has.Count.EqualTo(1),
+                    "The board in the slot should survive the round trip.");
+            });
+        });
+
+        await pair.CleanReturnAsync();
+    }
+
+    /// <summary>
+    /// The gotcha for anyone re-enabling this: FlatpackerMachineCircuitboard carries its own
+    /// SavingContraband, declared in the same commit with the same examine text. Un-marking only the
+    /// machine gets you a flatpacker that saves and loads with an empty board slot, because the
+    /// contraband test in IsInvalidEntity precedes the IsInsidePersistentStorage check that would
+    /// otherwise preserve a machine's slot contents. Re-enabling the flatpacker means un-marking both.
+    /// </summary>
+    [Test]
+    public async Task BoardIsPurgedSeparatelyWhenOnlyTheMachineIsUnmarked()
+    {
+        await using var pair = await PoolManager.GetServerClient();
+        var server = pair.Server;
+        var entMan = server.EntMan;
+        var saveSystem = entMan.System<ShipyardGridSaveSystem>();
+        var containers = entMan.System<SharedContainerSystem>();
+
+        var map = await pair.CreateTestMap();
+
+        EntityUid flatpacker = default, board = default;
+        await server.WaitPost(() =>
+        {
+            flatpacker = SpawnAnchored(entMan, FlatpackerProtoId, map);
+            entMan.RemoveComponent<SavingContrabandComponent>(flatpacker);
+
+            // Deliberately left marked.
+            board = entMan.SpawnEntity(BoardProtoId, map.GridCoords);
+            containers.Insert(board, containers.GetContainer(flatpacker, "board_slot"));
+        });
+
+        await server.WaitAssertion(() =>
+        {
+            Assert.That(entMan.HasComponent<SavingContrabandComponent>(board), Is.True,
+                "Fixture: the board is expected to carry its own marker.");
+        });
+
+        await server.WaitAssertion(() =>
+        {
+            Assert.That(saveSystem.TryBuildShipSaveYaml(map.Grid.Owner, out _, out _), Is.True);
+            Assert.Multiple(() =>
+            {
+                Assert.That(entMan.Deleted(flatpacker), Is.False, "The un-marked machine should survive.");
+                Assert.That(entMan.Deleted(board), Is.True,
+                    "The board should still be purged out of the slot on its own marker.");
+                Assert.That(containers.GetContainer(flatpacker, "board_slot").ContainedEntities, Is.Empty,
+                    "Which leaves the surviving flatpacker with an empty slot.");
+            });
+        });
+
+        await pair.CleanReturnAsync();
+    }
+
+    /// <summary>
+    /// The flatpacker prototype already sets Transform.anchored, so it spawns anchored onto the test
+    /// grid. Anchoring it a second time trips a debug assert inside AddToSnapGridCell rather than
+    /// no-opping, so only anchor if the spawn did not.
+    /// </summary>
+    private static EntityUid SpawnAnchored(IEntityManager entMan, string protoId, Robust.UnitTesting.Pool.TestMapData map)
+    {
+        var uid = entMan.SpawnEntity(protoId, map.GridCoords);
+
+        if (!entMan.GetComponent<TransformComponent>(uid).Anchored)
+            entMan.System<SharedTransformSystem>().AnchorEntity(uid);
+
+        return uid;
+    }
+}

--- a/Content.IntegrationTests/Tests/_Triad/Shipyard/OreSiloSaveTest.cs
+++ b/Content.IntegrationTests/Tests/_Triad/Shipyard/OreSiloSaveTest.cs
@@ -1,0 +1,192 @@
+// SPDX-FileCopyrightText: 2026 Triad Sector contributors
+//
+// SPDX-License-Identifier: AGPL-3.0-or-later
+
+using System.Linq;
+using System.Numerics;
+using Content.Server._Triad.Shipyard;
+using Content.Shared.Materials.OreSilo;
+using Robust.Shared.EntitySerialization;
+using Robust.Shared.EntitySerialization.Systems;
+using Robust.Shared.GameObjects;
+using Robust.Shared.Map;
+
+namespace Content.IntegrationTests.Tests._Triad.Shipyard;
+
+/// <summary>
+/// The ore-silo link used to persist BOTH halves: OreSiloClientComponent.Silo and
+/// OreSiloComponent.Clients were each a DataField. A ship save carries whichever half sits on the
+/// grid, so a silo saved without its clients, or a client saved without its silo, deserialized a uid
+/// that resolves to entity 0. Every downstream lookup then logged a resolve error with a full stack
+/// trace, which is where the prod "invalid EntityUid reference ... component: OreSilo" lines came
+/// from, and one of the guards written against it recorded millions of errors a day.
+///
+/// The subsystem had accumulated six defensive Exists() checks at the read sites. Only the client
+/// half is persisted now; the silo's client set is rebuilt from it on ComponentStartup, which is the
+/// same shape the engine uses for DeviceLinkSinkComponent.LinkedSources. The save additionally clears
+/// links whose silo is not coming along, so the file never contains an unresolvable reference at all.
+///
+/// These two tests pin both halves of that: the normal case still works, and the boundary case is
+/// severed cleanly rather than written and cleaned up afterwards.
+/// </summary>
+[TestFixture]
+[TestOf(typeof(SharedOreSiloSystem))]
+public sealed class OreSiloSaveTest
+{
+    private const string SiloProtoId = "MachineMaterialSilo";
+    private const string ClientProtoId = "MachineFlatpacker";
+
+    /// <summary>
+    /// Silo and client on the same grid: the link is inside the cut, so it must survive intact. This
+    /// is the test that would fail if dropping [DataField] from Clients had broken the normal case,
+    /// because the set is now rebuilt rather than restored.
+    /// </summary>
+    [Test]
+    public async Task SameGridSiloLinkSurvivesSaveAndLoad()
+    {
+        await using var pair = await PoolManager.GetServerClient();
+        var server = pair.Server;
+        var entMan = server.EntMan;
+        var saveSystem = entMan.System<ShipyardGridSaveSystem>();
+        var mapLoader = entMan.System<MapLoaderSystem>();
+
+        var map = await pair.CreateTestMap();
+
+        EntityUid silo = default, client = default;
+        await server.WaitPost(() =>
+        {
+            silo = SpawnAnchored(entMan, SiloProtoId, map);
+            client = SpawnAnchored(entMan, ClientProtoId, map);
+
+#pragma warning disable RA0002
+            entMan.EnsureComponent<OreSiloClientComponent>(client).Silo = silo;
+            entMan.EnsureComponent<OreSiloComponent>(silo).Clients.Add(client);
+#pragma warning restore RA0002
+        });
+
+        string? yaml = null;
+        await server.WaitAssertion(() =>
+        {
+            Assert.That(saveSystem.TryBuildShipSaveYaml(map.Grid.Owner, out yaml, out _), Is.True);
+            Assert.That(entMan.GetComponent<OreSiloClientComponent>(client).Silo, Is.EqualTo(silo),
+                "A link wholly inside the save must not be cleared: both ends are coming along.");
+        });
+
+        await server.WaitAssertion(() =>
+        {
+            var opts = new MapLoadOptions { MergeMap = map.MapId, Offset = new Vector2(100, 100) };
+            Assert.That(mapLoader.TryLoadGeneric(new System.IO.StringReader(yaml!), "silo-save-test", out var loaded, opts),
+                Is.True, "The saved ship did not load back.");
+
+            var loadedSilos = loaded!.Entities.Where(e => entMan.HasComponent<OreSiloComponent>(e)).ToList();
+            var loadedClients = loaded.Entities
+                .Where(e => entMan.TryGetComponent<OreSiloClientComponent>(e, out var c) && c.Silo != null)
+                .ToList();
+
+            Assert.Multiple(() =>
+            {
+                Assert.That(loadedSilos, Has.Count.EqualTo(1), "The silo should come back.");
+                Assert.That(loadedClients, Has.Count.EqualTo(1), "The client should come back still linked.");
+            });
+
+            var loadedSilo = loadedSilos[0];
+            var loadedClient = loadedClients[0];
+
+            Assert.Multiple(() =>
+            {
+                Assert.That(entMan.GetComponent<OreSiloClientComponent>(loadedClient).Silo, Is.EqualTo(loadedSilo),
+                    "The client should point at the silo that came back with it.");
+                Assert.That(entMan.GetComponent<OreSiloComponent>(loadedSilo).Clients, Does.Contain(loadedClient),
+                    "The silo's client set is no longer persisted and must be rebuilt from the client on startup. " +
+                    "An empty set here means OnClientStartup did not run or did not find the silo.");
+            });
+        });
+
+        await pair.CleanReturnAsync();
+    }
+
+    /// <summary>
+    /// Silo off the grid: the link crosses the boundary of the cut and is severed before serializing,
+    /// so the file never contains a reference it cannot resolve.
+    ///
+    /// Severing loses nothing. SharedOreSiloSystem.CanTransmitMaterials refuses any pair whose grids
+    /// differ, so a cross-grid link already transmits nothing while the ship is still sitting there.
+    /// </summary>
+    [Test]
+    public async Task OffGridSiloLinkIsClearedBeforeSerializing()
+    {
+        await using var pair = await PoolManager.GetServerClient();
+        var server = pair.Server;
+        var entMan = server.EntMan;
+        var saveSystem = entMan.System<ShipyardGridSaveSystem>();
+        var mapLoader = entMan.System<MapLoaderSystem>();
+
+        var map = await pair.CreateTestMap();
+
+        EntityUid silo = default, client = default;
+        await server.WaitPost(() =>
+        {
+            client = SpawnAnchored(entMan, ClientProtoId, map);
+
+            // Off the grid's tiles, so the engine parents it to the map instead.
+            silo = entMan.SpawnEntity(SiloProtoId, new MapCoordinates(new Vector2(6, 6), map.MapId));
+
+#pragma warning disable RA0002
+            entMan.EnsureComponent<OreSiloClientComponent>(client).Silo = silo;
+            entMan.EnsureComponent<OreSiloComponent>(silo).Clients.Add(client);
+#pragma warning restore RA0002
+        });
+
+        await server.WaitAssertion(() =>
+        {
+            Assert.That(entMan.GetComponent<TransformComponent>(silo).GridUid, Is.Not.EqualTo(map.Grid.Owner),
+                "Fixture: the silo landed on the grid, so this is not testing a boundary crossing.");
+        });
+
+        string? yaml = null;
+        await server.WaitAssertion(() =>
+        {
+            Assert.That(saveSystem.TryBuildShipSaveYaml(map.Grid.Owner, out yaml, out _), Is.True);
+
+            Assert.Multiple(() =>
+            {
+                Assert.That(entMan.GetComponent<OreSiloClientComponent>(client).Silo, Is.Null,
+                    "The off-grid link should be cleared from the client before serializing.");
+                Assert.That(entMan.GetComponent<OreSiloComponent>(silo).Clients, Does.Not.Contain(client),
+                    "Clearing should drop the client from the silo's set too, not just null the client half.");
+                Assert.That(entMan.Deleted(silo), Is.False,
+                    "Clearing a link must never delete the entity on the other end.");
+            });
+        });
+
+        await server.WaitAssertion(() =>
+        {
+            var opts = new MapLoadOptions { MergeMap = map.MapId, Offset = new Vector2(100, 100) };
+            Assert.That(mapLoader.TryLoadGeneric(new System.IO.StringReader(yaml!), "silo-offgrid-test", out var loaded, opts),
+                Is.True, "The saved ship did not load back.");
+
+            var linked = loaded!.Entities
+                .Where(e => entMan.TryGetComponent<OreSiloClientComponent>(e, out var c) && c.Silo != null)
+                .ToList();
+
+            Assert.That(linked, Is.Empty,
+                "Nothing in the loaded ship should carry a silo link: the only one it had pointed off-grid.");
+        });
+
+        await pair.CleanReturnAsync();
+    }
+
+    /// <summary>
+    /// Both prototypes set Transform.anchored, so they spawn anchored onto the test grid. Anchoring a
+    /// second time trips a debug assert inside AddToSnapGridCell rather than no-opping.
+    /// </summary>
+    private static EntityUid SpawnAnchored(IEntityManager entMan, string protoId, Robust.UnitTesting.Pool.TestMapData map)
+    {
+        var uid = entMan.SpawnEntity(protoId, map.GridCoords);
+
+        if (!entMan.GetComponent<TransformComponent>(uid).Anchored)
+            entMan.System<SharedTransformSystem>().AnchorEntity(uid);
+
+        return uid;
+    }
+}

--- a/Content.IntegrationTests/Tests/_Triad/Shipyard/OreSiloSaveTest.cs
+++ b/Content.IntegrationTests/Tests/_Triad/Shipyard/OreSiloSaveTest.cs
@@ -2,6 +2,8 @@
 //
 // SPDX-License-Identifier: AGPL-3.0-or-later
 
+#nullable enable
+
 using System.Linq;
 using System.Numerics;
 using Content.Server._Triad.Shipyard;

--- a/Content.IntegrationTests/Tests/_Triad/Shipyard/ShipSaveSerializationTest.cs
+++ b/Content.IntegrationTests/Tests/_Triad/Shipyard/ShipSaveSerializationTest.cs
@@ -2,6 +2,8 @@
 //
 // SPDX-License-Identifier: AGPL-3.0-or-later
 
+#nullable enable
+
 using System;
 using System.Collections.Generic;
 using System.IO;

--- a/Content.IntegrationTests/Tests/_Triad/Shipyard/ShipSaveSerializationTest.cs
+++ b/Content.IntegrationTests/Tests/_Triad/Shipyard/ShipSaveSerializationTest.cs
@@ -1,0 +1,520 @@
+// SPDX-FileCopyrightText: 2026 Triad Sector contributors
+//
+// SPDX-License-Identifier: AGPL-3.0-or-later
+
+using System;
+using System.Collections.Generic;
+using System.IO;
+using System.Linq;
+using System.Numerics;
+using Content.Server._Triad.Shipyard;
+using Content.Server.KillTracking;
+using Content.Server.NPC.Components;
+using Content.Shared._Shitmed.Body.Part;
+using Content.Shared.DeviceLinking;
+using Content.Shared.Humanoid;
+using Content.Shared.Payload.Components;
+using Content.Shared.SmartFridge;
+using Robust.Shared.Containers;
+using Robust.Shared.EntitySerialization;
+using Robust.Shared.EntitySerialization.Systems;
+using Robust.Shared.GameObjects;
+using Robust.Shared.Map;
+using Robust.Shared.Map.Components;
+using Robust.Shared.Serialization.Manager.Attributes;
+using Robust.Shared.Serialization.Markdown.Mapping;
+using Robust.Shared.Serialization.Markdown.Sequence;
+using Robust.Shared.Serialization.Markdown.Value;
+using Robust.Shared.Utility;
+using Robust.UnitTesting.Pool;
+
+namespace Content.IntegrationTests.Tests._Triad.Shipyard;
+
+/// <summary>
+/// Exercises the ship-grid save against the runtime state that was killing it in production. The save
+/// runs with the engine default <see cref="EntityExceptionBehaviour.Rethrow"/>, so one component the
+/// YAML writer cannot express takes the whole save with it.
+///
+/// Three things are pinned. Device links to sinks off the grid are cleared before serialization
+/// instead of colliding as a duplicate "invalid" key. A stocked SmartFridge comes back stocked and
+/// listed after a save and load, which depends on MapInit firing on load, which depends on the
+/// sanitizer stripping the mapInit flag. And the runtime-only state the fix stopped persisting no
+/// longer reaches the serializer, while a planted control proves the collision being guarded against
+/// is still real.
+/// </summary>
+[TestFixture]
+[TestOf(typeof(ShipyardGridSaveSystem))]
+public sealed class ShipSaveSerializationTest
+{
+    private const string SignalButtonProtoId = "SignalButtonDirectional";
+    private const string SmartFridgeProtoId = "SmartFridge";
+    private const string ProduceProtoId = "FoodAmbrosiaVulgaris";
+    private const string SinkProtoId = "ShipSaveTestSink";
+    private const string PressedPort = "Pressed";
+    private const string TogglePort = "Toggle";
+
+    [TestPrototypes]
+    private const string TestPrototypes = $@"
+- type: entity
+  id: {SinkProtoId}
+  components:
+  - type: DeviceLinkSink
+    ports:
+    - {TogglePort}
+";
+
+    /// <summary>
+    /// The production case, reduced: a docking button on the ship wired to shutters on the station.
+    /// Two links whose sinks are alive but not on the grid each serialize as the string "invalid",
+    /// and the second one is a duplicate dictionary key. The cleanup used to test whether the sink
+    /// existed, which a live station entity passes, so it never saw this class at all.
+    /// </summary>
+    [Test]
+    public async Task OffGridDeviceLinksAreClearedAndTheSaveRoundTrips()
+    {
+        await using var pair = await PoolManager.GetServerClient();
+        var server = pair.Server;
+        var entMan = server.EntMan;
+        var saveSystem = entMan.System<ShipyardGridSaveSystem>();
+        var deviceLink = entMan.System<SharedDeviceLinkSystem>();
+        var transform = entMan.System<SharedTransformSystem>();
+        var mapLoader = entMan.System<MapLoaderSystem>();
+
+        var map = await pair.CreateTestMap();
+
+        EntityUid button = default, onGridSink = default, offGridA = default, offGridB = default;
+        await server.WaitPost(() =>
+        {
+            button = entMan.SpawnEntity(SignalButtonProtoId, map.GridCoords);
+
+            onGridSink = entMan.SpawnEntity(SinkProtoId, map.GridCoords);
+            transform.AnchorEntity(onGridSink);
+
+            // Off the grid's one tile, so the engine parents these to the map rather than the grid.
+            offGridA = entMan.SpawnEntity(SinkProtoId, new MapCoordinates(new Vector2(4, 4), map.MapId));
+            offGridB = entMan.SpawnEntity(SinkProtoId, new MapCoordinates(new Vector2(5, 5), map.MapId));
+
+            foreach (var sink in new[] { onGridSink, offGridA, offGridB })
+                deviceLink.SaveLinks(null, button, sink, [(PressedPort, TogglePort)]);
+        });
+
+        await server.WaitAssertion(() =>
+        {
+            var source = entMan.GetComponent<DeviceLinkSourceComponent>(button);
+            Assert.Multiple(() =>
+            {
+                Assert.That(source.LinkedPorts.Keys, Is.EquivalentTo(new[] { onGridSink, offGridA, offGridB }),
+                    "Fixture: all three links must be in place before the save, or nothing below is tested.");
+                Assert.That(entMan.GetComponent<TransformComponent>(offGridA).GridUid, Is.Not.EqualTo(map.Grid.Owner),
+                    "Fixture: the off-grid sinks landed on the grid, so the test proves nothing.");
+                Assert.That(entMan.GetComponent<TransformComponent>(onGridSink).GridUid, Is.EqualTo(map.Grid.Owner),
+                    "Fixture: the on-grid sink is not on the grid.");
+            });
+        });
+
+        string? yaml = null;
+        await server.WaitAssertion(() =>
+        {
+            Assert.That(saveSystem.TryBuildShipSaveYaml(map.Grid.Owner, out yaml, out _), Is.True,
+                "The save threw or refused; with two off-grid links that is the production failure.");
+        });
+
+        await server.WaitAssertion(() =>
+        {
+            var source = entMan.GetComponent<DeviceLinkSourceComponent>(button);
+            Assert.Multiple(() =>
+            {
+                Assert.That(source.LinkedPorts.Keys, Is.EquivalentTo(new[] { onGridSink }),
+                    "Off-grid links must be cleared from the live source and the on-grid link must survive.");
+                Assert.That(entMan.EntityExists(offGridA) && entMan.EntityExists(offGridB), Is.True,
+                    "Clearing a link must not delete the sink on the other end.");
+            });
+        });
+
+        var loaded = await LoadShipYaml(server, mapLoader, yaml!, map);
+
+        await server.WaitAssertion(() =>
+        {
+            var sources = loaded.Entities.Where(e => entMan.HasComponent<DeviceLinkSourceComponent>(e)).ToList();
+            Assert.That(sources, Has.Count.EqualTo(1), "Exactly one link source should come back: the button.");
+
+            var source = entMan.GetComponent<DeviceLinkSourceComponent>(sources[0]);
+            Assert.That(source.LinkedPorts, Has.Count.EqualTo(1), "Only the on-grid link should round-trip.");
+
+            var sink = source.LinkedPorts.Keys.Single();
+            Assert.Multiple(() =>
+            {
+                Assert.That(sink, Is.Not.EqualTo(EntityUid.Invalid), "An \"invalid\" key reached the file.");
+                Assert.That(loaded.Entities, Does.Contain(sink), "The surviving link must resolve to the loaded sink.");
+            });
+        });
+
+        await pair.CleanReturnAsync();
+    }
+
+    /// <summary>
+    /// The listing (<see cref="SmartFridgeComponent.ContainedEntries"/>) is no longer persisted, because
+    /// its key is a data definition and cannot be written as a YAML mapping key. It is rebuilt from the
+    /// container on MapInit instead. This proves the rebuild runs on a real ship load and agrees with
+    /// what is physically inside.
+    /// </summary>
+    [Test]
+    public async Task SmartFridgeStockSurvivesSaveAndLoad()
+    {
+        await using var pair = await PoolManager.GetServerClient();
+        var server = pair.Server;
+        var entMan = server.EntMan;
+        var saveSystem = entMan.System<ShipyardGridSaveSystem>();
+        var containers = entMan.System<SharedContainerSystem>();
+        var mapLoader = entMan.System<MapLoaderSystem>();
+
+        var map = await pair.CreateTestMap();
+        var fridge = await StockAFridge(server, map);
+
+        string? yaml = null;
+        await server.WaitAssertion(() =>
+        {
+            Assert.That(saveSystem.TryBuildShipSaveYaml(map.Grid.Owner, out yaml, out _), Is.True,
+                "The save threw; a stocked fridge was one of the production failures.");
+        });
+
+        await server.WaitAssertion(() =>
+        {
+            var comp = entMan.GetComponent<SmartFridgeComponent>(fridge);
+            var container = containers.GetContainer(fridge, comp.Container);
+            Assert.Multiple(() =>
+            {
+                Assert.That(container.ContainedEntities, Has.Count.EqualTo(2),
+                    "The purge must keep machine contents, or the round trip below is testing an empty fridge.");
+                Assert.That(yaml, Does.Not.Contain("containedEntries"),
+                    "The listing must not be persisted at all; the writer cannot express it.");
+            });
+        });
+
+        var loaded = await LoadShipYaml(server, mapLoader, yaml!, map);
+
+        await server.WaitAssertion(() =>
+        {
+            var fridges = loaded.Entities.Where(e => entMan.HasComponent<SmartFridgeComponent>(e)).ToList();
+            Assert.That(fridges, Has.Count.EqualTo(1));
+
+            var uid = fridges[0];
+            var comp = entMan.GetComponent<SmartFridgeComponent>(uid);
+            var container = containers.GetContainer(uid, comp.Container);
+            var stocked = container.ContainedEntities.Select(e => entMan.GetNetEntity(e)).ToList();
+
+            Assert.Multiple(() =>
+            {
+                Assert.That(stocked, Has.Count.EqualTo(2), "The stock itself must survive the round trip.");
+                Assert.That(comp.Entries, Has.Count.EqualTo(1), "The menu entry is persisted and must survive.");
+                Assert.That(comp.ContainedEntries.GetValueOrDefault(comp.Entries[0]) ?? new HashSet<NetEntity>(),
+                    Is.EquivalentTo(stocked),
+                    "The listing must be rebuilt from the container on load. If this is empty, MapInit did not fire.");
+            });
+        });
+
+        await pair.CleanReturnAsync();
+    }
+
+    /// <summary>
+    /// Characterizes why the test above passes, so the dependency cannot rot silently. The engine's own
+    /// grid save keeps the per-entity mapInit flag, so on load the entity is flagged map-initialized
+    /// without the event ever being raised, and a load raises no container-insert events either. The
+    /// listing therefore comes back EMPTY over a full container. The Triad save passes only because the
+    /// sanitizer strips that flag. If this test ever fails, the engine has started raising MapInit on
+    /// post-init loads and that strip is no longer load-bearing.
+    /// </summary>
+    [Test]
+    public async Task ListingRebuildDependsOnTheSanitizerStrippingMapInit()
+    {
+        await using var pair = await PoolManager.GetServerClient();
+        var server = pair.Server;
+        var entMan = server.EntMan;
+        var containers = entMan.System<SharedContainerSystem>();
+        var mapLoader = entMan.System<MapLoaderSystem>();
+
+        var map = await pair.CreateTestMap();
+        await StockAFridge(server, map);
+
+        var path = new ResPath("/ship-save-test-engine-path.yml");
+        Entity<MapGridComponent>? loadedGrid = null;
+
+        await server.WaitAssertion(() =>
+        {
+            Assert.That(mapLoader.TrySaveGrid(map.Grid.Owner, path), Is.True, "Engine save failed.");
+        });
+
+        await server.WaitAssertion(() =>
+        {
+            Assert.That(mapLoader.TryLoadGrid(map.MapId, path, out loadedGrid, offset: new Vector2(100, 100)), Is.True,
+                "Engine load failed.");
+        });
+
+        await server.WaitAssertion(() =>
+        {
+            var query = entMan.EntityQueryEnumerator<SmartFridgeComponent, TransformComponent>();
+            SmartFridgeComponent? comp = null;
+            EntityUid uid = default;
+            while (query.MoveNext(out var candidate, out var fridge, out var xform))
+            {
+                if (xform.GridUid != loadedGrid!.Value.Owner)
+                    continue;
+
+                comp = fridge;
+                uid = candidate;
+            }
+
+            Assert.That(comp, Is.Not.Null, "No fridge came back on the loaded grid.");
+
+            var container = containers.GetContainer(uid, comp!.Container);
+            Assert.Multiple(() =>
+            {
+                Assert.That(container.ContainedEntities, Has.Count.EqualTo(2), "Contents survive the engine path too.");
+                Assert.That(comp.ContainedEntries.Values.Sum(set => set.Count), Is.Zero,
+                    "The engine path rebuilt the listing. MapInit now fires on post-init loads, so the " +
+                    "sanitizer's mapInit strip is no longer what makes the Triad round trip work.");
+            });
+        });
+
+        await pair.CleanReturnAsync();
+    }
+
+    /// <summary>
+    /// Each of the remaining fixed components, with the exact runtime state that used to throw, run
+    /// through the serializer with the live save's options. None may throw, and the dropped fields may
+    /// not appear. BodyPartAppearance keeps its value under the renamed key.
+    /// </summary>
+    [Test]
+    public async Task RuntimeOnlyStateNoLongerReachesTheSerializer()
+    {
+        await using var pair = await PoolManager.GetServerClient();
+        var server = pair.Server;
+        var entMan = server.EntMan;
+        var mapLoader = entMan.System<MapLoaderSystem>();
+
+        var map = await pair.CreateTestMap();
+
+        EntityUid offA = default, offB = default;
+        EntityUid payload = default, npc = default, tracker = default, limb = default;
+        await server.WaitPost(() =>
+        {
+            offA = entMan.SpawnEntity(null, new MapCoordinates(new Vector2(4, 4), map.MapId));
+            offB = entMan.SpawnEntity(null, new MapCoordinates(new Vector2(5, 5), map.MapId));
+
+            payload = entMan.SpawnEntity(null, map.GridCoords);
+            entMan.EnsureComponent<PayloadTriggerComponent>(payload).GrantedComponents.Add(typeof(TransformComponent));
+
+            npc = entMan.SpawnEntity(null, map.GridCoords);
+            var memories = entMan.EnsureComponent<NPCRetaliationComponent>(npc);
+#pragma warning disable RA0002
+            memories.AttackMemories[offA] = TimeSpan.Zero;
+            memories.AttackMemories[offB] = TimeSpan.Zero;
+#pragma warning restore RA0002
+
+            tracker = entMan.SpawnEntity(null, map.GridCoords);
+            var kills = entMan.EnsureComponent<KillTrackerComponent>(tracker);
+#pragma warning disable RA0002
+            kills.LifetimeDamage[new KillNpcSource(offA)] = 1;
+            kills.LifetimeDamage[new KillNpcSource(offB)] = 2;
+#pragma warning restore RA0002
+
+            limb = entMan.SpawnEntity(null, map.GridCoords);
+            entMan.EnsureComponent<BodyPartAppearanceComponent>(limb).Type = HumanoidVisualLayers.LArm;
+        });
+
+        await server.WaitAssertion(() =>
+        {
+            Assert.Multiple(() =>
+            {
+                AssertSerializesWithout(mapLoader, payload, "PayloadTrigger", "grantedComponents");
+                AssertSerializesWithout(mapLoader, npc, "NPCRetaliation", "attackMemories");
+                AssertSerializesWithout(mapLoader, tracker, "KillTracker", "lifetimeDamage");
+
+                var limbNode = FindComponentNode(Serialize(mapLoader, limb), "BodyPartAppearance");
+                Assert.That(limbNode, Is.Not.Null, "BodyPartAppearance with a non-default layer type should be written.");
+                Assert.That(limbNode!.TryGet<ValueDataNode>("layerType", out var layer) && layer.Value == "LArm", Is.True,
+                    "The layer type must survive under its renamed key.");
+            });
+        });
+
+        await pair.CleanReturnAsync();
+    }
+
+    /// <summary>
+    /// Control. A clean run above is only meaningful if the serializer still fails on the shape being
+    /// guarded against, so this plants it: a persisted dictionary keyed by EntityUid with two keys off
+    /// the grid. One such key is harmless and writes a single "invalid"; the second is the duplicate
+    /// key that killed saves. This is also the argument for a round-trip gate in CI: any new component
+    /// with this shape still kills the save, and nothing in the fix prevents that.
+    /// </summary>
+    [Test]
+    public async Task ControlTwoOffGridKeysInAPersistedDictionaryStillCollide()
+    {
+        await using var pair = await PoolManager.GetServerClient();
+        var server = pair.Server;
+        var entMan = server.EntMan;
+        var mapLoader = entMan.System<MapLoaderSystem>();
+
+        var map = await pair.CreateTestMap();
+
+        EntityUid offA = default, offB = default, oneKey = default, twoKeys = default;
+        await server.WaitPost(() =>
+        {
+            offA = entMan.SpawnEntity(null, new MapCoordinates(new Vector2(4, 4), map.MapId));
+            offB = entMan.SpawnEntity(null, new MapCoordinates(new Vector2(5, 5), map.MapId));
+
+            oneKey = entMan.SpawnEntity(null, map.GridCoords);
+            entMan.EnsureComponent<ShipSaveOffGridKeyControlComponent>(oneKey).Refs[offA] = 1;
+
+            twoKeys = entMan.SpawnEntity(null, map.GridCoords);
+            var refs = entMan.EnsureComponent<ShipSaveOffGridKeyControlComponent>(twoKeys).Refs;
+            refs[offA] = 1;
+            refs[offB] = 2;
+        });
+
+        await server.WaitAssertion(() =>
+        {
+            Assert.DoesNotThrow(() => Serialize(mapLoader, oneKey),
+                "One off-grid key writes a single \"invalid\" and must not throw; the bug is the collision.");
+        });
+
+        // The engine logs an error on its way to rethrowing, and the pool fails any test that logged an
+        // error when the pair is returned. Here that log IS the expected outcome. The handler's JudgeLog
+        // hook would let us accept exactly that line, but its signature names a Serilog type this
+        // project does not reference, so instead the failure threshold is lifted for exactly the
+        // duration of the one synchronous call that produces it, and restored after.
+        var failureLevel = pair.ServerLogHandler.FailureLevel;
+        pair.ServerLogHandler.FailureLevel = null;
+        try
+        {
+            await server.WaitAssertion(() =>
+            {
+                var ex = Assert.Throws<ArgumentException>(() => Serialize(mapLoader, twoKeys),
+                    "Two off-grid keys no longer collide. Either the engine changed how it writes missing " +
+                    "references, or the control is broken; either way the tests above are no longer proving anything.");
+                Assert.That(ex!.Message, Does.Contain("invalid"));
+            });
+        }
+        finally
+        {
+            pair.ServerLogHandler.FailureLevel = failureLevel;
+        }
+
+        await pair.CleanReturnAsync();
+    }
+
+    private static async Task<EntityUid> StockAFridge(Robust.UnitTesting.RobustIntegrationTest.ServerIntegrationInstance server, TestMapData map)
+    {
+        var entMan = server.EntMan;
+        var containers = entMan.System<SharedContainerSystem>();
+
+        EntityUid fridge = default;
+        await server.WaitPost(() =>
+        {
+            fridge = entMan.SpawnEntity(SmartFridgeProtoId, map.GridCoords);
+            var comp = entMan.GetComponent<SmartFridgeComponent>(fridge);
+            var container = containers.GetContainer(fridge, comp.Container);
+
+            for (var i = 0; i < 2; i++)
+            {
+                var item = entMan.SpawnEntity(ProduceProtoId, map.GridCoords);
+                containers.Insert(item, container);
+            }
+        });
+
+        await server.WaitAssertion(() =>
+        {
+            var comp = entMan.GetComponent<SmartFridgeComponent>(fridge);
+            Assert.Multiple(() =>
+            {
+                Assert.That(entMan.GetComponent<TransformComponent>(fridge).Anchored, Is.True,
+                    "Fixture: the fridge must be anchored or the purge deletes it.");
+                Assert.That(comp.Entries, Has.Count.EqualTo(1), "Fixture: two of one item should make one entry.");
+                Assert.That(comp.ContainedEntries[comp.Entries[0]], Has.Count.EqualTo(2),
+                    "Fixture: live inserts must populate the listing.");
+            });
+        });
+
+        return fridge;
+    }
+
+    private static async Task<LoadResult> LoadShipYaml(
+        Robust.UnitTesting.RobustIntegrationTest.ServerIntegrationInstance server,
+        MapLoaderSystem mapLoader,
+        string yaml,
+        TestMapData map)
+    {
+        LoadResult? loaded = null;
+        await server.WaitAssertion(() =>
+        {
+            // Merge onto the live test map, offset so the loaded grid does not sit on the original.
+            var opts = new MapLoadOptions { MergeMap = map.MapId, Offset = new Vector2(100, 100) };
+            Assert.That(mapLoader.TryLoadGeneric(new StringReader(yaml), "ship-save-test", out loaded, opts), Is.True,
+                "The saved YAML did not load back.");
+        });
+
+        return loaded!;
+    }
+
+    private static MappingDataNode Serialize(MapLoaderSystem mapLoader, EntityUid uid)
+    {
+        var (node, _) = mapLoader.SerializeEntitiesRecursive(
+            new HashSet<EntityUid> { uid },
+            ShipyardGridSaveSystem.ShipSaveSerializationOptions);
+        return node;
+    }
+
+    private static void AssertSerializesWithout(MapLoaderSystem mapLoader, EntityUid uid, string component, string droppedKey)
+    {
+        MappingDataNode? node = null;
+        Assert.DoesNotThrow(() => node = Serialize(mapLoader, uid), $"{component} with runtime state populated still throws.");
+
+        var componentNode = FindComponentNode(node!, component);
+        if (componentNode == null)
+            return; // Nothing non-default left to write, which is the point.
+
+        Assert.That(componentNode.Has(droppedKey), Is.False, $"{component}.{droppedKey} was written; it cannot be.");
+    }
+
+    /// <summary>
+    /// Walks the serializer's output: a root with an "entities" sequence of prototype groups, each with
+    /// its own "entities" sequence, each entity carrying a "components" sequence keyed by "type".
+    /// </summary>
+    private static MappingDataNode? FindComponentNode(MappingDataNode root, string componentType)
+    {
+        if (!root.TryGet<SequenceDataNode>("entities", out var groups))
+            return null;
+
+        foreach (var group in groups.OfType<MappingDataNode>())
+        {
+            if (!group.TryGet<SequenceDataNode>("entities", out var entities))
+                continue;
+
+            foreach (var entity in entities.OfType<MappingDataNode>())
+            {
+                if (!entity.TryGet<SequenceDataNode>("components", out var components))
+                    continue;
+
+                foreach (var component in components.OfType<MappingDataNode>())
+                {
+                    if (component.TryGet<ValueDataNode>("type", out var type) && type.Value == componentType)
+                        return component;
+                }
+            }
+        }
+
+        return null;
+    }
+}
+
+/// <summary>
+/// The shape that was killing saves, kept alive as a control: a persisted dictionary keyed by
+/// EntityUid whose keys can point off the grid. Sits at namespace scope because a registered component
+/// must be partial.
+/// </summary>
+[RegisterComponent]
+public sealed partial class ShipSaveOffGridKeyControlComponent : Component
+{
+    [DataField]
+    public Dictionary<EntityUid, int> Refs = new();
+}

--- a/Content.Server/KillTracking/KillTrackerComponent.cs
+++ b/Content.Server/KillTracking/KillTrackerComponent.cs
@@ -19,7 +19,15 @@ public sealed partial class KillTrackerComponent : Component
     /// <summary>
     /// A dictionary of sources and how much damage they've done to this entity over time.
     /// </summary>
+    // Triad: KillSource is a polymorphic record, not a scalar, so it serializes to a MappingDataNode
+    // and cannot be a YAML mapping key -- persisting this throws "Yaml mapping keys must serialize to
+    // a ValueDataNode" and kills the whole ship-grid save. Per-round damage attribution is runtime
+    // state, so it is no longer persisted.
+    /*
     [DataField("lifetimeDamage")]
+    */
+    [ViewVariables]
+    // End Triad
     public Dictionary<KillSource, FixedPoint2> LifetimeDamage = new();
 }
 

--- a/Content.Server/NPC/Components/NPCRetaliationComponent.cs
+++ b/Content.Server/NPC/Components/NPCRetaliationComponent.cs
@@ -19,6 +19,14 @@ public sealed partial class NPCRetaliationComponent : Component
     /// A dictionary that stores an entity and the time at which they will no longer be considered hostile.
     /// </summary>
     /// todo: this needs to support timeoffsetserializer at some point
+    // Triad: keys are arbitrary attackers anywhere in the world, not entities co-located with this
+    // NPC, so on a ship-grid save any attacker outside the save set serializes as the literal string
+    // "invalid". Two of them collide as a duplicate dictionary key and kill the whole save. Combat
+    // memory is runtime state that expires on AttackMemoryLength anyway, so it is no longer persisted.
+    /*
     [DataField("attackMemories")]
+    */
+    [ViewVariables]
+    // End Triad
     public Dictionary<EntityUid, TimeSpan> AttackMemories = new();
 }

--- a/Content.Server/_Triad/Shipyard/ShipyardGridSaveSystem.cs
+++ b/Content.Server/_Triad/Shipyard/ShipyardGridSaveSystem.cs
@@ -473,7 +473,7 @@ public sealed partial class ShipyardGridSaveSystem : EntitySystem
     /// whose sink is not on this grid. Preserves links whose sink is on the grid being saved.
     /// </summary>
     /// <remarks>
-    /// Triad: entity existence is NOT the right test here, which is why this ran for months while
+    /// Entity existence is NOT the right test here, which is why this ran for months while
     /// DeviceLinkSource stayed the top cause of failed ship saves. The save runs with
     /// <see cref="MissingEntityBehaviour.Ignore"/>, and EntitySerializer.Write returns the literal
     /// string "invalid" for ANY EntityUid outside the set being serialized, alive or not. Because

--- a/Content.Server/_Triad/Shipyard/ShipyardGridSaveSystem.cs
+++ b/Content.Server/_Triad/Shipyard/ShipyardGridSaveSystem.cs
@@ -276,66 +276,11 @@ public sealed partial class ShipyardGridSaveSystem : EntitySystem
 
         try
         {
-            // Purge invalid entities
-            PurgeInvalidEntities(gridUid);
-
-            // Triad: runs AFTER the purge so it sees the final entity set. In practice the engine
-            // already drops links to purged sinks (SharedDeviceLinkSystem.OnSinkRemoved fires on
-            // ComponentRemove during Del), so this ordering is defensive rather than load-bearing;
-            // the fix that matters is the off-grid test inside CleanupBrokenDeviceLinks.
-            // Clean up broken device links before serialization
-            CleanupBrokenDeviceLinks(gridUid);
+            // Triad: the part of a save that can actually fail lives in TryBuildShipSaveYaml, so it
+            // can be exercised without a session, a signing key or a client to deliver to.
+            if (!TryBuildShipSaveYaml(gridUid, out var yaml, out var appraisalCost))
+                return false;
             // End Triad
-
-            // remove any edge spreaders, we cannot save these
-            RemoveEdgeSpreaderComponentComponentsOnGrid(gridUid);
-
-            // Reset fabricators: disable loop/skip and cancel active jobs to prevent mid-save exceptions
-            ResetFabricatorsOnGrid(gridUid);
-
-            // reset station records computers to prevent errors with StationRecordsFilter
-            ResetGeneralRecordsConsolesOnGrid(gridUid);
-
-            // Remove repair data, it is re-added on load
-            RemComp<ShipRepairDataComponent>(gridUid);
-
-            // Remove SpreaderGrid component from grid;
-            RemComp<SpreaderGridComponent>(gridUid);
-
-            //_sawmill.Info($"Serializing ship grid {gridUid} as '{shipName}' after transient purge using direct serialization");
-
-            // 1) Serialize the grid and its children to a MappingDataNode (engine-standard format)
-            var entities = new HashSet<EntityUid> { gridUid };
-            // Prefer AutoInclude to pull in dependent entities; we'll sanitize nullspace and parents out below
-            var opts = SerializationOptions.Default with
-            {
-                // Do NOT auto-include referenced entities (players/admin observers/etc.).
-                // This prevents exceptions when encountering unserializable entities and keeps saves scoped to the grid.
-                MissingEntityBehaviour = MissingEntityBehaviour.Ignore,
-                ErrorOnOrphan = false,
-                // Disable auto-include logging to avoid excessive log spam/lag during saves.
-                LogAutoInclude = null
-            };
-
-
-            // triad start
-            // these three lines were lifted from the loading code, and should be refactored into a function at some point
-            var loadShipPrice = _configManager.GetCVar(TriadCCVars.LoadShipPrice);
-            var fullAppraisal = _pricing.AppraiseGrid(gridUid, null);
-            var appraisalCost = (int)MathF.Round((float)fullAppraisal * loadShipPrice);
-            // triad end
-
-            var (node, category) = _mapLoader.SerializeEntitiesRecursive(entities, opts);
-            /* if (category != FileCategory.Grid)
-            {
-                _sawmill.Warning($"Expected FileCategory.Grid but got {category}; continuing with sanitation");
-            } */
-
-            // 2) Sanitize the node to match blueprint conventions
-            SanitizeShipSaveNode(node);
-
-            // 3) Convert MappingDataNode to YAML text without touching disk
-            var yaml = WriteYamlToString(node);
 
             // Triad ship anti-tamper start
             var shipFileBox = _tamperPolicy.SignSave(yaml, appraisalCost);
@@ -379,6 +324,89 @@ public sealed partial class ShipyardGridSaveSystem : EntitySystem
             return false;
         }
     }
+
+    // Triad start: the save body, split out of TrySaveGridAsShip so it is testable.
+    /// <summary>
+    /// The serialization options every ship save runs with. Exposed so tests exercise the options the
+    /// live save uses rather than a copy that can drift from them.
+    /// </summary>
+    internal static readonly SerializationOptions ShipSaveSerializationOptions = SerializationOptions.Default with
+    {
+        // Do NOT auto-include referenced entities (players/admin observers/etc.).
+        // This prevents exceptions when encountering unserializable entities and keeps saves scoped to the grid.
+        MissingEntityBehaviour = MissingEntityBehaviour.Ignore,
+        ErrorOnOrphan = false,
+        // Disable auto-include logging to avoid excessive log spam/lag during saves.
+        LogAutoInclude = null
+    };
+
+    /// <summary>
+    /// Runs the pre-save passes over the live grid, serializes it, sanitizes the node and renders the
+    /// YAML. This is everything in a ship save that can throw; signing and delivery stay in
+    /// <see cref="TrySaveGridAsShip"/>. Mutates the grid: the purge and the link cleanup are permanent.
+    /// </summary>
+    /// <returns>False only when <paramref name="gridUid"/> is not a grid. Serialization failures throw.</returns>
+    internal bool TryBuildShipSaveYaml(
+        EntityUid gridUid,
+        [System.Diagnostics.CodeAnalysis.NotNullWhen(true)] out string? yaml,
+        out int appraisalCost)
+    {
+        yaml = null;
+        appraisalCost = 0;
+
+        if (!_gridQuery.HasComp(gridUid))
+            return false;
+
+        // Purge invalid entities
+        PurgeInvalidEntities(gridUid);
+
+        // Triad: runs AFTER the purge so it sees the final entity set. In practice the engine
+        // already drops links to purged sinks (SharedDeviceLinkSystem.OnSinkRemoved fires on
+        // ComponentRemove during Del), so this ordering is defensive rather than load-bearing;
+        // the fix that matters is the off-grid test inside CleanupBrokenDeviceLinks.
+        // Clean up broken device links before serialization
+        CleanupBrokenDeviceLinks(gridUid);
+        // End Triad
+
+        // remove any edge spreaders, we cannot save these
+        RemoveEdgeSpreaderComponentComponentsOnGrid(gridUid);
+
+        // Reset fabricators: disable loop/skip and cancel active jobs to prevent mid-save exceptions
+        ResetFabricatorsOnGrid(gridUid);
+
+        // reset station records computers to prevent errors with StationRecordsFilter
+        ResetGeneralRecordsConsolesOnGrid(gridUid);
+
+        // Remove repair data, it is re-added on load
+        RemComp<ShipRepairDataComponent>(gridUid);
+
+        // Remove SpreaderGrid component from grid;
+        RemComp<SpreaderGridComponent>(gridUid);
+
+        // 1) Serialize the grid and its children to a MappingDataNode (engine-standard format)
+        var entities = new HashSet<EntityUid> { gridUid };
+
+        // triad start
+        // these three lines were lifted from the loading code, and should be refactored into a function at some point
+        var loadShipPrice = _configManager.GetCVar(TriadCCVars.LoadShipPrice);
+        var fullAppraisal = _pricing.AppraiseGrid(gridUid, null);
+        appraisalCost = (int)MathF.Round((float)fullAppraisal * loadShipPrice);
+        // triad end
+
+        var (node, category) = _mapLoader.SerializeEntitiesRecursive(entities, ShipSaveSerializationOptions);
+        /* if (category != FileCategory.Grid)
+        {
+            _sawmill.Warning($"Expected FileCategory.Grid but got {category}; continuing with sanitation");
+        } */
+
+        // 2) Sanitize the node to match blueprint conventions
+        SanitizeShipSaveNode(node);
+
+        // 3) Convert MappingDataNode to YAML text without touching disk
+        yaml = WriteYamlToString(node);
+        return true;
+    }
+    // Triad end
 
     private void RemoveEdgeSpreaderComponentComponentsOnGrid(EntityUid gridUid)
     {

--- a/Content.Server/_Triad/Shipyard/ShipyardGridSaveSystem.cs
+++ b/Content.Server/_Triad/Shipyard/ShipyardGridSaveSystem.cs
@@ -524,7 +524,6 @@ public sealed partial class ShipyardGridSaveSystem : EntitySystem
         }
     }
 
-    // Triad start
     /// <summary>
     /// Clears ore-silo links whose silo is not on the grid being saved, so the save never writes a
     /// reference it cannot resolve.

--- a/Content.Server/_Triad/Shipyard/ShipyardGridSaveSystem.cs
+++ b/Content.Server/_Triad/Shipyard/ShipyardGridSaveSystem.cs
@@ -10,6 +10,7 @@ using Content.Shared.Chemistry.Components;
 using Content.Shared.Chemistry.Components.SolutionManager;
 using Content.Shared.DeviceLinking;
 using Content.Shared.DeviceLinking.Components;
+using Content.Shared.Materials.OreSilo; // Triad: clearing off-grid silo links
 using Content.Shared.Mind.Components;
 using Content.Shared.Wall;
 using Robust.Shared.Containers;
@@ -61,6 +62,7 @@ public sealed partial class ShipyardGridSaveSystem : EntitySystem
     [Dependency] private SharedContainerSystem _containerSystem = default!;
     [Dependency] private EntityLookupSystem _lookup = default!;
     [Dependency] private SharedDeviceLinkSystem _deviceLink = default!;
+    [Dependency] private SharedOreSiloSystem _oreSilo = default!; // Triad: clearing off-grid silo links
     [Dependency] private IPrototypeManager _prototypeManager = default!;
     [Dependency] private SharedTransformSystem _transform = default!;
     [Dependency] private StationSystem _station = default!;
@@ -366,6 +368,9 @@ public sealed partial class ShipyardGridSaveSystem : EntitySystem
         // the fix that matters is the off-grid test inside CleanupBrokenDeviceLinks.
         // Clean up broken device links before serialization
         CleanupBrokenDeviceLinks(gridUid);
+
+        // Same treatment for ore-silo links, which are the other two-way EntityUid link on a ship.
+        CleanupOffGridOreSiloLinks(gridUid);
         // End Triad
 
         // remove any edge spreaders, we cannot save these
@@ -518,6 +523,52 @@ public sealed partial class ShipyardGridSaveSystem : EntitySystem
             _sawmill.Warning($"CleanupBrokenDeviceLinks: Exception while cleaning device links on grid {gridUid}: {e.Message}");
         }
     }
+
+    // Triad start
+    /// <summary>
+    /// Clears ore-silo links whose silo is not on the grid being saved, so the save never writes a
+    /// reference it cannot resolve.
+    /// </summary>
+    /// <remarks>
+    /// A cross-grid silo link is already dead weight: SharedOreSiloSystem.CanTransmitMaterials refuses
+    /// any pair whose grids differ, so a link to a silo on another grid transmits nothing even before
+    /// the ship is saved. Carrying it into the save only produces the literal string "invalid" in the
+    /// YAML, one deserializer error per load, and a uid that resolves to entity 0 downstream.
+    ///
+    /// Only the client half needs clearing: OreSiloComponent.Clients is no longer persisted and is
+    /// rebuilt from the surviving clients on startup.
+    /// </remarks>
+    private void CleanupOffGridOreSiloLinks(EntityUid gridUid)
+    {
+        try
+        {
+            var query = _entityManager.EntityQueryEnumerator<OreSiloClientComponent, TransformComponent>();
+            while (query.MoveNext(out var uid, out var client, out var xform))
+            {
+                if (xform.GridUid != gridUid)
+                    continue;
+
+                if (client.Silo is not { } silo)
+                    continue;
+
+                // Keep links whose silo rides along in this same save.
+                if (_entityManager.EntityExists(silo)
+                    && !_entityManager.IsQueuedForDeletion(silo)
+                    && _transformQuery.TryComp(silo, out var siloXform)
+                    && siloXform.GridUid == gridUid)
+                {
+                    continue;
+                }
+
+                _oreSilo.ClearSiloLink((uid, client));
+            }
+        }
+        catch (Exception e)
+        {
+            _sawmill.Warning($"CleanupOffGridOreSiloLinks: Exception while clearing silo links on grid {gridUid}: {e.Message}");
+        }
+    }
+    // Triad end
 
     /// <summary>
     /// Deletes entities on the grid that should not be persisted with the ship, such as unanchored objects or items not inside of a stash.

--- a/Content.Server/_Triad/Shipyard/ShipyardGridSaveSystem.cs
+++ b/Content.Server/_Triad/Shipyard/ShipyardGridSaveSystem.cs
@@ -276,11 +276,16 @@ public sealed partial class ShipyardGridSaveSystem : EntitySystem
 
         try
         {
-            // Clean up broken device links before serialization
-            CleanupBrokenDeviceLinks(gridUid);
-
             // Purge invalid entities
             PurgeInvalidEntities(gridUid);
+
+            // Triad: runs AFTER the purge so it sees the final entity set. In practice the engine
+            // already drops links to purged sinks (SharedDeviceLinkSystem.OnSinkRemoved fires on
+            // ComponentRemove during Del), so this ordering is defensive rather than load-bearing;
+            // the fix that matters is the off-grid test inside CleanupBrokenDeviceLinks.
+            // Clean up broken device links before serialization
+            CleanupBrokenDeviceLinks(gridUid);
+            // End Triad
 
             // remove any edge spreaders, we cannot save these
             RemoveEdgeSpreaderComponentComponentsOnGrid(gridUid);
@@ -431,16 +436,27 @@ public sealed partial class ShipyardGridSaveSystem : EntitySystem
     }
 
     /// <summary>
-    /// Cleans up broken device links where one or both linked entities no longer exist.
-    /// Preserves valid links where both source and sink entities are still present.
+    /// Cleans up device links that cannot be serialized: links whose sink no longer exists, and links
+    /// whose sink is not on this grid. Preserves links whose sink is on the grid being saved.
     /// </summary>
+    /// <remarks>
+    /// Triad: entity existence is NOT the right test here, which is why this ran for months while
+    /// DeviceLinkSource stayed the top cause of failed ship saves. The save runs with
+    /// <see cref="MissingEntityBehaviour.Ignore"/>, and EntitySerializer.Write returns the literal
+    /// string "invalid" for ANY EntityUid outside the set being serialized, alive or not. Because
+    /// DeviceLinkSourceComponent.LinkedPorts is keyed by EntityUid, a link to a live off-grid entity
+    /// writes "invalid" exactly like a dead one does, and two such links collide as a duplicate
+    /// dictionary key: ArgumentException, and the entire save dies.
+    ///
+    /// Off-grid links are cleared for good rather than restored after serializing. Their sinks are
+    /// round scoped for our purposes, typically remote triggers, so a link that cannot be carried
+    /// into the save is not worth carrying on the live ship either -- and clearing it leaves the ship
+    /// in the state that was actually saved.
+    /// </remarks>
     private void CleanupBrokenDeviceLinks(EntityUid gridUid)
     {
         try
         {
-            var linksRemoved = 0;
-            var sourcesProcessed = 0;
-
             // Collect all entities on the grid with device link source components
             var sourceQuery = _entityManager.EntityQueryEnumerator<DeviceLinkSourceComponent, TransformComponent>();
             while (sourceQuery.MoveNext(out var sourceEnt, out var sourceComp, out var xform))
@@ -448,28 +464,26 @@ public sealed partial class ShipyardGridSaveSystem : EntitySystem
                 if (xform.GridUid != gridUid)
                     continue;
 
-                sourcesProcessed++;
-
-                // Check LinkedPorts and remove links to entities that no longer exist
-                var brokenSinks = new List<EntityUid>();
+                // Anything that will not serialize to a real uid: the sink is gone, or it is off-grid.
+                var unserializableSinks = new List<EntityUid>();
                 foreach (var sinkEnt in sourceComp.LinkedPorts.Keys)
                 {
                     if (!_entityManager.EntityExists(sinkEnt) || _entityManager.IsQueuedForDeletion(sinkEnt))
                     {
-                        brokenSinks.Add(sinkEnt);
+                        unserializableSinks.Add(sinkEnt);
+                        continue;
                     }
+
+                    if (!_transformQuery.TryComp(sinkEnt, out var sinkXform) || sinkXform.GridUid != gridUid)
+                        unserializableSinks.Add(sinkEnt);
                 }
 
                 // Use the DeviceLinkSystem to properly remove broken links
-                foreach (var brokenSink in brokenSinks)
+                foreach (var sinkEnt in unserializableSinks)
                 {
-                    _deviceLink.RemoveSinkFromSource(sourceEnt, brokenSink, sourceComp);
-                    linksRemoved++;
+                    _deviceLink.RemoveSinkFromSource(sourceEnt, sinkEnt, sourceComp);
                 }
             }
-
-            /* if (linksRemoved > 0)
-                _sawmill.Info($"CleanupBrokenDeviceLinks: Removed {linksRemoved} broken device link(s) from {sourcesProcessed} source(s) on grid {gridUid}"); */
         }
         catch (Exception e)
         {

--- a/Content.Server/_Triad/Shipyard/ShipyardGridSaveSystem.cs
+++ b/Content.Server/_Triad/Shipyard/ShipyardGridSaveSystem.cs
@@ -10,7 +10,7 @@ using Content.Shared.Chemistry.Components;
 using Content.Shared.Chemistry.Components.SolutionManager;
 using Content.Shared.DeviceLinking;
 using Content.Shared.DeviceLinking.Components;
-using Content.Shared.Materials.OreSilo; // Triad: clearing off-grid silo links
+using Content.Shared.Materials.OreSilo;
 using Content.Shared.Mind.Components;
 using Content.Shared.Wall;
 using Robust.Shared.Containers;
@@ -62,7 +62,7 @@ public sealed partial class ShipyardGridSaveSystem : EntitySystem
     [Dependency] private SharedContainerSystem _containerSystem = default!;
     [Dependency] private EntityLookupSystem _lookup = default!;
     [Dependency] private SharedDeviceLinkSystem _deviceLink = default!;
-    [Dependency] private SharedOreSiloSystem _oreSilo = default!; // Triad: clearing off-grid silo links
+    [Dependency] private SharedOreSiloSystem _oreSilo = default!;
     [Dependency] private IPrototypeManager _prototypeManager = default!;
     [Dependency] private SharedTransformSystem _transform = default!;
     [Dependency] private StationSystem _station = default!;
@@ -278,11 +278,10 @@ public sealed partial class ShipyardGridSaveSystem : EntitySystem
 
         try
         {
-            // Triad: the part of a save that can actually fail lives in TryBuildShipSaveYaml, so it
-            // can be exercised without a session, a signing key or a client to deliver to.
+            // The part of a save that can actually fail lives in TryBuildShipSaveYaml, so it can be
+            // exercised without a session, a signing key or a client to deliver to.
             if (!TryBuildShipSaveYaml(gridUid, out var yaml, out var appraisalCost))
                 return false;
-            // End Triad
 
             // Triad ship anti-tamper start
             var shipFileBox = _tamperPolicy.SignSave(yaml, appraisalCost);
@@ -327,7 +326,7 @@ public sealed partial class ShipyardGridSaveSystem : EntitySystem
         }
     }
 
-    // Triad start: the save body, split out of TrySaveGridAsShip so it is testable.
+    // The save body, split out of TrySaveGridAsShip so it is testable.
     /// <summary>
     /// The serialization options every ship save runs with. Exposed so tests exercise the options the
     /// live save uses rather than a copy that can drift from them.
@@ -362,16 +361,15 @@ public sealed partial class ShipyardGridSaveSystem : EntitySystem
         // Purge invalid entities
         PurgeInvalidEntities(gridUid);
 
-        // Triad: runs AFTER the purge so it sees the final entity set. In practice the engine
-        // already drops links to purged sinks (SharedDeviceLinkSystem.OnSinkRemoved fires on
-        // ComponentRemove during Del), so this ordering is defensive rather than load-bearing;
-        // the fix that matters is the off-grid test inside CleanupBrokenDeviceLinks.
+        // Runs AFTER the purge so it sees the final entity set. In practice the engine already drops
+        // links to purged sinks (SharedDeviceLinkSystem.OnSinkRemoved fires on ComponentRemove during
+        // Del), so this ordering is defensive rather than load-bearing; the fix that matters is the
+        // off-grid test inside CleanupBrokenDeviceLinks.
         // Clean up broken device links before serialization
         CleanupBrokenDeviceLinks(gridUid);
 
         // Same treatment for ore-silo links, which are the other two-way EntityUid link on a ship.
         CleanupOffGridOreSiloLinks(gridUid);
-        // End Triad
 
         // remove any edge spreaders, we cannot save these
         RemoveEdgeSpreaderComponentComponentsOnGrid(gridUid);
@@ -391,12 +389,10 @@ public sealed partial class ShipyardGridSaveSystem : EntitySystem
         // 1) Serialize the grid and its children to a MappingDataNode (engine-standard format)
         var entities = new HashSet<EntityUid> { gridUid };
 
-        // triad start
         // these three lines were lifted from the loading code, and should be refactored into a function at some point
         var loadShipPrice = _configManager.GetCVar(TriadCCVars.LoadShipPrice);
         var fullAppraisal = _pricing.AppraiseGrid(gridUid, null);
         appraisalCost = (int)MathF.Round((float)fullAppraisal * loadShipPrice);
-        // triad end
 
         var (node, category) = _mapLoader.SerializeEntitiesRecursive(entities, ShipSaveSerializationOptions);
         /* if (category != FileCategory.Grid)
@@ -411,7 +407,6 @@ public sealed partial class ShipyardGridSaveSystem : EntitySystem
         yaml = WriteYamlToString(node);
         return true;
     }
-    // Triad end
 
     private void RemoveEdgeSpreaderComponentComponentsOnGrid(EntityUid gridUid)
     {

--- a/Content.Server/_Triad/Shipyard/ShipyardGridSaveSystem.cs
+++ b/Content.Server/_Triad/Shipyard/ShipyardGridSaveSystem.cs
@@ -568,7 +568,6 @@ public sealed partial class ShipyardGridSaveSystem : EntitySystem
             _sawmill.Warning($"CleanupOffGridOreSiloLinks: Exception while clearing silo links on grid {gridUid}: {e.Message}");
         }
     }
-    // Triad end
 
     /// <summary>
     /// Deletes entities on the grid that should not be persisted with the ship, such as unanchored objects or items not inside of a stash.

--- a/Content.Shared/Materials/OreSilo/OreSiloComponent.cs
+++ b/Content.Shared/Materials/OreSilo/OreSiloComponent.cs
@@ -12,8 +12,21 @@ public sealed partial class OreSiloComponent : Component
 {
     /// <summary>
     /// The <see cref="OreSiloClientComponent"/> that are connected to this silo.
+    /// Runtime-only: rebuilt from the clients on startup. <see cref="OreSiloClientComponent.Silo"/> is
+    /// the authoritative half of the link.
     /// </summary>
+    // Triad: persisting BOTH halves of a two-way link is what produced the dangling ore-silo
+    // references in production. A ship save carries whichever half sits on the grid, so a silo saved
+    // without its clients (or a client saved without its silo) deserialized a uid that resolves to
+    // entity 0, and every downstream lookup then logged a resolve error with a full stack trace.
+    // Only the client half is persisted now and this set is rebuilt from it, which is the same shape
+    // the engine already uses for DeviceLinkSinkComponent.LinkedSources: one side saved, the other
+    // reconstructed by the source's ComponentStartup.
+    /*
     [DataField, AutoNetworkedField]
+    */
+    [AutoNetworkedField]
+    // End Triad
     public HashSet<EntityUid> Clients = new();
 
     /// <summary>

--- a/Content.Shared/Materials/OreSilo/SharedOreSiloSystem.cs
+++ b/Content.Shared/Materials/OreSilo/SharedOreSiloSystem.cs
@@ -17,7 +17,6 @@ public abstract partial class SharedOreSiloSystem : EntitySystem
     {
         SubscribeLocalEvent<OreSiloComponent, ToggleOreSiloClientMessage>(OnToggleOreSiloClient);
         SubscribeLocalEvent<OreSiloComponent, ComponentShutdown>(OnSiloShutdown);
-        SubscribeLocalEvent<OreSiloComponent, MapInitEvent>(OnSiloMapInit); // Triad: drop links that did not survive the load
         Subs.BuiEvents<OreSiloComponent>(OreSiloUiKey.Key,
             subs =>
         {
@@ -28,30 +27,35 @@ public abstract partial class SharedOreSiloSystem : EntitySystem
         SubscribeLocalEvent<OreSiloClientComponent, GetStoredMaterialsEvent>(OnGetStoredMaterials);
         SubscribeLocalEvent<OreSiloClientComponent, ConsumeStoredMaterialsEvent>(OnConsumeStoredMaterials);
         SubscribeLocalEvent<OreSiloClientComponent, ComponentShutdown>(OnClientShutdown);
-        SubscribeLocalEvent<OreSiloClientComponent, MapInitEvent>(OnClientMapInit); // Triad: drop links that did not survive the load
+        SubscribeLocalEvent<OreSiloClientComponent, ComponentStartup>(OnClientStartup); // Triad: rebuild the silo's client set
 
         _clientQuery = GetEntityQuery<OreSiloClientComponent>();
     }
 
-    // Triad: both sides of the link are DataFields, so a silo/client pair that sits on one grid is
-    // saved and restored intact, which is what we want. When only one side is in the save, though, the
-    // other side deserializes as a dangling reference and lands as entity 0. Prod shows the deserializer
-    // reporting exactly that ("invalid EntityUid reference ... component: OreSilo"), and the entity 0
-    // then reaches the transform and metadata lookups downstream, where each call logs an error with a
-    // full stack trace. Prune what did not come back rather than carrying a link to nothing.
-    private void OnSiloMapInit(Entity<OreSiloComponent> ent, ref MapInitEvent args)
+    // Triad: the client half is the only half that is persisted, so it is also the only half that can
+    // arrive pointing at nothing. Validate it once here and rebuild the silo's client set from it.
+    //
+    // This replaces a pair of MapInitEvent handlers that pruned dead uids out of both halves after the
+    // fact. ComponentStartup is the better hook for two reasons: it fires for every entity on every
+    // load path, where MapInit only fires for pre-init content, and the deserializer allocates every
+    // entity before starting any of them, so the silo is guaranteed to exist by the time its clients
+    // start. It is also the hook SharedDeviceLinkSystem.OnSourceStartup already uses to do exactly
+    // this job for device links.
+    private void OnClientStartup(Entity<OreSiloClientComponent> ent, ref ComponentStartup args)
     {
-        if (ent.Comp.Clients.RemoveWhere(client => !Exists(client)) > 0)
-            Dirty(ent);
-    }
-
-    private void OnClientMapInit(Entity<OreSiloClientComponent> ent, ref MapInitEvent args)
-    {
-        if (ent.Comp.Silo is not { } silo || Exists(silo))
+        if (ent.Comp.Silo is not { } silo)
             return;
 
-        ent.Comp.Silo = null;
-        Dirty(ent);
+        // A link saved without the other end, or a silo deleted while this client was not loaded.
+        if (!TryComp<OreSiloComponent>(silo, out var siloComp))
+        {
+            ent.Comp.Silo = null;
+            Dirty(ent);
+            return;
+        }
+
+        if (siloComp.Clients.Add(ent))
+            Dirty(silo, siloComp);
     }
 
     private void OnToggleOreSiloClient(Entity<OreSiloComponent> ent, ref ToggleOreSiloClientMessage args)
@@ -191,6 +195,35 @@ public abstract partial class SharedOreSiloSystem : EntitySystem
         silo = linked;
         return true;
     }
+
+    // Triad start
+    /// <summary>
+    /// Breaks a client's link to its silo, from both halves. Safe to call when the silo is already
+    /// gone, and a no-op when the client has no link.
+    /// </summary>
+    /// <remarks>
+    /// Exists so callers outside this system can drop a link without writing to the [Access]-restricted
+    /// members themselves. The ship save uses it to clear links whose silo is not coming along.
+    /// </remarks>
+    [PublicAPI]
+    public void ClearSiloLink(Entity<OreSiloClientComponent?> client)
+    {
+        if (!Resolve(client, ref client.Comp, false))
+            return;
+
+        if (client.Comp.Silo is not { } silo)
+            return;
+
+        client.Comp.Silo = null;
+        Dirty(client, client.Comp);
+
+        if (!TryComp<OreSiloComponent>(silo, out var siloComp))
+            return;
+
+        if (siloComp.Clients.Remove(client))
+            Dirty(silo, siloComp);
+    }
+    // Triad end
 
     /// <summary>
     /// Checks if a given client fulfills the criteria to link/receive materials from an ore silo.

--- a/Content.Shared/Payload/Components/PayloadTriggerComponent.cs
+++ b/Content.Shared/Payload/Components/PayloadTriggerComponent.cs
@@ -41,6 +41,19 @@ public sealed partial class PayloadTriggerComponent : Component
     ///     when removing the component, to ensure that removal of this trigger only removes the components that it was
     ///     responsible for adding.
     /// </remarks>
+    // Triad: System.Type has no data definition and no type serializer, so once a trigger is installed
+    // in a case and this set is non-empty, persisting it throws "No data definition found for type
+    // System.RuntimeType" and kills the whole ship-grid save. Runtime-only now.
+    // This never round-tripped anyway: the write threw, and a load raises no container-insert event
+    // (SharedContainerSystem.OnStartupValidation re-flags contents without re-inserting them), so
+    // after a load PayloadSystem.OnEntityInserted has not run and both this set and Active are empty.
+    // The case keeps the components it was granted, since they serialize as its own, but uninstalling
+    // the trigger will not remove them and direct triggers no longer forward to the case. Both are
+    // pre-existing: Active was never persisted either. Not changed here.
+    /*
     [DataField("grantedComponents", serverOnly: true)]
+    */
+    [ViewVariables]
+    // End Triad
     public HashSet<Type> GrantedComponents = new();
 }

--- a/Content.Shared/SmartFridge/SharedSmartFridgeSystem.cs
+++ b/Content.Shared/SmartFridge/SharedSmartFridgeSystem.cs
@@ -32,6 +32,9 @@ public abstract partial class SharedSmartFridgeSystem : EntitySystem
         SubscribeLocalEvent<SmartFridgeComponent, EntInsertedIntoContainerMessage>(OnItemInserted);
         SubscribeLocalEvent<SmartFridgeComponent, EntRemovedFromContainerMessage>(OnItemRemoved);
         SubscribeLocalEvent<SmartFridgeComponent, AfterAutoHandleStateEvent>(OnAfterAutoHandleState);
+        // Triad: rebuild the stock listing from the container on load, see OnMapInit
+        SubscribeLocalEvent<SmartFridgeComponent, MapInitEvent>(OnMapInit);
+        // End Triad
 
         SubscribeLocalEvent<SmartFridgeComponent, GetVerbsEvent<AlternativeVerb>>(OnGetAltVerb);
         SubscribeLocalEvent<SmartFridgeComponent, GetDumpableVerbEvent>(OnGetDumpableVerb);
@@ -78,6 +81,33 @@ public abstract partial class SharedSmartFridgeSystem : EntitySystem
 
         args.Handled = DoInsert(ent, args.User, [args.Used], true);
     }
+
+    // Triad: ContainedEntries is no longer a DataField (see SmartFridgeComponent), because a
+    // SmartFridgeEntry key cannot be written as a YAML mapping key and killed the whole ship save.
+    // It is derived state over the container, so rebuild it once the fridge is loaded -- otherwise a
+    // saved ship comes back with a stocked fridge that reports itself empty. Entries is still
+    // persisted and is deliberately NOT cleared here: it is the fridge's menu and outlives its stock.
+    private void OnMapInit(Entity<SmartFridgeComponent> ent, ref MapInitEvent args)
+    {
+        if (!_container.TryGetContainer(ent, ent.Comp.Container, out var container))
+            return;
+
+        ent.Comp.ContainedEntries.Clear();
+
+        foreach (var contained in container.ContainedEntities)
+        {
+            var key = new SmartFridgeEntry(Identity.Name(contained, EntityManager));
+            if (!ent.Comp.Entries.Contains(key))
+                ent.Comp.Entries.Add(key);
+
+            ent.Comp.ContainedEntries.TryAdd(key, new());
+            ent.Comp.ContainedEntries[key].Add(GetNetEntity(contained));
+        }
+
+        Dirty(ent);
+        UpdateUI(ent);
+    }
+    // End Triad
 
     private void OnItemInserted(Entity<SmartFridgeComponent> ent, ref EntInsertedIntoContainerMessage args)
     {

--- a/Content.Shared/SmartFridge/SmartFridgeComponent.cs
+++ b/Content.Shared/SmartFridge/SmartFridgeComponent.cs
@@ -45,7 +45,15 @@ public sealed partial class SmartFridgeComponent : Component
     /// <summary>
     /// A mapping of smart fridge entries to the actual contained contents
     /// </summary>
+    // Triad: SmartFridgeEntry is a data definition, so it serializes to a MappingDataNode and cannot
+    // be a YAML mapping key -- persisting this threw "Yaml mapping keys must serialize to a
+    // ValueDataNode" and killed the whole ship-grid save. This is a UI index over live container
+    // contents, so it is runtime-only now and rebuilt from the container on MapInit.
+    /*
     [DataField, AutoNetworkedField]
+    */
+    [AutoNetworkedField]
+    // End Triad
     [Access(typeof(SharedSmartFridgeSystem), Other = AccessPermissions.ReadExecute)]
     public Dictionary<SmartFridgeEntry, HashSet<NetEntity>> ContainedEntries = new();
 

--- a/Content.Shared/_Shitmed/Body/Part/BodyPartAppearanceComponent.cs
+++ b/Content.Shared/_Shitmed/Body/Part/BodyPartAppearanceComponent.cs
@@ -12,7 +12,15 @@ public sealed partial class BodyPartAppearanceComponent : Component
     /// <summary>
     ///     HumanoidVisualLayer type for this body part.
     /// </summary>
+    // Triad: this DataField's YAML key was "type", which collides with the component node's own
+    // "type:" discriminator when the engine writes the mapping, throwing "Already contains key type"
+    // and killing the whole ship-grid save. Renamed the key rather than dropping the field, so a
+    // severed limb keeps its layer type across a save. No prototype sets it, so no content changes.
+    /*
     [DataField, AutoNetworkedField]
+    */
+    [DataField("layerType"), AutoNetworkedField]
+    // End Triad
     public HumanoidVisualLayers Type { get; set; }
 
     /// <summary>

--- a/Resources/Prototypes/Entities/Objects/Devices/Circuitboards/Machine/production.yml
+++ b/Resources/Prototypes/Entities/Objects/Devices/Circuitboards/Machine/production.yml
@@ -1142,11 +1142,6 @@
       MatterBin: 1 # Frontier stackRequirements<requirements
     stackRequirements:
       Steel: 1
-# Triad: re-enabled alongside MachineFlatpacker. The board carried its own marker, and because the
-# contraband check in IsInvalidEntity runs before the IsInsidePersistentStorage check, un-marking only
-# the machine left a flatpacker that saved and loaded with an empty board slot.
-#  - type: SavingContraband
-#    examineText: ship-saving-contraband-1-text
 
 - type: entity
   id: EmitterCircuitboard

--- a/Resources/Prototypes/Entities/Objects/Devices/Circuitboards/Machine/production.yml
+++ b/Resources/Prototypes/Entities/Objects/Devices/Circuitboards/Machine/production.yml
@@ -1142,8 +1142,11 @@
       MatterBin: 1 # Frontier stackRequirements<requirements
     stackRequirements:
       Steel: 1
-  - type: SavingContraband
-    examineText: ship-saving-contraband-1-text
+# Triad: re-enabled alongside MachineFlatpacker. The board carried its own marker, and because the
+# contraband check in IsInvalidEntity runs before the IsInsidePersistentStorage check, un-marking only
+# the machine left a flatpacker that saved and loaded with an empty board slot.
+#  - type: SavingContraband
+#    examineText: ship-saving-contraband-1-text
 
 - type: entity
   id: EmitterCircuitboard

--- a/Resources/Prototypes/Entities/Structures/Machines/flatpacker.yml
+++ b/Resources/Prototypes/Entities/Structures/Machines/flatpacker.yml
@@ -97,14 +97,6 @@
     - board_slot
   - type: MaterialStorageMagnetPickup # Frontier
     range: 0.30 # Frontier
-# Triad: re-enabled for ship saving. This was excluded with no technical justification on record: it
-# entered the exclusion list in a batch captioned "obvious non-ship entities", under the heading
-# "Uplinks and bundled items", alongside mercenary uplinks and criminal-records computers. A
-# flatpacker holding a board, carrying stored materials, mid-pack and linked to an off-grid ore silo
-# saves and loads back intact; see FlatpackerSaveTest. Its machine board carried a separate marker
-# and is re-enabled with it. Restore both lines together if this is ever reverted.
-#  - type: SavingContraband
-#    examineText: ship-saving-contraband-1-text
 #  - type: StaticPrice # Frontier
 #    price: 2000
 

--- a/Resources/Prototypes/Entities/Structures/Machines/flatpacker.yml
+++ b/Resources/Prototypes/Entities/Structures/Machines/flatpacker.yml
@@ -97,8 +97,14 @@
     - board_slot
   - type: MaterialStorageMagnetPickup # Frontier
     range: 0.30 # Frontier
-  - type: SavingContraband
-    examineText: ship-saving-contraband-1-text
+# Triad: re-enabled for ship saving. This was excluded with no technical justification on record: it
+# entered the exclusion list in a batch captioned "obvious non-ship entities", under the heading
+# "Uplinks and bundled items", alongside mercenary uplinks and criminal-records computers. A
+# flatpacker holding a board, carrying stored materials, mid-pack and linked to an off-grid ore silo
+# saves and loads back intact; see FlatpackerSaveTest. Its machine board carried a separate marker
+# and is re-enabled with it. Restore both lines together if this is ever reverted.
+#  - type: SavingContraband
+#    examineText: ship-saving-contraband-1-text
 #  - type: StaticPrice # Frontier
 #    price: 2000
 


### PR DESCRIPTION
## About the PR

Ship saves have been failing on live for weeks: 24 distinct grids over the last 30 days, because a single component holding runtime state the YAML writer cannot express takes the whole save down with it. This fixes every cause found in that window plus two latent ones, and re-enables flatpackers for ship saving, which turned out to have been excluded with no technical reason on record.

## Why / Balance

The save runs with the engine default `EntityExceptionBehaviour.Rethrow`, so one bad component aborts the entire grid save. Seven distinct causes, all the same shape:

| Component | Why it threw |
|---|---|
| `SmartFridge.containedEntries` | dictionary keyed by a data definition, which cannot be a YAML mapping key |
| `KillTracker.lifetimeDamage` | same, `KillSource` is a polymorphic record |
| `NPCRetaliation.attackMemories` | keyed by `EntityUid` on arbitrary attackers; two off-grid keys both write `invalid` and collide |
| `PayloadTrigger.grantedComponents` | `HashSet<Type>`; `RuntimeType` has no data definition |
| `BodyPartAppearance` | a DataField whose YAML key was literally `type`, colliding with the component node's own discriminator |
| `DeviceLinkSource.linkedPorts` | the top cause on live: existence was the wrong test, see below |
| `OreSilo` | both halves of a two-way link were persisted |

`DeviceLinkSource` is worth calling out because a guard for it already existed and did not work. The save uses `MissingEntityBehaviour.Ignore`, and `EntitySerializer.Write` returns the literal string `invalid` for any `EntityUid` outside the set being serialized, **alive or not**. `LinkedPorts` is keyed by `EntityUid`, so a docking button wired to station-side shutters writes `invalid` for a perfectly live entity, and the second such link is a duplicate dictionary key. The old cleanup only looked for deleted entities, so it never saw this class at all.

The ore silo had accumulated six defensive `Exists()` checks at its read sites, one of them recording millions of errors a day. Only the client half is persisted now and the silo's client set is rebuilt from it on `ComponentStartup`, which is the shape the engine already uses for `DeviceLinkSinkComponent.LinkedSources`.

On the balance side, the only player-facing change is flatpackers. They were dropped from saves by `SavingContraband`, which they picked up in a batch captioned "obvious non-ship entities" under the heading "Uplinks and bundled items", next to mercenary uplinks and criminal-records computers, inside a commit about an unrelated bug. Their assigned class is the mildest one, "Legal to own, but will be seized upon storing". A flatpacker holding a board, carrying materials, mid-pack and linked to an off-grid ore silo saves and loads back intact, so the exclusion is lifted. Its machine board carried a separate marker and is lifted with it.

## Media

N/A, this is a save-pipeline fix with no visual component.

## Requirements

- [x] I have read the guidelines and documentation relevant to this PR.
- [ ] I have added media to this PR or it does not require an ingame showcase.
- [x] I can confirm this PR contains either no AI-generated content, or AI-generated content that meets our guidelines.

## How to test

Automated, 9 integration tests across three fixtures:

```
dotnet test Content.IntegrationTests/Content.IntegrationTests.csproj --filter "FullyQualifiedName~ShipSaveSerializationTest|FullyQualifiedName~FlatpackerSaveTest|FullyQualifiedName~OreSiloSaveTest"
```

Two of those are deliberately controls rather than assertions about our own code. `ControlTwoOffGridKeysInAPersistedDictionaryStillCollide` plants a component with the bug's exact shape and proves the serializer still throws on two off-grid keys and not on one, so a clean run of the rest means something. `ListingRebuildDependsOnTheSanitizerStrippingMapInit` saves the same fridge through the engine's own path, where the listing comes back empty over a full container, pinning why the Triad round trip works at all.

In game: buy a ship, save it, load it. Verified over three save/load cycles with no `Ship save failed`, no serializer exception, and no occurrence of the literal string `invalid` in the saved file.

Not yet verified in game, and worth a reviewer's eye: a ship carrying an actual flatpacker, and a silo-and-client pair on the same grid. Both are covered by integration tests but neither has been exercised by hand. For the silo specifically, put it on the ship rather than the station, since `CanTransmitMaterials` refuses any pair whose grids differ.

## Breaking changes

- `OreSiloComponent.Clients` is no longer a `[DataField]`. It stays `[AutoNetworkedField]` and is rebuilt on `ComponentStartup` from `OreSiloClientComponent.Silo`, which is now the authoritative half. Existing maps that set it in YAML would silently stop having it applied, though nothing in the repo does.
- `BodyPartAppearance`'s DataField key changed from `type` to `layerType`. Nothing sets it in YAML, and it could never round-trip before because writing it threw, so no data migration is needed.
- `SmartFridge.containedEntries`, `KillTracker.lifetimeDamage`, `NPCRetaliation.attackMemories` and `PayloadTrigger.grantedComponents` are no longer persisted. All four are runtime state and no prototype sets any of them. Stale keys in already-saved ships are ignored on read: the generated `Read` is a `TryGet` per known key with no pass over leftovers.
- New internals on `ShipyardGridSaveSystem`: `TryBuildShipSaveYaml` and `ShipSaveSerializationOptions`, both `internal`, split out so the fallible part of a save is reachable without a session or a signing key. `TrySaveGridAsShip` is behaviourally unchanged.
- New public API `SharedOreSiloSystem.ClearSiloLink`, so callers outside that system can drop a link without writing to `[Access]`-restricted members.

**Changelog**

:cl:
- fix: Ship saves no longer fail outright when a smart fridge, a wired docking button, an assembled grenade, a severed limb or an ore silo link is aboard.
- fix: Loading a saved ship no longer leaves a stocked smart fridge reporting itself empty.
- tweak: Flatpackers and their machine boards can now be saved with a ship instead of being seized.
