### PR TITLE
Migrate Legacy Artifacts in Ship Saves Instead of Failing the Load

### DIFF
--- a/Content.IntegrationTests/Tests/_Triad/Shipyard/LegacyXenoarchShipLoadTest.cs
+++ b/Content.IntegrationTests/Tests/_Triad/Shipyard/LegacyXenoarchShipLoadTest.cs
@@ -1,0 +1,144 @@
+// SPDX-FileCopyrightText: 2026 Triad Sector contributors
+//
+// SPDX-License-Identifier: AGPL-3.0-or-later
+
+using System.IO;
+using System.Linq;
+using System.Text.RegularExpressions;
+using Content.Server._HL.Shipyard;
+using Content.Shared.Xenoarchaeology.Artifact.Components;
+using Robust.Shared.ContentPack;
+using Robust.Shared.EntitySerialization.Systems;
+using Robust.Shared.GameObjects;
+using Robust.Shared.Map;
+using Robust.Shared.Maths;
+using Robust.Shared.Utility;
+
+namespace Content.IntegrationTests.Tests._Triad.Shipyard;
+
+/// <summary>
+/// Guards the day-one rollout bug of the xenoarchaeology rework: ship files live on the player's
+/// machine, so a ship saved on the legacy build hands the loader entities whose prototypes the rework
+/// removed, and one missing prototype fails the entire ship load ("Failed to load ship.", 13 times on
+/// prod within hours of the deploy).
+///
+/// The fix is two layered halves and this test exercises them together, end to end:
+/// triad_migration.yml renames the artifact bodies to their node-graph replacements inside the
+/// engine's deserializer, and <see cref="ShipSaveYamlSanitizer.ScrubShipLoadYaml"/> drops the legacy
+/// grant action and the deleted legacy component nodes before the loader sees them. Either half alone
+/// still fails: without the migration the load dies on the missing body prototype, without the scrub
+/// it survives but spews an error per legacy node. The pool fails any test whose run logged an error,
+/// so a clean pass here is also the zero-noise assertion.
+/// </summary>
+[TestFixture]
+public sealed class LegacyXenoarchShipLoadTest
+{
+    // The legacy nodes real pre-rework files carry, verbatim shapes from a live map file of that era:
+    // the Artifact/BiasedArtifact component nodes on the body, and the grant action parented into the
+    // body's 'actions' container. {0} is the grid's yaml uid.
+    private const string LegacyInjection = @"- proto: VariedXenoArtifactItem
+  entities:
+  - uid: 9001
+    components:
+    - type: Transform
+      parent: {0}
+      pos: 0.5,0.5
+    - type: Artifact
+      isSuppressed: True
+    - type: BiasedArtifact
+    - type: ContainerContainer
+      containers:
+        actions: !type:Container
+          ents:
+          - 9002
+- proto: ActionArtifactActivate
+  entities:
+  - uid: 9002
+    components:
+    - type: Transform
+      parent: 9001
+";
+
+    private static readonly Regex UidLine = new(@"^  - uid: (\d+)$", RegexOptions.Multiline | RegexOptions.Compiled);
+
+    [Test]
+    public async Task LegacyArtifactShipStillLoads()
+    {
+        await using var pair = await PoolManager.GetServerClient();
+        var server = pair.Server;
+        var entManager = server.ResolveDependency<IEntityManager>();
+        var mapLoader = entManager.System<MapLoaderSystem>();
+        var mapSystem = entManager.System<SharedMapSystem>();
+        var userData = server.ResolveDependency<IResourceManager>().UserData;
+
+        var savedPath = new ResPath("/legacy xenoarch ship.yml");
+        var legacyPath = new ResPath("/legacy xenoarch ship injected.yml");
+
+        // A current-format grid file to graft the legacy entities into, so the fixture cannot rot
+        // away from the real save format the way a hand-authored file would.
+        await server.WaitPost(() =>
+        {
+            mapSystem.CreateMap(out var mapId);
+            var grid = mapSystem.CreateGridEntity(mapId);
+            mapSystem.SetTile(grid, new Vector2i(0, 0), new Tile(1));
+            entManager.RunMapInit(grid.Owner, entManager.GetComponent<MetaDataComponent>(grid));
+            Assert.That(mapLoader.TrySaveGrid(grid.Owner, savedPath));
+            entManager.DeleteEntity(grid.Owner);
+            mapSystem.DeleteMap(mapId);
+        });
+
+        await server.WaitIdleAsync();
+
+        string savedYaml;
+        await using (var stream = userData.Open(savedPath, FileMode.Open))
+        using (var reader = new StreamReader(stream))
+        {
+            // The emitter writes \r\n on Windows; the anchors and splice below assume \n.
+            savedYaml = (await reader.ReadToEndAsync()).Replace("\r\n", "\n");
+        }
+
+        // The freshly saved grid is the file's only entity, so its uid is the file's only uid. Both
+        // asserts are controls: if the save format grows a second entity or drops the marker line,
+        // the injection below would target the wrong parent and the test would prove nothing.
+        var uids = UidLine.Matches(savedYaml);
+        Assert.That(uids, Has.Count.EqualTo(1), "expected the empty grid to be the file's only entity");
+        var gridYamlUid = uids[0].Groups[1].Value;
+        Assert.That(savedYaml, Does.Contain("\nentities:\n"), "expected a top-level entities sequence");
+
+        var injected = savedYaml.Replace("\nentities:\n",
+            "\nentities:\n" + LegacyInjection.Replace("{0}", gridYamlUid));
+
+        // The production entry point the console load path runs. Four nodes: the action entity, two
+        // legacy component nodes, and the container slot that held the action.
+        var scrubbedYaml = ShipSaveYamlSanitizer.ScrubShipLoadYaml(injected, out var scrubbed);
+        Assert.That(scrubbed, Is.EqualTo(4), "the scrub missed a legacy node the injection planted");
+
+        await server.WaitPost(() =>
+        {
+            using var writer = userData.OpenWriteText(legacyPath);
+            writer.Write(scrubbedYaml);
+        });
+
+        await server.WaitAssertion(() =>
+        {
+            mapSystem.CreateMap(out var mapId);
+            Assert.That(mapLoader.TryLoadGrid(mapId, legacyPath, out var grid),
+                "a legacy-artifact ship failed to load; the whole point of the migration is that it cannot");
+
+            // The migration renamed the body inside the deserializer: the file says
+            // VariedXenoArtifactItem, the world holds its node-graph replacement.
+            var artifacts = entManager.GetEntities()
+                .Where(uid => entManager.GetComponentOrNull<MetaDataComponent>(uid)?.EntityPrototype?.ID
+                              == "ComplexXenoArtifactItem")
+                .ToList();
+            Assert.That(artifacts, Has.Count.EqualTo(1));
+            Assert.That(entManager.HasComponent<XenoArtifactComponent>(artifacts[0]),
+                "the renamed body composed without the rework's artifact component");
+
+            entManager.DeleteEntity(grid!.Value.Owner);
+            mapSystem.DeleteMap(mapId);
+        });
+
+        await pair.CleanReturnAsync();
+    }
+}

