### PR TITLE
12 Gauge Box Shellcount Revert

### DIFF
--- a/Resources/Prototypes/_Mono/Entities/Objects/Weapons/Guns/Ammunition/BaseAmmoProvider.yml
+++ b/Resources/Prototypes/_Mono/Entities/Objects/Weapons/Guns/Ammunition/BaseAmmoProvider.yml
@@ -32,7 +32,7 @@
       whitelist:
         tags:
         - ShellShotgun12_gaugeBuckshot
-      capacity: 16 # Triad 32 -> 16
+      capacity: 32
     - type: MagazineVisuals
       magState: mag
       steps: 5


### PR DESCRIPTION
## About the PR
This simply reverts the 12 gauge ammo count in their boxes back to what it was by default.

## Why / Balance
Carrying 3-4 boxes of ammo for a 12 gauge only to run out mid Expedition or Roid felt really bad.

## Requirements
<!-- Confirm the following by placing an X in the brackets [X]: -->
- [x] I have read the guidelines and documentation relevant to this PR.
- [x] I have added media to this PR or it does not require an ingame showcase.
- [x] I can confirm this PR contains either no AI-generated content, or AI-generated content that meets our guidelines.
<!-- You should understand that not following the above may get your PR closed at maintainer’s discretion -->
<!-- When using AI, make sure you are already proficient in creating whatever content you are attempting to generate and that you already have experience contributing to SS14. This means using AI to enhance your preexisting workflow, not vibecoding. -->

## How to test
grab 12 gauge box of ammo, observe how many shells it has now yay!

## Breaking changes
Reverted the nerf to 12 gauge box ammo count.

**Changelog**
<!-- Add a Changelog entry to make players aware of new features or changes that could affect gameplay.
Make sure to read the guidelines and take this Changelog template out of the comment block in order for it to show up.
Changelog must have a :cl: symbol, so the bot recognizes the changes and adds them to the game's changelog.
Remove this symbol for non-player facing PRs.-->
:cl:
- tweak: Reverted the 12 Gauge Box ammo count nerf
