### PR TITLE
Fix/Xenoarch Grid Local and Ship Saves

### DIFF
--- a/Content.Client/Xenoarchaeology/Ui/NodeScannerDisplay.xaml.cs
+++ b/Content.Client/Xenoarchaeology/Ui/NodeScannerDisplay.xaml.cs
@@ -84,8 +84,14 @@ public sealed partial class NodeScannerDisplay : FancyWindow
 
             foreach (var triggeredIndex in triggeredIndexes)
             {
-                var node = _artifact.GetNode((attachedArtifactEnt, artifactComponent), triggeredIndex);
-                var triggeredNodeName = (_ent.GetComponentOrNull<NameIdentifierComponent>(node)?.Identifier ?? 0).ToString("D3");
+                // Triad: GetNode throws on an index it cannot resolve, and this loop runs on a timer
+                // over two separately networked collections: the triggered indexes come off the
+                // unlocking component, the slots they point at off the artifact's NodeVertices. A
+                // node the client has not received yet took the whole scanner window down with it.
+                if (!_artifact.TryGetNode((attachedArtifactEnt, artifactComponent), triggeredIndex, out var node))
+                    continue;
+
+                var triggeredNodeName = (_ent.GetComponentOrNull<NameIdentifierComponent>(node.Value)?.Identifier ?? 0).ToString("D3");
                 _triggeredNodeNames.Add(triggeredNodeName);
             }
 

--- a/Content.Client/Xenoarchaeology/Ui/XenoArtifactGraphControl.xaml.cs
+++ b/Content.Client/Xenoarchaeology/Ui/XenoArtifactGraphControl.xaml.cs
@@ -85,9 +85,17 @@ public sealed partial class XenoArtifactGraphControl : BoxContainer
             return;
         var artifact = _artifact.Value;
 
-        var maxDepth = _artifactSystem.GetAllNodes(artifact)
-                                      .Max(s => s.Comp.Depth);
+        // Triad: Max() throws on an empty sequence, and this runs every frame the console is open.
+        // GetAllNodes skips node NetEntities the client cannot resolve yet, so an artifact whose
+        // nodes have not landed reads as empty here, as does one whose graph generation is still
+        // pending a tick. Draw nothing rather than throwing sixty times a second.
+        var maxDepth = 0;
+        foreach (var node in _artifactSystem.GetAllNodes(artifact))
+            maxDepth = Math.Max(maxDepth, node.Comp.Depth);
+
         var segments = _artifactSystem.GetSegments(artifact);
+        if (segments.Count == 0)
+            return;
 
         var bottomLeft = Position // the position
                          + new Vector2(0, Size.Y * UIScale) // the scaled height of the control

--- a/Content.Server/Emp/EmpSystem.cs
+++ b/Content.Server/Emp/EmpSystem.cs
@@ -53,10 +53,17 @@ public sealed partial class EmpSystem : SharedEmpSystem
     /// <param name="energyConsumption">The amount of energy consumed by the EMP pulse.</param>
     /// <param name="duration">The duration of the EMP effects.</param>
     /// <param name="immuneGrids">Frontier: a list of the grids that should not be affected by the pulse.</param>