--- a/Content.Server/_HL/Shipyard/ShipSaveYamlSanitizer.cs
+++ b/Content.Server/_HL/Shipyard/ShipSaveYamlSanitizer.cs
@@ -198,6 +198,65 @@ public static class ShipSaveYamlSanitizer
         ["VendingMachinePurchase"] = "purchaseGrid",
     };
 
+    // Entity prototypes removed by the 2026-08 xenoarchaeology rework whose entities are dropped from
+    // a ship file on load. Only the legacy grant action lives here: the artifact bodies themselves are
+    // renamed to their node-graph replacements by triad_migration.yml instead, which this scrub must
+    // not duplicate. Dropping the group here (rather than leaving it to the migration's null entry)
+    // lets the reference prune below clean up the container slots that pointed at it.
+    private static readonly HashSet<string> LegacyRemovedEntityPrototypes = new(StringComparer.Ordinal)
+    {
+        "ActionArtifactActivate",
+    };
+
+    // Component types the 2026-08 xenoarchaeology rework deleted from the codebase. A ship saved on
+    // the legacy build can carry these nodes on its (now renamed) artifacts; the deserializer skips an
+    // unregistered component anyway, this just does it without an error line per node. Four legacy
+    // names were re-registered by the rework with new data shapes (AnalysisConsole, ArtifactAnalyzer,
+    // NodeScanner, SuppressArtifactContainer) and are deliberately absent: those are live components
+    // on current saves and their nodes must reach the loader.
+    private static readonly HashSet<string> LegacyRemovedComponentTypes = new(StringComparer.Ordinal)
+    {
+        "ActiveArtifactAnalyzer",
+        "ActiveScannedArtifact",
+        "Artifact",
+        "ArtifactAnchorTrigger",
+        "ArtifactDamageTrigger",
+        "ArtifactDeathTrigger",
+        "ArtifactElectricityTrigger",
+        "ArtifactExamineTrigger",
+        "ArtifactGasTrigger",
+        "ArtifactHeatTrigger",
+        "ArtifactInteractionTrigger",
+        "ArtifactLandTrigger",
+        "ArtifactMagnetTrigger",
+        "ArtifactMicrowaveTrigger",
+        "ArtifactMusicTrigger",
+        "ArtifactPressureTrigger",
+        "ArtifactTimerTrigger",
+        "BiasedArtifact",
+        "ChargeBatteryArtifact",
+        "ChemicalPuddleArtifact",
+        "DamageNearbyArtifact",
+        "EmpArtifact",
+        "FoamArtifact",
+        "GasArtifact",
+        "IgniteArtifact",
+        "KnockArtifact",
+        "LightFlickerArtifact",
+        "PhasingArtifact",
+        "PolyOthersArtifact",
+        "PortalArtifact",
+        "RandomInstrumentArtifact",
+        "RandomTeleportArtifact",
+        "ShuffleArtifact",
+        "SpawnArtifact",
+        "TelepathicArtifact",
+        "TemperatureArtifact",
+        "ThrowArtifact",
+        "TraversalDistorter",
+        "TriggerArtifact",
+    };
+
     public static void SanitizeShipSaveNode(MappingDataNode root, IPrototypeManager prototypeManager)
     {
         // Keep serialized nullspace empty so ship exports stay scoped to the grid payload.
@@ -566,7 +625,9 @@ public static class ShipSaveYamlSanitizer
     }
 
     /// <summary>
