### PR TITLE
Fix Tech Disks

### DIFF
--- a/Resources/Prototypes/_Triad/Recipes/Lathes/Packs/faction.yml
+++ b/Resources/Prototypes/_Triad/Recipes/Lathes/Packs/faction.yml
@@ -18,3 +18,22 @@
   - WeaponShotgunSultanPulsar
   - PrintableDirtyBomb
   - WeaponSubMachineGunAtreidesRogue
+  - JawsOfLifeRogue
+  - HyposprayRogue
+  - WeaponRifleXlr556Tsf
+  - Magazine762x51mmFMJ
+  - Magazine762x51mmEmpty
+  - AmmoBox762x51mmFMJ
+  - AmmoBox145x114mmBig
+  - Magazine635x40mmCaseless
+  - AmmoBox635x40mmCaseless
+  - MagazineAsmgtUniversal635x40mm
+  - EmagRogue
+  - AccessBreakerRogue
+  - WeaponRifleMR3CTSF
+  - Magazine8x65mmSKR
+  - Magazine8x65mmEmpty
+  - AmmoBox8x65mmSKR
+  - WeaponSubMachineGunDrozdTSF
+  - WeaponRifleLecterTSF
+  - WeaponRifleAnnieTSF


### PR DESCRIPTION
## About the PR
Some tech disks had recipes on them that weren't accessible by any lathe. This fixes that

**Changelog**
:cl:
- fix: Fixed some technology disks not giving you the recipes on the disk.