-    public void EmpPulse(MapCoordinates coordinates, float range, float energyConsumption, float duration, List<EntityUid>? immuneGrids = null)
+    /// <param name="onlyGrid">Triad: when set, only entities standing on this grid are affected. Lets a
+    /// grid-local source (an artifact firing on its own ship) pulse without reaching a docked neighbour.
+    /// Pass the source's own grid; null keeps the old behaviour of hitting everything in range.</param>
+    public void EmpPulse(MapCoordinates coordinates, float range, float energyConsumption, float duration, List<EntityUid>? immuneGrids = null, EntityUid? onlyGrid = null)
     {
         foreach (var uid in _lookup.GetEntitiesInRange(coordinates, range))
         {
+            // Triad: grid-local pulse
+            if (onlyGrid != null && Transform(uid).GridUid != onlyGrid)
+                continue;
+
             // Frontier: Block EMP on grid
             var gridUid = Transform(uid).GridUid;
             if (gridUid != null &&

--- a/Content.Server/Xenoarchaeology/Artifact/RandomArtifactSpriteSystem.cs
+++ b/Content.Server/Xenoarchaeology/Artifact/RandomArtifactSpriteSystem.cs
@@ -14,13 +14,21 @@ public sealed class RandomArtifactSpriteSystem : EntitySystem
     [Dependency] private readonly AppearanceSystem _appearance = default!;
     [Dependency] private readonly SharedItemSystem _item = default!;
 
+    /// <summary>
+    /// Triad: artifacts that started up this tick carrying no sprite index. Settled on the next tick,
+    /// once their map's life stage can be read. See <see cref="Update"/>.
+    /// </summary>
+    private readonly List<EntityUid> _pendingRoll = new();
+
     public override void Initialize()
     {
         base.Initialize();
 
         SubscribeLocalEvent<RandomArtifactSpriteComponent, MapInitEvent>(OnMapInit);
-        // Triad: ComponentStartup runs for a file-restored artifact, MapInitEvent does not. See
-        // EnsureSprite.
+        // Triad: ComponentStartup runs for a file-restored artifact, MapInitEvent does not. It must
+        // not WRITE anything though: it also runs for a bare prototype spawn on an uninitialised map,
+        // and UninitializedSaveTest holds those to serialising exactly like their prototype. See
+        // OnStartup.
         SubscribeLocalEvent<RandomArtifactSpriteComponent, ComponentStartup>(OnStartup);
         SubscribeLocalEvent<RandomArtifactSpriteComponent, ArtifactUnlockingStartedEvent>(UnlockingStageStarted);
         SubscribeLocalEvent<RandomArtifactSpriteComponent, ArtifactUnlockingFinishedEvent>(UnlockingStageFinished);
@@ -30,6 +38,8 @@ public sealed class RandomArtifactSpriteSystem : EntitySystem
     public override void Update(float frameTime)
     {
         base.Update(frameTime);
+
+        SettlePendingRolls();
 
         var query = EntityQueryEnumerator<RandomArtifactSpriteComponent, AppearanceComponent>();
         while (query.MoveNext(out var uid, out var component, out var appearance))
@@ -49,29 +59,75 @@ public sealed class RandomArtifactSpriteSystem : EntitySystem
         }
     }
 
-    private void OnMapInit(EntityUid uid, RandomArtifactSpriteComponent component, MapInitEvent args)
+    /// <summary>
+    /// Triad: settles artifacts that started up with no index. The test is the MAP's life stage, not
+    /// the entity's: an artifact on a map that has not initialised yet (a prototype spawn, the
+    /// shipyard hold) still has its MapInit coming and must be left completely alone, because writing
+    /// to it now would land in an uninitialised save. What is left is an artifact restored from a save
+    /// written before spriteIndex existed, onto a map whose init already happened. That one is
+    /// stranded and is the one this is for.
+    /// </summary>
+    private void SettlePendingRolls()
     {
-        EnsureSprite((uid, component));
+        if (_pendingRoll.Count == 0)
+            return;
+
+        foreach (var uid in _pendingRoll)
+        {
+            if (!TryComp<RandomArtifactSpriteComponent>(uid, out var comp) || comp.SpriteIndex != null)
+                continue;
+
+            if (Transform(uid).MapUid is not { } mapUid
+                || MetaData(mapUid).EntityLifeStage < EntityLifeStage.MapInitialized)
+                continue;
+
+            RollSprite((uid, comp));
+        }
+
+        _pendingRoll.Clear();
     }
 
-    private void OnStartup(Entity<RandomArtifactSpriteComponent> ent, ref ComponentStartup args)
+    private void OnMapInit(EntityUid uid, RandomArtifactSpriteComponent component, MapInitEvent args)
     {
-        EnsureSprite(ent);
+        RollSprite((uid, component));
     }
 
     /// <summary>
-    /// Triad: rolls the sprite index once and pushes it into appearance. This has to run on startup
-    /// rather than only on MapInit: appearance data does not serialise, and an artifact loaded from a
-    /// ship file onto a running map never receives MapInitEvent, so the index was gone and the
-    /// artifact rendered as its bare prototype sprite. The held prefix survived on its own because
-    /// ItemComponent.HeldPrefix is a real DataField, which is why a restored artifact looked correct
-    /// in hand and wrong on the floor.
+    /// Triad: appearance data does not serialise (AppearanceComponent.AppearanceData is internal with
+    /// no DataField), so a restored artifact has to be told its sprite again on the way in, and
+    /// MapInitEvent never arrives for one loaded from a file onto a running map.
+    ///
+    /// This only ever RE-APPLIES an index the component already carries. It must not roll one, and it
+    /// must not write: ComponentStartup also runs for a plain prototype spawn on an uninitialised map,
+    /// and UninitializedSaveTest holds those to serialising byte-for-byte like their prototype. Doing
+    /// the roll here put spriteIndex and heldPrefix into every uninitialised save and failed CI, which
+    /// is the same trap the self-activate action fell into in SharedXenoArtifactSystem.
+    ///
+    /// An artifact out of a save written before spriteIndex existed carries no index, so there is
+    /// nothing to re-apply and nothing above will ever roll it. <see cref="Update"/> picks those up.
     /// </summary>
-    private void EnsureSprite(Entity<RandomArtifactSpriteComponent> ent)
+    private void OnStartup(Entity<RandomArtifactSpriteComponent> ent, ref ComponentStartup args)
     {
-        ent.Comp.SpriteIndex ??= _random.Next(ent.Comp.MinSprite, ent.Comp.MaxSprite + 1);
+        if (ent.Comp.SpriteIndex is not { } index)
+        {
+            _pendingRoll.Add(ent.Owner);
+            return;
+        }
 
-        var index = ent.Comp.SpriteIndex.Value;
+        ApplySprite(ent, index);
+    }
+
+    /// <summary>
+    /// Triad: rolls an index if the component does not have one yet, then applies it.
+    /// </summary>
+    private void RollSprite(Entity<RandomArtifactSpriteComponent> ent)
+    {
+        var index = ent.Comp.SpriteIndex ??= _random.Next(ent.Comp.MinSprite, ent.Comp.MaxSprite + 1);
+        ApplySprite(ent, index);
+    }
+
+    private void ApplySprite(Entity<RandomArtifactSpriteComponent> ent, int index)
+    {
         _appearance.SetData(ent, SharedArtifactsVisuals.SpriteIndex, index);
         _item.SetHeldPrefix(ent, "ano" + index.ToString("D2")); //set item artifact inhands
     }

--- a/Content.Server/Xenoarchaeology/Artifact/RandomArtifactSpriteSystem.cs
+++ b/Content.Server/Xenoarchaeology/Artifact/RandomArtifactSpriteSystem.cs
@@ -19,6 +19,9 @@ public sealed class RandomArtifactSpriteSystem : EntitySystem
         base.Initialize();
 
         SubscribeLocalEvent<RandomArtifactSpriteComponent, MapInitEvent>(OnMapInit);
+        // Triad: ComponentStartup runs for a file-restored artifact, MapInitEvent does not. See
+        // EnsureSprite.
+        SubscribeLocalEvent<RandomArtifactSpriteComponent, ComponentStartup>(OnStartup);
         SubscribeLocalEvent<RandomArtifactSpriteComponent, ArtifactUnlockingStartedEvent>(UnlockingStageStarted);
         SubscribeLocalEvent<RandomArtifactSpriteComponent, ArtifactUnlockingFinishedEvent>(UnlockingStageFinished);
         SubscribeLocalEvent<RandomArtifactSpriteComponent, XenoArtifactActivatedEvent>(ArtifactActivated);
@@ -35,7 +38,10 @@ public sealed class RandomArtifactSpriteSystem : EntitySystem
                 continue;
 
             var timeDif = _time.CurTime - component.ActivationStart.Value;
-            if (timeDif.Seconds >= component.ActivationTime)
+            // Triad: TimeSpan.Seconds is the seconds COMPONENT of the span, not its length, so with
+            // the default 0.4s activation this stayed 0 for a whole second and only cleared when it
+            // ticked over to 1. The flash ran two and a half times as long as authored.
+            if (timeDif.TotalSeconds >= component.ActivationTime)
             {
                 _appearance.SetData(uid, SharedArtifactsVisuals.IsActivated, false, appearance);
                 component.ActivationStart = null;
@@ -45,9 +51,29 @@ public sealed class RandomArtifactSpriteSystem : EntitySystem
 
     private void OnMapInit(EntityUid uid, RandomArtifactSpriteComponent component, MapInitEvent args)
     {
-        var randomSprite = _random.Next(component.MinSprite, component.MaxSprite + 1);
-        _appearance.SetData(uid, SharedArtifactsVisuals.SpriteIndex, randomSprite);
-        _item.SetHeldPrefix(uid, "ano" + randomSprite.ToString("D2")); //set item artifact inhands
+        EnsureSprite((uid, component));
+    }
+
+    private void OnStartup(Entity<RandomArtifactSpriteComponent> ent, ref ComponentStartup args)
+    {
+        EnsureSprite(ent);
+    }
+
+    /// <summary>
+    /// Triad: rolls the sprite index once and pushes it into appearance. This has to run on startup
+    /// rather than only on MapInit: appearance data does not serialise, and an artifact loaded from a
+    /// ship file onto a running map never receives MapInitEvent, so the index was gone and the
+    /// artifact rendered as its bare prototype sprite. The held prefix survived on its own because
+    /// ItemComponent.HeldPrefix is a real DataField, which is why a restored artifact looked correct
+    /// in hand and wrong on the floor.
+    /// </summary>
+    private void EnsureSprite(Entity<RandomArtifactSpriteComponent> ent)
+    {
+        ent.Comp.SpriteIndex ??= _random.Next(ent.Comp.MinSprite, ent.Comp.MaxSprite + 1);
+
+        var index = ent.Comp.SpriteIndex.Value;
+        _appearance.SetData(ent, SharedArtifactsVisuals.SpriteIndex, index);
+        _item.SetHeldPrefix(ent, "ano" + index.ToString("D2")); //set item artifact inhands
     }
 
     private void UnlockingStageStarted(Entity<RandomArtifactSpriteComponent> ent, ref ArtifactUnlockingStartedEvent args)

--- a/Content.Server/Xenoarchaeology/Artifact/XAE/Components/XAEPortalComponent.cs
+++ b/Content.Server/Xenoarchaeology/Artifact/XAE/Components/XAEPortalComponent.cs
@@ -18,7 +18,11 @@ public sealed partial class XAEPortalComponent : Component
     /// <summary>
     /// Maximum range that the target entity should be from the portal, in meters.
     /// </summary>
+    // Triad: 1000<100. Frontier added this as a fence against cross-map yanks, but on a sector
+    // where every ship shares one map 1000m reaches most of the neighbourhood, so it fenced
+    // nothing. The grid gate in XAEPortalSystem is the real limit now; this only keeps the pick
+    // to somewhere on the hull you could plausibly have walked to.
     [DataField, AutoNetworkedField]
-    public float MaxRange = 1000f;
+    public float MaxRange = 100f; // Frontier: 1000f
     // End Frontier
 }

--- a/Content.Server/Xenoarchaeology/Artifact/XAE/XAEChargeBatterySystem.cs
+++ b/Content.Server/Xenoarchaeology/Artifact/XAE/XAEChargeBatterySystem.cs
@@ -23,8 +23,13 @@ public sealed class XAEChargeBatterySystem : BaseXAESystem<XAEChargeBatteryCompo
         var chargeBatteryComponent = ent.Comp;
         _batteryEntities.Clear();
         _lookup.GetEntitiesInRange(args.Coordinates, chargeBatteryComponent.Radius, _batteryEntities);
+
+        var xform = Transform(ent.Owner); // Triad: the node inherits the artifact's grid
         foreach (var battery in _batteryEntities)
         {
+            if (!XenoArtifact.IsGridLocal(xform, battery)) // Triad: no charging the ship next door
+                continue;
+
             _battery.SetCharge(battery, battery.Comp.MaxCharge, battery);
         }
     }

--- a/Content.Server/Xenoarchaeology/Artifact/XAE/XAECreatePuddleSystem.cs
+++ b/Content.Server/Xenoarchaeology/Artifact/XAE/XAECreatePuddleSystem.cs
@@ -66,12 +66,20 @@ public sealed class XAECreatePuddleSystem: BaseXAESystem<XAECreatePuddleComponen
         if (component.SelectedChemicals == null)
             return;
 
-        var amountPerChem = component.ChemicalSolution.MaxVolume / component.SelectedChemicals.Count;
+        // Triad: TrySpillAt does not drain the solution you hand it, and AddReagent does not clamp at
+        // MaxVolume, so filling the component's own solution on every activation left the previous
+        // fill sitting in it and the puddle grew by a full charge each use. Mix the spill fresh and
+        // leave the authored solution as the template it reads like. Clone carries maxVol and
+        // canReact across; the authored one holds no reagents.
+        var spill = component.ChemicalSolution.Clone();
+        var amountPerChem = spill.MaxVolume / component.SelectedChemicals.Count;
         foreach (var reagent in component.SelectedChemicals)
         {
-            component.ChemicalSolution.AddReagent(reagent, amountPerChem);
+            spill.AddReagent(reagent, amountPerChem);
         }
 
-        _puddle.TrySpillAt(ent, component.ChemicalSolution, out _);
+        // Triad: spill under the artifact, not under the node. The node lives in the artifact's
+        // container so this resolved to the same tile by accident; say what we mean.
+        _puddle.TrySpillAt(args.Artifact.Owner, spill, out _);
     }
 }

--- a/Content.Server/Xenoarchaeology/Artifact/XAE/XAEEmpInAreaSystem.cs
+++ b/Content.Server/Xenoarchaeology/Artifact/XAE/XAEEmpInAreaSystem.cs
@@ -16,7 +16,15 @@ public sealed class XAEEmpInAreaSystem : BaseXAESystem<XAEEmpInAreaComponent>
     /// <inheritdoc />
     protected override void OnActivated(Entity<XAEEmpInAreaComponent> ent, ref XenoArtifactNodeActivatedEvent args)
     {
-        // Triad: EmpPulse still takes MapCoordinates on this tree
-        _emp.EmpPulse(_transform.ToMapCoordinates(args.Coordinates), ent.Comp.Range, ent.Comp.EnergyConsumption, ent.Comp.DisableDuration);
+        // Triad: EmpPulse still takes MapCoordinates on this tree. onlyGrid keeps the pulse on the
+        // hull running the artifact instead of browning out whatever is docked alongside.
+        var xform = Transform(ent.Owner);
+        _emp.EmpPulse(
+            _transform.ToMapCoordinates(args.Coordinates),
+            ent.Comp.Range,
+            ent.Comp.EnergyConsumption,
+            ent.Comp.DisableDuration,
+            onlyGrid: xform.GridUid
+        );
     }
 }