-    /// Strips dangling entity references from a ship file on its way in. Returns how many were removed.
+    /// Strips stale nodes from a ship file on its way in: entities of removed legacy prototypes,
+    /// component nodes of removed legacy component types, and dangling entity references. Returns how
+    /// many nodes were removed.
     /// </summary>
     // Triad: the save-side prune only protects ships saved after it shipped, and there is no backlog we
     // can migrate: ship files live on the player's machine and are handed back to us at load time, so a
@@ -578,17 +639,92 @@ public static class ShipSaveYamlSanitizer
     // 'invalid' the writer emits for a reference it could not resolve, since that is never a uid the
     // file defines. Nothing removed here was reachable: the deserializer resolves both cases to
     // EntityUid.Invalid regardless, it just logs an error per occurrence on the way.
+    //
+    // The legacy strip runs first so the uids of dropped legacy entities feed the same prune, clearing
+    // the container slots that held them (a legacy artifact's grant action sits in its 'actions'
+    // container). Prototype RENAMES are deliberately not handled here: triad_migration.yml applies
+    // them inside the engine's deserializer, for this path and every other map load alike.
     public static int ScrubShipLoadNode(MappingDataNode root)
     {
         if (!root.TryGet("entities", out SequenceDataNode? protoSeq) || protoSeq == null)
             return 0;
 
-        return PruneContainerReferencesToRemovedEntities(protoSeq, new HashSet<string>(StringComparer.Ordinal));
+        var removedEntityUids = new HashSet<string>(StringComparer.Ordinal);
+        var scrubbed = StripLegacyRemovedNodes(protoSeq, removedEntityUids);
+        return scrubbed + PruneContainerReferencesToRemovedEntities(protoSeq, removedEntityUids);
     }
 
     /// <summary>
-    /// Parses a ship file, strips dangling entity references, and re-emits it. Returns the text
-    /// unchanged when there is nothing to remove or when it cannot be parsed.
+    /// Removes whole entity groups whose prototype no longer exists and component nodes whose type no
+    /// longer exists, collecting the removed entities' uids so the caller can prune references to
+    /// them. Returns how many nodes were removed.
+    /// </summary>
+    private static int StripLegacyRemovedNodes(SequenceDataNode protoSeq, HashSet<string> removedEntityUids)
+    {
+        var scrubbed = 0;
+
+        for (var protoIdx = protoSeq.Count - 1; protoIdx >= 0; protoIdx--)
+        {
+            if (protoSeq[protoIdx] is not MappingDataNode protoMap)
+                continue;
+
+            if (!protoMap.TryGet("entities", out SequenceDataNode? entitiesSeq) || entitiesSeq == null)
+                continue;
+
+            if (protoMap.TryGet("proto", out ValueDataNode? protoIdNode)
+                && protoIdNode != null
+                && !protoIdNode.IsNull
+                && LegacyRemovedEntityPrototypes.Contains(protoIdNode.Value))
+            {
+                foreach (var entityNode in entitiesSeq)
+                {
+                    if (entityNode is MappingDataNode entMap
+                        && entMap.TryGet("uid", out ValueDataNode? uidNode)
+                        && uidNode != null
+                        && !uidNode.IsNull)
+                    {
+                        removedEntityUids.Add(uidNode.Value);
+                    }
+
+                    scrubbed++;
+                }
+
+                protoSeq.RemoveAt(protoIdx);
+                continue;
+            }
+
+            foreach (var entityNode in entitiesSeq)
+            {
+                if (entityNode is not MappingDataNode entMap)
+                    continue;
+
+                if (!entMap.TryGet("components", out SequenceDataNode? comps) || comps == null)
+                    continue;
+
+                for (var compIdx = comps.Count - 1; compIdx >= 0; compIdx--)
+                {
+                    if (comps[compIdx] is not MappingDataNode compMap)
+                        continue;
+
+                    if (!compMap.TryGet("type", out ValueDataNode? typeNode) || typeNode == null)
+                        continue;
+
+                    if (!LegacyRemovedComponentTypes.Contains(typeNode.Value))
+                        continue;
+
+                    comps.RemoveAt(compIdx);
+                    scrubbed++;
+                }
+            }
+        }
+
+        return scrubbed;
+    }
+
+    /// <summary>
+    /// Parses a ship file, strips removed legacy entities and components plus dangling entity
+    /// references, and re-emits it. Returns the text unchanged when there is nothing to remove or
+    /// when it cannot be parsed.
     /// </summary>
     public static string ScrubShipLoadYaml(string yaml, out int scrubbed)
     {

--- a/Content.Server/_Triad/Shipyard/ShipyardSystem.Triad.cs
+++ b/Content.Server/_Triad/Shipyard/ShipyardSystem.Triad.cs
@@ -27,13 +27,13 @@ public sealed partial class ShipyardSystem : SharedShipyardSystem
         ResPath tempPath = default;
         try
         {
-            // Triad: strip dangling entity references before the loader sees them. The save path has
-            // pruned these since the engine 287 bump, but ship files live on the player's machine, so
-            // anything saved before that still carries them and there is no backlog we can migrate.
-            // A file written by the current build has nothing to remove and comes back byte-identical.
+            // Triad: strip stale nodes before the loader sees them: dangling entity references from
+            // pre-287 saves, and legacy xenoarch entities/components from pre-rework saves. Ship files
+            // live on the player's machine, so there is no backlog we can migrate; a file written by
+            // the current build has nothing to remove and comes back byte-identical.
             yamlData = ShipSaveYamlSanitizer.ScrubShipLoadYaml(yamlData, out var scrubbed);
             if (scrubbed > 0)
-                _sawmill.Info($"Scrubbed {scrubbed} dangling entity reference(s) from a pre-287 ship file on load");
+                _sawmill.Info($"Scrubbed {scrubbed} stale node(s) (dangling references / legacy entities) from an older ship file on load");
 
             // Create a temp path under UserData/ShipyardTemp
             var fileName = $"shipyard_load_{DateTime.UtcNow:yyyyMMdd_HHmmss_fff}_{Guid.NewGuid():N}.yml";

--- a/Content.Tests/Server/_HL/Shipyard/ShipSaveYamlSanitizerTest.cs
+++ b/Content.Tests/Server/_HL/Shipyard/ShipSaveYamlSanitizerTest.cs
@@ -93,4 +93,84 @@ entities:
         Assert.That(scrubbed, Is.EqualTo(0));
         Assert.That(result, Is.EqualTo(garbage), "a parse failure must hand the loader the original text");
     }
+
+    // The shape a pre-rework ship save carries: a legacy artifact whose grant action sits in its
+    // 'actions' container, with the legacy component nodes real map files serialized (Artifact with
+    // isSuppressed, BiasedArtifact). uid 2 is the artifact, uid 3 the action.
+    private const string ShipWithLegacyArtifact = @"meta:
+  format: 7
+entities:
+- proto: WallSolid
+  entities:
+  - uid: 1
+    components:
+    - type: Transform
+- proto: VariedXenoArtifactItem
+  entities:
+  - uid: 2
+    components:
+    - type: Transform
+    - type: Artifact
+      isSuppressed: True
+    - type: BiasedArtifact
+    - type: ContainerContainer
+      containers:
+        actions: !type:Container
+          ents:
+          - 3
+- proto: ActionArtifactActivate
+  entities:
+  - uid: 3
+    components:
+    - type: Transform
+      parent: 2
+";
+
+    [Test]
+    public void ScrubDropsLegacyActionEntityAndItsContainerSlot()
+    {
+        var result = ShipSaveYamlSanitizer.ScrubShipLoadYaml(ShipWithLegacyArtifact, out var scrubbed);
+
+        // One action entity, two legacy component nodes, one container slot.
+        Assert.That(scrubbed, Is.EqualTo(4));
+        Assert.That(result, Does.Not.Contain("ActionArtifactActivate"),
+            "the legacy grant action has no replacement and must not reach the loader");
+        Assert.That(result, Does.Not.Contain("- 3"),
+            "the dropped action's container slot must be pruned with it");
+    }
+
+    [Test]
+    public void ScrubStripsLegacyComponentNodesButLeavesTheRenameToTheMigration()
+    {
+        var result = ShipSaveYamlSanitizer.ScrubShipLoadYaml(ShipWithLegacyArtifact, out _);
+
+        Assert.That(result, Does.Not.Contain("BiasedArtifact"));
+        Assert.That(result, Does.Not.Contain("isSuppressed"),
+            "the legacy Artifact node goes whole, its fields with it");
+        // Renaming the body is triad_migration.yml's job, applied inside the engine's deserializer.
+        // The scrub touching prototype ids would hide a broken migration entry instead of failing on it.
+        Assert.That(result, Does.Contain("VariedXenoArtifactItem"));
+    }
+
+    [Test]
+    public void ScrubKeepsLiveComponentsWhoseNamesTheReworkReused()
+    {
+        // ArtifactAnalyzer was deleted by the rework and re-registered with a new data shape; a save
+        // written by the current build legitimately carries it, so the scrub must not eat it.
+        const string ship = @"meta:
+  format: 7
+entities:
+- proto: MachineArtifactAnalyzer
+  entities:
+  - uid: 1
+    components:
+    - type: Transform
+    - type: ArtifactAnalyzer
+";
+
+        var result = ShipSaveYamlSanitizer.ScrubShipLoadYaml(ship, out var scrubbed);
+
+        Assert.That(scrubbed, Is.EqualTo(0));
+        Assert.That(result, Is.EqualTo(ship));
+    }
 }