--- a/Content.Server/Xenoarchaeology/Artifact/XAE/XAEIgniteSystem.cs
+++ b/Content.Server/Xenoarchaeology/Artifact/XAE/XAEIgniteSystem.cs
@@ -35,8 +35,13 @@ public sealed class XAEIgniteSystem : BaseXAESystem<XAEIgniteComponent>
         var component = ent.Comp;
         _entities.Clear();
         _lookup.GetEntitiesInRange(ent.Owner, component.Range, _entities);
+
+        var xform = Transform(ent.Owner); // Triad: the node inherits the artifact's grid
         foreach (var target in _entities)
         {
+            if (!XenoArtifact.IsGridLocal(xform, target)) // Triad: don't set the neighbours on fire
+                continue;
+
             if (!_flammables.TryGetComponent(target, out var fl))
                 continue;
 

--- a/Content.Server/Xenoarchaeology/Artifact/XAE/XAELightFlickerSystem.cs
+++ b/Content.Server/Xenoarchaeology/Artifact/XAE/XAELightFlickerSystem.cs
@@ -34,8 +34,13 @@ public sealed class XAELightFlickerSystem : BaseXAESystem<XAELightFlickerCompone
     {
         _entities.Clear();
         _lookup.GetEntitiesInRange(ent.Owner, ent.Comp.Radius, _entities, LookupFlags.StaticSundries);
+
+        var xform = Transform(ent.Owner); // Triad: the node inherits the artifact's grid
         foreach (var light in _entities)
         {
+            if (!XenoArtifact.IsGridLocal(xform, light)) // Triad: only our own lights flicker
+                continue;
+
             if (!_lights.HasComponent(light))
                 continue;
 

--- a/Content.Server/Xenoarchaeology/Artifact/XAE/XAEPolymorphSystem.cs
+++ b/Content.Server/Xenoarchaeology/Artifact/XAE/XAEPolymorphSystem.cs
@@ -26,9 +26,14 @@ public sealed class XAEPolymorphSystem : BaseXAESystem<XAEPolymorphComponent>
     {
         _humanoids.Clear();
         _lookup.GetEntitiesInRange(args.Coordinates, ent.Comp.Range, _humanoids);
+
+        var xform = Transform(ent.Owner); // Triad: the node inherits the artifact's grid
         foreach (var comp in _humanoids)
         {
             var target = comp.Owner;
+            if (!XenoArtifact.IsGridLocal(xform, target)) // Triad: only our own crew
+                continue;
+
             if (!_mob.IsAlive(target))
                 continue;
 

--- a/Content.Server/Xenoarchaeology/Artifact/XAE/XAEPortalSystem.cs
+++ b/Content.Server/Xenoarchaeology/Artifact/XAE/XAEPortalSystem.cs
@@ -48,6 +48,13 @@ public sealed class XAEPortalSystem : BaseXAESystem<XAEPortalComponent>
                     continue;
                 // End Frontier: ensure range check (don't teleport people from across the map or off of protected grids)
 
+                // Triad: same map is not a fence on a sector where every ship shares one. The
+                // candidate has to be standing on the artifact's own grid, so a portal is a hazard
+                // for the crew running the artifact and never a way to reach into someone else's
+                // hull. Same-map-no-grid still works for an artifact taken EVA.
+                if (!XenoArtifact.IsGridLocal(entXform, uid))
+                    continue;
+
                 validMinds.Add(uid);
             }
         }

--- a/Content.Server/Xenoarchaeology/Artifact/XAE/XAETelepathicSystem.cs
+++ b/Content.Server/Xenoarchaeology/Artifact/XAE/XAETelepathicSystem.cs
@@ -26,8 +26,13 @@ public sealed class XAETelepathicSystem : BaseXAESystem<XAETelepathicComponent>
         // try to find victims nearby
         _entities.Clear();
         _lookup.GetEntitiesInRange(ent, component.Range, _entities);
+
+        var xform = Transform(ent.Owner); // Triad: the node inherits the artifact's grid
         foreach (var victimUid in _entities)
         {
+            if (!XenoArtifact.IsGridLocal(xform, victimUid)) // Triad: whispers stay on our hull
+                continue;
+
             if (!HasComp<ActorComponent>(victimUid))
                 continue;
 

--- a/Content.Server/Xenoarchaeology/Artifact/XAE/XAEThrowThingsAroundSystem.cs
+++ b/Content.Server/Xenoarchaeology/Artifact/XAE/XAEThrowThingsAroundSystem.cs
@@ -59,6 +59,9 @@ public sealed class XAEThrowThingsAroundSystem : BaseXAESystem<XAEThrowThingsAro
         _lookup.GetEntitiesInRange(ent, component.Range, _entities, LookupFlags.Dynamic | LookupFlags.Sundries);
         foreach (var entity in _entities)
         {
+            if (!XenoArtifact.IsGridLocal(xform, entity)) // Triad: don't yeet the dock's cargo
+                continue;
+
             if (_physQuery.TryGetComponent(entity, out var phys)
                 && (phys.CollisionMask & (int)CollisionGroup.GhostImpassable) != 0)
                 continue;

--- a/Content.Server/Xenoarchaeology/Artifact/XAT/XATMagnetSystem.cs
+++ b/Content.Server/Xenoarchaeology/Artifact/XAT/XATMagnetSystem.cs
@@ -30,12 +30,18 @@ public sealed class XATMagnetSystem : BaseQueryUpdateXATSystem<XATMagnetComponen
     /// <inheritdoc />
     protected override void UpdateXAT(Entity<XenoArtifactComponent> artifact, Entity<XATMagnetComponent, XenoArtifactNodeComponent> node, float frameTime)
     {
-        var coords = Transform(artifact.Owner).Coordinates;
+        var xform = Transform(artifact.Owner);
+        var coords = xform.Coordinates;
 
         _magbootEntities.Clear();
         _lookup.GetEntitiesInRange(coords, node.Comp1.MagbootsRange, _magbootEntities);
         foreach (var ent in _magbootEntities)
         {
+            // Triad: two metres reaches straight through a docking wall, so someone in magboots
+            // standing on the ship next door used to solve your node. Same fence the effects use.
+            if (!XenoArtifact.IsGridLocal(xform, ent))
+                continue;
+
             if(!TryComp<ItemToggleComponent>(ent, out var itemToggle) || !itemToggle.Activated)
                 continue;
 
@@ -57,6 +63,12 @@ public sealed class XATMagnetSystem : BaseQueryUpdateXATSystem<XATMagnetComponen
             var artifact = _xenoArtifactQuery.Get(GetEntity(node.Attached.Value));
 
             if (!CanTrigger(artifact, (uid, node)))
+                continue;
+
+            // Triad: forty metres is most of a sector berth. A depot's salvage magnet, or the ship
+            // moored alongside pulsing theirs, used to solve a node for a crew who did nothing.
+            // The magnet has to be on the artifact's own hull.
+            if (!XenoArtifact.IsGridLocal(artifact.Owner, args.Magnet))
                 continue;
 
             var artifactCoordinates = Transform(artifact).Coordinates;

--- a/Content.Server/Xenoarchaeology/Artifact/XenoArtifactSystem.ProcGen.cs
+++ b/Content.Server/Xenoarchaeology/Artifact/XenoArtifactSystem.ProcGen.cs
@@ -25,6 +25,10 @@ public sealed partial class XenoArtifactSystem
         }
 
         RebuildXenoArtifactMetaData((ent, ent));
+
+        // Triad: the flag now means "still owes a graph" rather than "was built wanting one", so the
+        // deferred pass in XenoArtifactSystem can tell a restored artifact from a generated one.
+        ent.Comp.IsGenerationRequired = false;
     }
 
     /// <summary>

--- a/Content.Server/Xenoarchaeology/Artifact/XenoArtifactSystem.cs
+++ b/Content.Server/Xenoarchaeology/Artifact/XenoArtifactSystem.cs
@@ -1,3 +1,4 @@
+using System.Linq;
 using Content.Server.Cargo.Systems; // Triad: PriceCalculationEvent is still server-side here
 using Content.Server.Kitchen.Components; // Triad: BeingMicrowavedEvent relay
 using Content.Shared.Xenoarchaeology.Artifact;
@@ -8,6 +9,11 @@ namespace Content.Server.Xenoarchaeology.Artifact;
 /// <inheritdoc cref="SharedXenoArtifactSystem"/>
 public sealed partial class XenoArtifactSystem : SharedXenoArtifactSystem
 {
+    /// <summary>
+    /// Triad: artifacts that started up this tick and still want a graph. See OnArtifactStartup.
+    /// </summary>
+    private readonly List<EntityUid> _pendingGeneration = new();
+
     /// <inheritdoc/>
     public override void Initialize()
     {
@@ -21,9 +27,61 @@ public sealed partial class XenoArtifactSystem : SharedXenoArtifactSystem
         SubscribeLocalEvent<XenoArtifactComponent, BeingMicrowavedEvent>(OnMicrowaved);
     }
 
+    /// <inheritdoc />
+    public override void Update(float frameTime)
+    {
+        base.Update(frameTime);
+
+        if (_pendingGeneration.Count == 0)
+            return;
+
+        // Triad: drained a tick after startup so a freshly spawned artifact has had its MapInit and
+        // cleared the flag by the time we look. See OnArtifactStartup for why this exists.
+        foreach (var uid in _pendingGeneration)
+        {
+            if (!TryComp<XenoArtifactComponent>(uid, out var comp) || !comp.IsGenerationRequired)
+                continue;
+
+            // The test is the MAP's life stage, not the entity's. An entity loaded from a file onto a
+            // map that is already running never receives MapInitEvent: the map's init already
+            // happened, and the loader restores it as merely Initialized. That artifact is stranded,
+            // and it is the one we are here for. An artifact on a map that has NOT initialized yet
+            // (the shipyard hold) still has its MapInit coming and must be left alone.
+            if (Transform(uid).MapUid is not { } mapUid
+                || MetaData(mapUid).EntityLifeStage < EntityLifeStage.MapInitialized)
+                continue;
+
+            if (GetAllNodes((uid, comp)).Any())
+            {
+                comp.IsGenerationRequired = false;
+                continue;
+            }
+
+            Log.Info($"{ToPrettyString(uid)} arrived map-initialized with no node graph (restored from a file?); generating one now.");
+            GenerateArtifactStructure((uid, comp));
+        }
+
+        _pendingGeneration.Clear();
+    }
+
     private void OnMicrowaved(EntityUid uid, XenoArtifactComponent comp, BeingMicrowavedEvent args)
     {
         RelayEventToNodes((uid, comp), ref args);
+    }
+
+    /// <summary>
+    /// Triad: generation hangs off MapInitEvent, and an entity loaded from a file onto a map that is
+    /// already running never gets one. The loader starts it (Initialized) but the map's own init
+    /// already happened, so nothing raises MapInit on it afterwards. An artifact that came out of a
+    /// ship file, including the legacy bodies triad_migration renames into current ones, therefore
+    /// reached the world with an empty graph and stayed inert: nothing to trigger, nothing to unlock,
+    /// worth nothing. Queue every artifact that starts up and settle it on the next tick, once we can
+    /// see whether its map is live or still waiting to be initialized.
+    /// </summary>
+    protected override void AfterArtifactStartup(Entity<XenoArtifactComponent> ent)
+    {
+        if (ent.Comp.IsGenerationRequired)
+            _pendingGeneration.Add(ent.Owner);
     }
 
     private void OnArtifactMapInit(Entity<XenoArtifactComponent> ent, ref MapInitEvent args)

--- a/Content.Server/Xenoarchaeology/Equipment/ArtifactAnalyzerSystem.cs
+++ b/Content.Server/Xenoarchaeology/Equipment/ArtifactAnalyzerSystem.cs
@@ -28,8 +28,14 @@ public sealed class ArtifactAnalyzerSystem : SharedArtifactAnalyzerSystem
         if (!TryGetArtifactFromConsole(ent, out var artifact))
             return;
 
+        // Triad: the client renders the whole breakdown and a total the moment the button is pressed,
+        // so bailing quietly here told the crew they had banked points they never got. Ships carry
+        // consoles far more often than they carry a research server, so say so out loud.
         if (!_research.TryGetClientServer(ent, out var server, out var serverComponent))
+        {
+            _popup.PopupEntity(Loc.GetString("analyzer-artifact-extract-no-server"), ent, PopupType.MediumCaution);
             return;
+        }
 
         var sumResearch = 0;
         foreach (var node in _xenoArtifact.GetAllNodes(artifact.Value))

--- a/Content.Server/Xenoarchaeology/Equipment/Systems/ArtifactCrusherSystem.cs
+++ b/Content.Server/Xenoarchaeology/Equipment/Systems/ArtifactCrusherSystem.cs
@@ -104,8 +104,15 @@ public sealed class ArtifactCrusherSystem : SharedArtifactCrusherSystem
                 }
             }
 
+            // Triad: this was missing its continue, so every non-body item, which is to say every
+            // artifact this machine exists to crush, got deleted and then passed to GibBody anyway.
+            // Harmless today only because GibBody's Resolve bails first; it is one refactor away
+            // from being a crash on the crusher's main path.
             if (!TryComp<BodyComponent>(contained, out var body))
+            {
                 Del(contained);
+                continue;
+            }
 
             var gibs = _body.GibBody(contained, body: body, gibOrgans: true);
             foreach (var gib in gibs)

--- a/Content.Shared/Magic/Events/KnockSpellEvent.cs
+++ b/Content.Shared/Magic/Events/KnockSpellEvent.cs
@@ -14,4 +14,12 @@ public sealed partial class KnockSpellEvent : InstantActionEvent, ISpeakSpell
 
     [DataField]
     public string? Speech { get; private set; }
+
+    /// <summary>
+    /// Triad: when set, only doors and lockers on this grid are opened. A wizard casting knock
+    /// leaves it null and keeps the old behaviour; a grid-local caster (an artifact firing on its
+    /// own ship) passes its grid so the spell cannot pop the airlocks of whatever is docked
+    /// alongside.
+    /// </summary>
+    public EntityUid? OnlyGrid;
 }

--- a/Content.Shared/Magic/SharedMagicSystem.cs
+++ b/Content.Shared/Magic/SharedMagicSystem.cs
@@ -422,6 +422,10 @@ public abstract partial class SharedMagicSystem : EntitySystem
         // Look for doors and lockers, and don't open/unlock them if they're already opened/unlocked.
         foreach (var target in _lookup.GetEntitiesInRange(_transform.GetMapCoordinates(args.Performer, transform), args.Range, flags: LookupFlags.Dynamic | LookupFlags.Static))
         {
+            // Triad: grid fence for grid-local casters, see KnockSpellEvent.OnlyGrid
+            if (args.OnlyGrid != null && Transform(target).GridUid != args.OnlyGrid)
+                continue;
+
             if (!_interaction.InRangeUnobstructed(args.Performer, target, range: 0, collisionMask: CollisionGroup.Opaque))
                 continue;
 

--- a/Content.Shared/Maps/TileSystem.cs
+++ b/Content.Shared/Maps/TileSystem.cs
@@ -173,7 +173,11 @@ public sealed partial class TileSystem : EntitySystem
 
         // Frontier
         var ev = new FloorTileAttemptEvent();
-        RaiseLocalEvent(mapGrid);
+        // Triad: was RaiseLocalEvent(mapGrid), which broadcasts the grid COMPONENT as an event object
+        // and never raises ev, so ev.Cancelled below was dead. Nothing subscribes today, so nothing
+        // changes yet; it is the artifact tile-pry path's only cancel hook and it should work when
+        // something does. Matches the sibling raise in FloorTileSystem.CanPlaceTile.
+        RaiseLocalEvent(gridUid, ref ev);
 
         if (((TryComp<ProtectedGridComponent>(gridUid, out var prot) && prot.PreventFloorRemoval) || ev.Cancelled) && tileDef.ID == "Plating")
             return false;

--- a/Content.Shared/Xenoarchaeology/Artifact/Components/XenoArtifactComponent.cs
+++ b/Content.Shared/Xenoarchaeology/Artifact/Components/XenoArtifactComponent.cs
@@ -5,6 +5,7 @@ using Robust.Shared.Audio;
 using Robust.Shared.Containers;
 using Robust.Shared.GameStates;
 using Robust.Shared.Prototypes;
+using Robust.Shared.Serialization.TypeSerializers.Implementations.Custom; // Triad: TimeOffsetSerializer
 using Robust.Shared.Utility;
 
 namespace Content.Shared.Xenoarchaeology.Artifact.Components;
@@ -90,7 +91,11 @@ public sealed partial class XenoArtifactComponent : Component
     /// <summary>
     /// When next unlock session can be triggered.
     /// </summary>
-    [DataField, AutoPausedField]
+    // Triad: this is an absolute CurTime, and CurTime restarts from zero every time the server does.
+    // Written raw, a ship file carries the deadline the previous server stamped, so an artifact stored
+    // aboard restored onto a fresher server and refused every trigger until the new uptime caught up
+    // with the old one. TimeOffsetSerializer writes it as an offset from now and re-bases it on load.
+    [DataField(customTypeSerializer: typeof(TimeOffsetSerializer)), AutoPausedField]
     public TimeSpan NextUnlockTime;
     #endregion
 

--- a/Content.Shared/Xenoarchaeology/Artifact/Components/XenoArtifactUnlockingComponent.cs
+++ b/Content.Shared/Xenoarchaeology/Artifact/Components/XenoArtifactUnlockingComponent.cs
@@ -1,5 +1,6 @@
 using Robust.Shared.Audio;
 using Robust.Shared.GameStates;
+using Robust.Shared.Serialization.TypeSerializers.Implementations.Custom; // Triad: TimeOffsetSerializer
 
 namespace Content.Shared.Xenoarchaeology.Artifact.Components;
 
@@ -18,7 +19,10 @@ public sealed partial class XenoArtifactUnlockingComponent : Component
     /// <summary>
     /// The time at which the unlocking state ends.
     /// </summary>
-    [DataField, AutoNetworkedField, AutoPausedField]
+    // Triad: absolute CurTime, so a ship saved mid-session used to restore with a window that had
+    // already expired on a fresher server, or one that never closed. See NextUnlockTime on
+    // XenoArtifactComponent for the same fix and the reasoning.
+    [DataField(customTypeSerializer: typeof(TimeOffsetSerializer)), AutoNetworkedField, AutoPausedField]
     public TimeSpan EndTime;
 
     // Triad: ArtifexiumApplied removed with the reagent

--- a/Content.Shared/Xenoarchaeology/Artifact/SharedXenoArtifactSystem.Graph.cs
+++ b/Content.Shared/Xenoarchaeology/Artifact/SharedXenoArtifactSystem.Graph.cs
@@ -53,8 +53,11 @@ public abstract partial class SharedXenoArtifactSystem
     /// <exception cref="ArgumentException">Throws if requested index doesn't exist on artifact. </exception>
     public Entity<XenoArtifactNodeComponent> GetNode(Entity<XenoArtifactComponent> ent, int index)
     {
-        if (ent.Comp.NodeVertices[index] is { } netUid && GetEntity(netUid) is var uid)
-            return (uid, XenoArtifactNode(uid));
+        // Triad: was indexing NodeVertices raw, so an out-of-range index threw IndexOutOfRange rather
+        // than the ArgumentException this documents. Going through TryGetNode bounds-checks it and
+        // gives the caller the exception the summary promises.
+        if (TryGetNode((ent.Owner, ent.Comp), index, out var node))
+            return node.Value;
 
         throw new ArgumentException($"index {index} does not correspond to an existing node in {ToPrettyString(ent)}");
     }
@@ -71,8 +74,18 @@ public abstract partial class SharedXenoArtifactSystem
         if (index < 0 || index >= ent.Comp.NodeVertices.Length)
             return false;
 
-        if (ent.Comp.NodeVertices[index] is { } netUid && GetEntity(netUid) is var uid)
-            node = (uid, XenoArtifactNode(uid));
+        // Triad: `GetEntity(netUid) is var uid` is a var pattern, which always matches, so an
+        // unresolvable NetEntity fell straight through to XenoArtifactNode() and threw out of a
+        // method named Try. NodeVertices is an AutoNetworkedField of NetEntities: the client can
+        // hold the artifact's state a tick before the node entities themselves land, and TryGetIndex,
+        // GetDirectPredecessorNodes and GetDirectSuccessorNodes all route through here. Resolve for
+        // real and report a miss as a miss.
+        if (ent.Comp.NodeVertices[index] is { } netUid
+            && TryGetEntity(netUid, out var uid)
+            && _nodeQuery.TryComp(uid, out var nodeComp))
+        {
+            node = (uid.Value, nodeComp);
+        }
 
         return node != null;
     }

--- a/Content.Shared/Xenoarchaeology/Artifact/SharedXenoArtifactSystem.Node.cs
+++ b/Content.Shared/Xenoarchaeology/Artifact/SharedXenoArtifactSystem.Node.cs
@@ -168,9 +168,16 @@ public abstract partial class SharedXenoArtifactSystem
     /// </summary>
     public List<Entity<XenoArtifactNodeComponent>> GetActiveNodes(Entity<XenoArtifactComponent> ent)
     {
-        return ent.Comp.CachedActiveNodes
-                  .Select(activeNode => _nodeQuery.Get(GetEntity(activeNode)))
-                  .ToList();
+        // Triad: CachedActiveNodes is networked NetEntities, and _nodeQuery.Get throws on anything it
+        // cannot resolve. GetAllNodes right above already skips those; these did not. Skip to match.
+        var output = new List<Entity<XenoArtifactNodeComponent>>(ent.Comp.CachedActiveNodes.Count);
+        foreach (var activeNode in ent.Comp.CachedActiveNodes)
+        {
+            if (TryGetEntity(activeNode, out var node) && _nodeQuery.TryComp(node, out var nodeComp))
+                output.Add((node.Value, nodeComp));
+        }
+
+        return output;
     }
 
     /// <summary>
@@ -216,8 +223,10 @@ public abstract partial class SharedXenoArtifactSystem
             var outSegment = new List<Entity<XenoArtifactNodeComponent>>();
             foreach (var netNode in segment)
             {
-                var node = GetEntity(netNode);
-                outSegment.Add((node, XenoArtifactNode(node)));
+                // Triad: same unresolvable-NetEntity throw as GetActiveNodes, and this one runs from
+                // the analysis console's Draw every frame.
+                if (TryGetEntity(netNode, out var node) && _nodeQuery.TryComp(node, out var nodeComp))
+                    outSegment.Add((node.Value, nodeComp));
             }
 
             output.Add(outSegment);

--- a/Content.Shared/Xenoarchaeology/Artifact/SharedXenoArtifactSystem.Triad.cs
+++ b/Content.Shared/Xenoarchaeology/Artifact/SharedXenoArtifactSystem.Triad.cs
@@ -7,6 +7,7 @@ using Content.Shared.EntityTable.EntitySelectors;
 using Content.Shared.Random.Helpers;
 using Content.Shared.Xenoarchaeology.Artifact.Components;
 using Content.Shared.Xenoarchaeology.Artifact.Prototypes;
+using Robust.Shared.Map;
 using Robust.Shared.Prototypes;
 using Robust.Shared.Serialization;
 
@@ -28,6 +29,54 @@ namespace Content.Shared.Xenoarchaeology.Artifact;
 /// </summary>
 public abstract partial class SharedXenoArtifactSystem
 {
+    [Dependency] private readonly SharedTransformSystem _transform = default!;
+
+    #region Grid locality
+
+    /// <summary>
+    /// Triad: artifact effects are grid-local. An artifact belongs to the ship carrying it, so every
+    /// area effect filters its candidates through this before touching them. Docking two hulls no
+    /// longer lets a node reach across the airlock, and nothing an artifact does can land on another
+    /// crew's ship.
+    ///
+    /// An artifact with no grid under it (EVA, drifting in a debris field) is local to nothing, so it
+    /// reaches only other gridless entities on the same map rather than reaching into every hull
+    /// within range.
+    /// </summary>
+    /// <param name="artifact">The artifact the effect is firing from. The node entity works too: it
+    /// lives in the artifact's container and inherits its grid.</param>
+    /// <param name="target">Candidate the effect wants to touch.</param>
+    public bool IsGridLocal(EntityUid artifact, EntityUid target)
+    {
+        return IsGridLocal(Transform(artifact), target);
+    }
+
+    /// <inheritdoc cref="IsGridLocal(EntityUid,EntityUid)"/>
+    /// <remarks>
+    /// Overload for effect loops, which resolve the artifact's transform once and then test many
+    /// candidates against it.
+    /// </remarks>
+    public bool IsGridLocal(TransformComponent artifactXform, EntityUid target)
+    {
+        var targetXform = Transform(target);
+        return artifactXform.MapUid == targetXform.MapUid
+               && artifactXform.GridUid == targetXform.GridUid;
+    }
+
+    /// <summary>
+    /// Triad: as <see cref="IsGridLocal(EntityUid,EntityUid)"/>, but for the effects that land on a
+    /// clicked location rather than on an entity. Stops an artifact held on a docked shuttle from
+    /// dropping gas, foam or an EMP onto the grid next door.
+    /// </summary>
+    public bool IsGridLocal(EntityUid artifact, EntityCoordinates coordinates)
+    {
+        var artifactXform = Transform(artifact);
+        return artifactXform.MapUid == _transform.GetMap(coordinates)
+               && artifactXform.GridUid == _transform.GetGrid(coordinates);
+    }
+
+    #endregion
+
     #region Severity profile
 
     /// <summary>

--- a/Content.Shared/Xenoarchaeology/Artifact/SharedXenoArtifactSystem.XAE.cs
+++ b/Content.Shared/Xenoarchaeology/Artifact/SharedXenoArtifactSystem.XAE.cs
@@ -79,6 +79,13 @@ public abstract partial class SharedXenoArtifactSystem
         if (TryComp<UseDelayComponent>(artifact, out var delay) && !_useDelay.TryResetDelay((artifact, delay), true))
             return false;
 
+        // Triad: the guard above asks where the ARTIFACT is, but the effects land wherever the player
+        // clicked, and AfterInteract will happily hand us a tile on the grid next door. Reel the
+        // landing spot back onto the artifact's own hull so a docked shuttle cannot be used to lob gas
+        // or an EMP onto a depot, and so no effect ever lands on a grid the artifact is not aboard.
+        if (!IsGridLocal(artifact.Owner, coordinates))
+            coordinates = Transform(artifact).Coordinates;
+
         var success = false;
         foreach (var node in GetActiveNodes(artifact))
         {

--- a/Content.Shared/Xenoarchaeology/Artifact/SharedXenoArtifactSystem.cs
+++ b/Content.Shared/Xenoarchaeology/Artifact/SharedXenoArtifactSystem.cs
@@ -46,6 +46,16 @@ public abstract partial class SharedXenoArtifactSystem : EntitySystem
     private void OnStartup(Entity<XenoArtifactComponent> ent, ref ComponentStartup args)
     {
         ent.Comp.NodeContainer = _container.EnsureContainer<Container>(ent, XenoArtifactComponent.NodeContainerId);
+        AfterArtifactStartup(ent);
+    }
+
+    /// <summary>
+    /// Triad: startup hook for the server half. ComponentStartup is already taken here and the bus
+    /// refuses a second subscription for the same component and event, so the server gets a call
+    /// rather than its own subscription.
+    /// </summary>
+    protected virtual void AfterArtifactStartup(Entity<XenoArtifactComponent> ent)
+    {
     }
 
     public void SetSuppressed(Entity<XenoArtifactComponent> ent, bool val)

--- a/Content.Shared/Xenoarchaeology/Artifact/XAE/BaseXAESystem.cs
+++ b/Content.Shared/Xenoarchaeology/Artifact/XAE/BaseXAESystem.cs
@@ -1,11 +1,17 @@
 namespace Content.Shared.Xenoarchaeology.Artifact.XAE;
 
 /// <summary>
-/// Base class for 
+/// Base class for
 /// </summary>
 /// <typeparam name="T"></typeparam>
 public abstract class BaseXAESystem<T> : EntitySystem where T : Component
 {
+    /// <summary>
+    /// Triad: effect systems reach for this to keep themselves grid-local. See
+    /// <see cref="SharedXenoArtifactSystem.IsGridLocal(Robust.Shared.GameObjects.EntityUid,Robust.Shared.GameObjects.EntityUid)"/>.
+    /// </summary>
+    [Dependency] protected readonly SharedXenoArtifactSystem XenoArtifact = default!;
+
     /// <inheritdoc/>
     public override void Initialize()
     {

--- a/Content.Shared/Xenoarchaeology/Artifact/XAE/XAEDamageInAreaSystem.cs
+++ b/Content.Shared/Xenoarchaeology/Artifact/XAE/XAEDamageInAreaSystem.cs
@@ -29,8 +29,13 @@ public sealed class XAEDamageInAreaSystem : BaseXAESystem<XAEDamageInAreaCompone
         var damageInAreaComponent = ent.Comp;
         _entitiesInRange.Clear();
         _lookup.GetEntitiesInRange(ent.Owner, damageInAreaComponent.Radius, _entitiesInRange);
+
+        var xform = Transform(ent.Owner); // Triad: the node inherits the artifact's grid
         foreach (var entityInRange in _entitiesInRange)
         {
+            if (!XenoArtifact.IsGridLocal(xform, entityInRange)) // Triad: our hull takes the hit, not theirs
+                continue;
+
             if (!_random.Prob(damageInAreaComponent.DamageChance))
                 continue;
 

--- a/Content.Shared/Xenoarchaeology/Artifact/XAE/XAEKnockSystem.cs
+++ b/Content.Shared/Xenoarchaeology/Artifact/XAE/XAEKnockSystem.cs
@@ -20,7 +20,9 @@ public sealed class XAEKnockSystem : BaseXAESystem<XAEKnockComponent>
         var ev = new KnockSpellEvent
         {
             Performer = ent.Owner,
-            Range = ent.Comp.KnockRange
+            Range = ent.Comp.KnockRange,
+            // Triad: keep the doors we pop to our own hull, see KnockSpellEvent.OnlyGrid
+            OnlyGrid = Transform(ent.Owner).GridUid
         };
         RaiseLocalEvent(ev);
     }

--- a/Content.Shared/Xenoarchaeology/Artifact/XAE/XAERandomTeleportInvokerSystem.cs
+++ b/Content.Shared/Xenoarchaeology/Artifact/XAE/XAERandomTeleportInvokerSystem.cs
@@ -1,5 +1,6 @@
 using Content.Shared.Popups;
 using Content.Shared.Xenoarchaeology.Artifact.XAE.Components;
+using Robust.Shared.Containers;
 using Robust.Shared.Random;
 using Robust.Shared.Timing;
 
@@ -10,20 +11,50 @@ public sealed class XAERandomTeleportInvokerSystem : BaseXAESystem<XAERandomTele
     [Dependency] private readonly IRobustRandom _random = default!;
     [Dependency] private readonly SharedPopupSystem _popup = default!;
     [Dependency] private readonly SharedTransformSystem _xform = default!;
+    [Dependency] private readonly SharedContainerSystem _container = default!;
     [Dependency] private readonly IGameTiming _timing = default!;
+
+    /// <summary>
+    /// Triad: how many destinations to sample before giving up on finding one still on the artifact's
+    /// own grid. A blink that lands the artifact in space is a lost artifact, not a hazard.
+    /// </summary>
+    private const int GridSampleAttempts = 8;
 
     /// <inheritdoc />
     protected override void OnActivated(Entity<XAERandomTeleportInvokerComponent> ent, ref XenoArtifactNodeActivatedEvent args)
     {
         if (!_timing.IsFirstTimePredicted)
             return;
-        // todo: teleport person who activated artifact with artifact itself
+
         var component = ent.Comp;
 
-        var xform = Transform(ent.Owner);
+        // Triad: ent.Owner is the NODE, which lives inside the artifact's node-container. Offsetting
+        // its coordinates only nudged it around inside that container, so the blink moved nothing and
+        // the effect was a popup with a danger rating attached. Move the artifact.
+        var artifact = args.Artifact.Owner;
+
+        // A held or bagged artifact has to leave the container before it can go anywhere, otherwise
+        // SetCoordinates rewrites the parent out from under the container that is holding it.
+        if (_container.IsEntityInContainer(artifact))
+            _container.TryRemoveFromContainer(artifact, force: true);
+
+        var xform = Transform(artifact);
         _popup.PopupCoordinates(Loc.GetString("blink-artifact-popup"), xform.Coordinates, PopupType.Medium);
 
-        var offsetTo = _random.NextVector2(component.MinRange, component.MaxRange);
-        _xform.SetCoordinates(ent.Owner, xform, xform.Coordinates.Offset(offsetTo));
+        var origin = xform.Coordinates;
+        var grid = xform.GridUid;
+
+        for (var i = 0; i < GridSampleAttempts; i++)
+        {
+            var candidate = origin.Offset(_random.NextVector2(component.MinRange, component.MaxRange));
+
+            // Off-grid artifacts have nothing to stay on, so any destination will do. On a ship, the
+            // artifact has to still be aboard when it lands.
+            if (grid != null && _xform.GetGrid(candidate) != grid)
+                continue;
+
+            _xform.SetCoordinates(artifact, candidate);
+            return;
+        }
     }
 }

--- a/Content.Shared/Xenoarchaeology/Artifact/XAE/XAERemoveCollisionSystem.cs
+++ b/Content.Shared/Xenoarchaeology/Artifact/XAE/XAERemoveCollisionSystem.cs
@@ -14,12 +14,17 @@ public sealed class XAERemoveCollisionSystem : BaseXAESystem<XAERemoveCollisionC
     /// <inheritdoc />
     protected override void OnActivated(Entity<XAERemoveCollisionComponent> ent, ref XenoArtifactNodeActivatedEvent args)
     {
-        if (!TryComp<FixturesComponent>(ent.Owner, out var fixtures))
+        // Triad: ent.Owner is the NODE, an effect-only entity with no Fixtures, so this bailed every
+        // time and the phasing effect burned its one durability on nothing. The artifact is the thing
+        // that phases.
+        var artifact = args.Artifact.Owner;
+
+        if (!TryComp<FixturesComponent>(artifact, out var fixtures))
             return;
 
         foreach (var fixture in fixtures.Fixtures.Values)
         {
-            _physics.SetHard(ent.Owner, fixture, false, fixtures);
+            _physics.SetHard(artifact, fixture, false, fixtures);
         }
     }
 }

--- a/Content.Shared/Xenoarchaeology/Artifact/XAE/XAEShuffleSystem.cs
+++ b/Content.Shared/Xenoarchaeology/Artifact/XAE/XAEShuffleSystem.cs
@@ -37,8 +37,15 @@ public sealed class XAEShuffleSystem : BaseXAESystem<XAEShuffleComponent>
         List<Entity<TransformComponent>> toShuffle = new();
         _entities.Clear();
         _lookup.GetEntitiesInRange(ent.Owner, ent.Comp.Radius, _entities, LookupFlags.Dynamic | LookupFlags.Sundries);
+
+        var artifactXform = Transform(ent.Owner); // Triad: the node inherits the artifact's grid
         foreach (var entity in _entities)
         {
+            // Triad: shuffling has to stay on one hull. Swapping someone across a dock drops them
+            // through a wall on a grid they were never on.
+            if (!XenoArtifact.IsGridLocal(artifactXform, entity))
+                continue;
+
             if (!_mobState.HasComponent(entity))
                 continue;
 

--- a/Content.Shared/Xenoarchaeology/Artifact/XAT/Components/XATTimerComponent.cs
+++ b/Content.Shared/Xenoarchaeology/Artifact/XAT/Components/XATTimerComponent.cs
@@ -1,5 +1,6 @@
 using Content.Shared.Destructible.Thresholds;
 using Robust.Shared.GameStates;
+using Robust.Shared.Serialization.TypeSerializers.Implementations.Custom; // Triad: TimeOffsetSerializer
 
 namespace Content.Shared.Xenoarchaeology.Artifact.XAT.Components;
 
@@ -12,7 +13,10 @@ public sealed partial class XATTimerComponent : Component
     /// <summary>
     /// Next time timer going to activate.
     /// </summary>
-    [DataField, AutoNetworkedField, AutoPausedField]
+    // Triad: absolute CurTime, same defect as NextUnlockTime on XenoArtifactComponent. Dormant while
+    // TriggerTimer stays commented out in triggers.yml, but the field would go stale on a ship save
+    // the moment anyone re-enables it.
+    [DataField(customTypeSerializer: typeof(TimeOffsetSerializer)), AutoNetworkedField, AutoPausedField]
     public TimeSpan NextActivation;
 
     /// <summary>

--- a/Content.Shared/Xenoarchaeology/Artifact/XAT/XATCompNearbySystem.cs
+++ b/Content.Shared/Xenoarchaeology/Artifact/XAT/XATCompNearbySystem.cs
@@ -28,7 +28,18 @@ public sealed class XATCompNearbySystem : BaseQueryUpdateXATSystem<XATCompNearby
 
         _entities.Clear();
         _entityLookup.GetEntitiesInRange(comp.Type, pos, compNearbyComponent.Radius, _entities);
-        if (_entities.Count >= compNearbyComponent.Count)
+
+        // Triad: the lookup is a circle on the map, so a docked neighbour's cargo counts toward the
+        // required tally. Only what is aboard the artifact's own hull should.
+        var xform = Transform(artifact.Owner);
+        var count = 0;
+        foreach (var candidate in _entities)
+        {
+            if (XenoArtifact.IsGridLocal(xform, candidate))
+                count++;
+        }
+
+        if (count >= compNearbyComponent.Count)
             Trigger(artifact, node);
     }
 }

--- a/Content.Shared/Xenoarchaeology/Artifact/XAT/XATDeathSystem.cs
+++ b/Content.Shared/Xenoarchaeology/Artifact/XAT/XATDeathSystem.cs
@@ -41,6 +41,11 @@ public sealed class XATDeathSystem : BaseXATSystem<XATDeathComponent>
             if (!CanTrigger(artifact, (uid, node)))
                 continue;
 
+            // Triad: fifteen metres crosses a dock. Someone dying aboard the ship moored next to
+            // yours is not your artifact's doing, and should not solve your node.
+            if (!XenoArtifact.IsGridLocal(artifact.Owner, args.Target))
+                continue;
+
             var artifactCoords = Transform(artifact).Coordinates;
             if (_transform.InRange(targetCoords, artifactCoords, comp.Range))
                 Trigger(artifact, (uid, comp, node));

--- a/Content.Shared/Xenoarchaeology/Artifact/XAT/XATInteractAttackSystem.cs
+++ b/Content.Shared/Xenoarchaeology/Artifact/XAT/XATInteractAttackSystem.cs
@@ -4,6 +4,7 @@ using Content.Shared.Weapons.Melee.Events;
 using Content.Shared.Whitelist;
 using Content.Shared.Xenoarchaeology.Artifact.Components;
 using Content.Shared.Xenoarchaeology.Artifact.XAT.Components;
+using Robust.Shared.Network;
 using Robust.Shared.Physics.Events;
 using Robust.Shared.Random;
 
@@ -15,9 +16,10 @@ namespace Content.Shared.Xenoarchaeology.Artifact.XAT;
 /// </summary>
 public sealed partial class XATInteractAttackSystem : BaseXATSystem<XATInteractAttackComponent>
 {
-    [Dependency] private SharedPopupSystem _popup = default!;
-    [Dependency] private IRobustRandom _random = default!;
-    [Dependency] private EntityWhitelistSystem _whitelistSystem = default!;
+    [Dependency] private readonly SharedPopupSystem _popup = default!;
+    [Dependency] private readonly IRobustRandom _random = default!;
+    [Dependency] private readonly EntityWhitelistSystem _whitelistSystem = default!;
+    [Dependency] private readonly INetManager _net = default!;
 
     public override void Initialize()
     {
@@ -75,6 +77,13 @@ public sealed partial class XATInteractAttackSystem : BaseXATSystem<XATInteractA
     /// <returns>True if enough interactions have been made, False if not.</returns>
     private bool DoTriggerCountdown(Entity<XATInteractAttackComponent> ent, EntityUid artifact, EntityUid? user)
     {
+        // Triad: all three feeding events are raised on both sides, and StartCollideEvent re-fires on
+        // every client prediction pass, so the countdown was decremented several times per real hit
+        // and the popup fired once per pass on top of the server's. Trigger() already refuses to run
+        // outside the first predicted pass, so returning false here costs nothing.
+        if (!Timing.IsFirstTimePredicted)
+            return false;
+
         if (ent.Comp.MaxCount == null || ent.Comp.Count == null) //ensure countdown isn't null
             SetMaxCount(ent);
 
@@ -82,7 +91,7 @@ public sealed partial class XATInteractAttackSystem : BaseXATSystem<XATInteractA
 
         if (ent.Comp.Count > 0)
         {
-            if (ent.Comp.InsufficientInteractionPopup != null && user != null) // Triad: no nullable-recipient overload here
+            if (ent.Comp.InsufficientInteractionPopup != null && user != null && _net.IsServer) // Triad: no nullable-recipient overload here
                 _popup.PopupEntity(Loc.GetString(ent.Comp.InsufficientInteractionPopup), artifact, user.Value); //tell user they need to interact in the same way more times
 
             Dirty(ent);

--- a/Content.Shared/Xenoarchaeology/Artifact/XAT/XATStaminaDamageThresholdReachedSystem.cs
+++ b/Content.Shared/Xenoarchaeology/Artifact/XAT/XATStaminaDamageThresholdReachedSystem.cs
@@ -2,6 +2,7 @@ using Content.Shared.Damage.Systems; // Triad: BeforeStaminaDamageEvent lives be
 using Content.Shared.Popups;
 using Content.Shared.Xenoarchaeology.Artifact.Components;
 using Content.Shared.Xenoarchaeology.Artifact.XAT.Components;
+using Robust.Shared.Network;
 
 namespace Content.Shared.Xenoarchaeology.Artifact.XAT;
 
@@ -10,7 +11,8 @@ namespace Content.Shared.Xenoarchaeology.Artifact.XAT;
 /// </summary>
 public sealed partial class XATStaminaDamageThresholdReachedSystem : BaseXATSystem<XATStaminaDamageThresholdReachedComponent>
 {
-    [Dependency] private SharedPopupSystem _popup = default!;
+    [Dependency] private readonly SharedPopupSystem _popup = default!;
+    [Dependency] private readonly INetManager _net = default!;
 
     public override void Initialize()
     {
@@ -28,6 +30,13 @@ public sealed partial class XATStaminaDamageThresholdReachedSystem : BaseXATSyst
         if (args.Value <= 0) //prevent stamina regeneration being considered
             return;
 
+        // Triad: BeforeStaminaDamageEvent is raised on both sides and the client re-runs it on every
+        // prediction pass, so the accumulator counted one hit several times and drifted until the
+        // next server state corrected it. XATDamageThresholdReached already guards its accumulator
+        // this way; this one was missed when the trigger came over in the rework.
+        if (!Timing.IsFirstTimePredicted)
+            return;
+
         node.Comp1.AccumulatedDamage += args.Value;
         Dirty(node);
 
@@ -39,7 +48,10 @@ public sealed partial class XATStaminaDamageThresholdReachedSystem : BaseXATSyst
         }
         else
         {
-            if (node.Comp1.InsufficientDamagePopup != null)
+            // Triad: unguarded PopupEntity in a shared system shows once from the client's own pass
+            // and again when the server's popup arrives. The rest of this feature lets the server own
+            // its popups; match it.
+            if (node.Comp1.InsufficientDamagePopup != null && _net.IsServer)
                 _popup.PopupEntity(Loc.GetString(node.Comp1.InsufficientDamagePopup), artifact); //tell user they need to interact in the same way more times
         }
 

--- a/Content.Shared/Xenoarchaeology/Equipment/NodeScannerSystem.cs
+++ b/Content.Shared/Xenoarchaeology/Equipment/NodeScannerSystem.cs
@@ -33,9 +33,18 @@ public sealed class NodeScannerSystem : EntitySystem
 
             connected.NextUpdate = _timing.CurTime + connected.LinkUpdateInterval;
 
+            // Triad: AttachedTo is a raw uid with nothing watching the artifact's lifetime, and it is a
+            // DataField, so it also comes back out of a ship file pointing at an artifact that was
+            // never in the file. Transform() throws on both, once per scanner per second, forever.
+            // Drop the link instead.
             var attachedArtifact = connected.AttachedTo;
-            var artifactCoordinates = Transform(attachedArtifact).Coordinates;
-            if (!_transform.InRange(artifactCoordinates, transform.Coordinates, scanner.MaxLinkedRange))
+            if (!TryComp<TransformComponent>(attachedArtifact, out var artifactTransform))
+            {
+                RemCompDeferred(uid, connected);
+                continue;
+            }
+
+            if (!_transform.InRange(artifactTransform.Coordinates, transform.Coordinates, scanner.MaxLinkedRange))
             {
                 //scanner is too far, disconnect
                 RemCompDeferred(uid, connected);

--- a/Content.Shared/Xenoarchaeology/XenoArtifacts/RandomArtifactSpriteComponent.cs
+++ b/Content.Shared/Xenoarchaeology/XenoArtifacts/RandomArtifactSpriteComponent.cs
@@ -12,5 +12,15 @@ public sealed partial class RandomArtifactSpriteComponent : Component
     [DataField("activationTime")]
     public double ActivationTime = 0.4;
 
+    /// <summary>
+    /// Triad: the rolled sprite index, persisted. It used to live only in AppearanceData, which is an
+    /// internal field with no DataField on it and therefore does not survive a save at all. Combined
+    /// with the roll hanging off MapInitEvent, which a file-restored entity never receives, an
+    /// artifact stored on a ship came back with no index and rendered as its bare prototype sprite.
+    /// Null means "not rolled yet".
+    /// </summary>
+    [DataField]
+    public int? SpriteIndex;
+
     public TimeSpan? ActivationStart;
 }

--- a/Resources/Locale/en-US/xenoarchaeology/artifact-analyzer.ftl
+++ b/Resources/Locale/en-US/xenoarchaeology/artifact-analyzer.ftl
@@ -54,3 +54,5 @@ analysis-console-info-peak-value = [font="Monospace" size=11][color={ $cap ->
 analysis-console-info-unknown-value = [font="Monospace" size=11][color=gray]Insufficient data[/color][/font]
 
 analyzer-artifact-extract-popup = Energy shimmers on the artifact's surface!
+# Triad: the console will happily total up points with no research server on the other end.
+analyzer-artifact-extract-no-server = The console has no research server to bank the data to.

--- a/Resources/Prototypes/XenoArch/effects.yml
+++ b/Resources/Prototypes/XenoArch/effects.yml
@@ -1038,15 +1038,12 @@
       deleteSpawnerAfterSpawn: false
       table: !type:GroupSelector
         children:
-        - id: MobAdultSlimesYellowAngry
-        - id: MobAngryBee
-        - id: MobBearSpace
-        - id: MobXenoRavager
-        - id: MobTick
-        - id: MobSpiderSpace
-        - id: MobPurpleSnake
+        # Triad: this table used to open with the whole hostile roster, so "friendly fauna" at
+        # danger 2 could deal you a space bear, a xeno ravager or an angry bee. That is what the
+        # hostile table at danger 4 is for; the severity curve cannot rate a node whose outcome
+        # ranges from a kitten to a ravager. Removed: MobAdultSlimesYellowAngry, MobAngryBee,
+        # MobBearSpace, MobXenoRavager, MobTick, MobSpiderSpace, MobPurpleSnake, MobKangarooSpace.
         - id: MobMouse
-        - id: MobKangarooSpace
         - id: MobPig
         - id: MobParrot
         - id: MobKangaroo

--- a/Resources/ServerInfo/Guidebook/Antagonist/NuclearOperatives.xml
+++ b/Resources/ServerInfo/Guidebook/Antagonist/NuclearOperatives.xml
@@ -47,7 +47,7 @@
   You can purchase the same kinds of gear traitors can, but you have higher quality gear available to you and more telecrystals to spend.
   <Box>
     <GuideEntityEmbed Entity="WeaponLightMachineGunL6" Caption="Weaponry"/>
-    <GuideEntityEmbed Entity="Magazine7.62x39mmBox" State="icon" Caption="Ammo"/>
+    <GuideEntityEmbed Entity="Magazine762x39mmBox" State="icon" Caption="Ammo"/>
     <GuideEntityEmbed Entity="C4" Caption="Explosives"/>
     <GuideEntityEmbed Entity="ClothingOuterHardsuitJuggernaut" Caption="Wearables"/>
     <GuideEntityEmbed Entity="Stimpack" Caption="Chemicals"/>

--- a/Resources/ServerInfo/Guidebook/Antagonist/Traitors.xml
+++ b/Resources/ServerInfo/Guidebook/Antagonist/Traitors.xml
@@ -32,7 +32,7 @@
 
   <Box>
     <GuideEntityEmbed Entity="WeaponPistolCobra" Caption="Weaponry"/>
-    <GuideEntityEmbed Entity="AmmoBox7.62x39mmFMJ" State="icon" Caption="Ammo"/>
+    <GuideEntityEmbed Entity="AmmoBox762x39mmFMJ" State="icon" Caption="Ammo"/>
     <GuideEntityEmbed Entity="C4" Caption="Explosives"/>
     <GuideEntityEmbed Entity="ClothingOuterHardsuitSyndie" Caption="Wearables"/>
     <GuideEntityEmbed Entity="Stimpack" Caption="Chemicals"/>

--- a/Resources/ServerInfo/_Triad/Guidebook/Shipyard/Gondola.xml
+++ b/Resources/ServerInfo/_Triad/Guidebook/Shipyard/Gondola.xml
@@ -6,9 +6,9 @@
   <GuideEntityEmbed Entity="FloorWaterEntity" Caption="Pool"/>
   <GuideEntityEmbed Entity="GasThermoMachineHeater" Caption="Sauna"/>
   </Box>
-  <Box>
-  <GuideEntityEmbed Entity="ShuttleMapGondola" Caption=""/>
-  </Box>
+  <!-- Triad: the ShuttleMapGondola embed was pulled because nothing declares that prototype, so it
+       rendered as a hole in a live page. 128x96.rsi has no gondola state to point one at yet; add
+       the sprite, add the prototype to _Triad/Guidebook/shuttle_maps.yml, then restore this Box. -->
     [color=#a4885c]Ship Size:[/color] Medium
 
 	[color=#a4885c]Recommended Crew:[/color] 1-4


### PR DESCRIPTION
## About the PR

Six commits of bug fixes across the reworked xenoarch code, found by reading it end to end after a live report that artifact nodes sometimes could not be activated no matter what the crew did. The two big families are effects and triggers reaching across grids on a shared sector map, and state that did not survive a ship save.

## Why / Balance

**Grid locality.** On a sector map every ship shares one map, so "same map" was never a fence. Area effects reached through docking airlocks into whoever was moored alongside, and the portal effect at 1000m could yank crew off a depot. Effects now filter candidates through `IsGridLocal`, and `TryActivateXenoArtifact` reels a clicked location back onto the artifact's own hull, because `AfterInteract` will happily hand it a tile on the grid next door. Portal range drops 1000 to 100 now that the grid gate does the real work.

The trigger side had the same hole on the way in: a depot's salvage magnet at 40m, someone dying aboard the next berth at 15m, a neighbour's cargo counting toward `XATCompNearby`'s tally. All four key off the artifact's grid now, so carrying an artifact aboard someone else's ship makes their magnet the one that solves it.

**Ship saves.** Three separate things hung off `MapInitEvent`, which an entity loaded from a file onto a running map never receives.

Graph generation was one, so artifacts out of a ship file arrived with an empty node graph and stayed inert, worth nothing. There is now a deferred pass that settles it on the next tick once it can see whether the map is live.

`NextUnlockTime`, `EndTime` and `XATTimer`'s `NextActivation` stored absolute `CurTime` in plain DataFields. `CurTime` restarts when the server does, so a ship file carried the previous server's clock and an artifact that had ever completed one unlock session came back refusing every trigger, silently, until the new uptime caught up. That is the report this PR started from. `TimeOffsetSerializer` fixes it, the way the crusher and node scanner already did.

The sprite index was the third. It lived only in `AppearanceData`, which is internal with no DataField and does not serialise at all, so a stored artifact came back rendering as its bare prototype sprite. `ItemComponent.HeldPrefix` is a real DataField, which is why it looked correct in hand and wrong on the floor.

**Effects that did nothing.** Blink offset the node entity, which lives inside the artifact's own container, so it nudged the node around inside that container and the artifact never moved. Phasing read `Fixtures` off the node, which node prototypes do not carry, so it always bailed. The puddle effect filled the component's own `Solution` every activation and `TrySpillAt` does not drain what you hand it, so the puddle grew by a full charge each use.

**Client robustness.** `TryGetNode` was never a `Try`: `GetEntity(netUid) is var uid` is a var pattern, so it always matches, and an unresolvable NetEntity fell through to `_nodeQuery.Get` and threw. `GetAllNodes` in the same file already used `TryGetEntity`; its three siblings did not. Downstream of that, the console's graph control called `Max()` on an empty sequence every frame, and the node scanner called `GetNode` on a timer over indices from a different networked component.

**Prediction.** `XATInteractAttack` and `XATStaminaDamageThresholdReached` mutate an interaction counter with no `IsFirstTimePredicted` guard, in shared systems, on events raised both sides. `StartCollideEvent` re-fires every client prediction pass, so one hit decremented the countdown several times, and both fired their popup from the client's own pass and again when the server's arrived.

`XenoArtifactFaunaSpawn` is rated danger 2 and captioned friendly fauna and was rolling angry bees, a xeno ravager and a space bear. Those are out of the table.

## Media

No visual changes beyond artifacts rendering with the correct sprite again after a ship load.

## Requirements

- [x] I have read the guidelines and documentation relevant to this PR.
- [ ] I have added media to this PR or it does not require an ingame showcase.
- [x] I can confirm this PR contains either no AI-generated content, or AI-generated content that meets our guidelines.

## How to test

The clock fix needs two server lifetimes and is the one worth doing by hand: take a ship carrying an artifact that has completed at least one unlock session, save it, restart the server, load it, and trigger a node. Before this it was dead for however long the previous server had been up.

Otherwise: dock two ships and confirm an artifact effect stops at the airlock; open an analysis console on a freshly restored ship artifact and confirm the graph draws; check a restored artifact's world sprite matches its in-hands one.

## Breaking changes

`RandomArtifactSpriteComponent` gains a `spriteIndex` DataField. Artifacts in existing ship saves have no index recorded, so they roll a fresh one on their next load and keep it from then on: a stored artifact may change appearance once.

`EmpSystem.EmpPulse` gains an optional `onlyGrid` parameter and `KnockSpellEvent` gains an optional `OnlyGrid` field. Both default to null and existing callers are unaffected.

**Changelog**
:cl:
- fix: Artifacts stored on a ship no longer come back inert, unsolvable, or wearing the wrong sprite.
- fix: Artifact effects and triggers are now local to the ship running the artifact. Docking next to someone no longer lets their artifact gas your hull, and their salvage magnet no longer solves your nodes.
- fix: The blink and phasing artifact effects now actually do something.
- fix: The analysis console says so when there is no research server to bank points to, instead of quietly banking nothing.
- fix: Artifact "friendly fauna" no longer spawns angry bees and space bears.