--- a/Resources/triad_migration.yml
+++ b/Resources/triad_migration.yml
@@ -286,3 +286,14 @@ NovaCygniTranslatorImplant: TerraSlavicTranslatorImplant
 NovaCygniTranslator: TerraSlavicTranslator
 SpawnPointDeputy: null
 JupiterCarrierComputer: null
+
+# 2026-08-24 xenoarchaeology rework: the legacy artifact entities no longer exist, but ship saves
+# live on the player's machine and can still carry them, and one missing prototype fails the whole
+# ship load. Bodies map to their node-graph replacements (a fresh graph rolls on load); the legacy
+# grant action has no replacement. The ship-load scrub strips the matching legacy component nodes.
+SimpleXenoArtifactItem: ComplexXenoArtifactItem
+MediumXenoArtifactItem: ComplexXenoArtifactItem
+VariedXenoArtifactItem: ComplexXenoArtifactItem
+SimpleXenoArtifact: ComplexXenoArtifact
+MediumXenoArtifact: ComplexXenoArtifact
+ActionArtifactActivate: null


### PR DESCRIPTION
## About the PR
Ship saves live on the player's machine, so a ship last saved before #542 still hands the loader legacy artifact entities, and the deserializer fails the whole file on any missing prototype. 13 failed loads on prod in the 15 hours since the rework deployed, against 138 successful.

This migrates the removed artifact bodies to their node-graph replacements and drops the legacy grant action and dead component nodes on the way in, so an affected ship loads and its artifact comes back as a fresh unsolved one.

## Why / Balance
A player whose ship has an artifact aboard currently cannot bring that ship out at all, and the console only says "Failed to load ship." with nothing pointing at why. The artifact is the thing that changed, so trading a solved legacy artifact for an unsolved current one is the cheap half of the fix; losing the ship is not.

Side effect worth knowing: the migrated artifact rolls a fresh node graph on load, so anyone who had solved one before the rework starts it over. All three legacy sizes map to the Complex form, which is the only one the rework kept.

## Media
N/A, server-side fix.

## Requirements
- [x] I have read the guidelines and documentation relevant to this PR.
- [ ] I have added media to this PR or it does not require an ingame showcase.
- [x] I can confirm this PR contains either no AI-generated content, or AI-generated content that meets our guidelines.

## How to test
`dotnet test --filter FullyQualifiedName~LegacyXenoarchShipLoadTest` saves a real grid, grafts the legacy artifact entities into the file, and loads it back through the production scrub, asserting the body comes out as `ComplexXenoArtifactItem` carrying the rework's component; the pool fails the run on any logged error, so a pass is also the assertion that the load is quiet. `dotnet test --filter FullyQualifiedName~ShipSaveYamlSanitizerTest` covers the scrub itself, including that it leaves alone the four component names the rework re-registered. In game, load a ship saved before the rework with an artifact aboard. Not yet verified against a real affected player's file from prod, only against fixtures built from a pre-rework map.

## Breaking changes
None.

**Changelog**
:cl:
- fix: Ships saved before the xenoarchaeology rework load again if they had an artifact aboard. The artifact comes back as a new unsolved one.
