### PR TITLE
Player Faction Warning Labels

### DIFF
--- a/Content.Client/Lobby/UI/HumanoidProfileEditor.xaml
+++ b/Content.Client/Lobby/UI/HumanoidProfileEditor.xaml
@@ -179,6 +179,10 @@
                                              MinHeight="400" MaxHeight="400"
                                              Visible="False"/>
                             </BoxContainer>
+                            <RichTextLabel Name="CompanyWarningLabel"
+                                    HorizontalExpand="False"
+                                    VerticalExpand="True" MaxWidth="400"
+                                    HorizontalAlignment="Left" />
                         </BoxContainer>
                     </ScrollContainer>
                 </BoxContainer>

--- a/Content.Client/Lobby/UI/HumanoidProfileEditor.xaml
+++ b/Content.Client/Lobby/UI/HumanoidProfileEditor.xaml
@@ -179,10 +179,15 @@
                                              MinHeight="400" MaxHeight="400"
                                              Visible="False"/>
                             </BoxContainer>
-                            <RichTextLabel Name="CompanyWarningLabel"
-                                    HorizontalExpand="False"
-                                    VerticalExpand="True" MaxWidth="400"
-                                    HorizontalAlignment="Left" />
+                            <BoxContainer Margin="15,15,15,10" VerticalExpand="True">
+                                <PanelContainer StyleClasses="BackgroundDark" Margin="10,8,10,8" MaxWidth="650" MaxHeight="100">
+                                    <RichTextLabel Name="CompanyWarningLabel"
+                                           VerticalAlignment="Top"
+                                           HorizontalExpand="True"
+                                           HorizontalAlignment="Right"
+                                           Margin="5,5,5,5"/>
+                                </PanelContainer>
+                            </BoxContainer>
                         </BoxContainer>
                     </ScrollContainer>
                 </BoxContainer>

--- a/Content.Client/Lobby/UI/HumanoidProfileEditor.xaml.cs
+++ b/Content.Client/Lobby/UI/HumanoidProfileEditor.xaml.cs
@@ -1973,11 +1973,12 @@ namespace Content.Client.Lobby.UI
                 CompanyButton.SelectId(0);
                 CompanyImage.Visible = false;
 
-                // Also reset the profile's company to None if the current one is disabled
-                if (_prototypeManager.TryIndex<CompanyPrototype>(Profile.Company, out var companyProto) && companyProto.Disabled)
-                {
+                // Also reset the profile's company to None if the current one is disabled, or they aren't whitelisted for it
+                if (!_prototypeManager.TryIndex<CompanyPrototype>(Profile.Company, out var companyProto))
+                    return;
+
+                if (companyProto.Disabled || !_companyManager.IsAllowed(companyProto))
                     Profile = Profile.WithCompany("None");
-                }
             }
         }
     }

--- a/Content.Client/Lobby/UI/HumanoidProfileEditor.xaml.cs
+++ b/Content.Client/Lobby/UI/HumanoidProfileEditor.xaml.cs
@@ -475,6 +475,8 @@ namespace Content.Client.Lobby.UI
                 //Logger.Debug($"Added company to dropdown: {i} - {companies[i].ID} - {companies[i].Name}");
             }
 
+            CompanyWarningLabel.SetMarkup($"[color=red]{Loc.GetString("humanoid-profile-editor-company-warning")}[/color]");
+
             CompanyButton.OnItemSelected += args =>
             {
                 CompanyButton.SelectId(args.Id);

--- a/Content.Server/_Mono/Company/CompanyCommand.cs
+++ b/Content.Server/_Mono/Company/CompanyCommand.cs
@@ -9,7 +9,7 @@ using Robust.Shared.Toolshed.TypeParsers;
 
 namespace Content.Server._Mono.Company;
 
-[ToolshedCommand(Name = "company"), AnyCommand]
+[ToolshedCommand(Name = "faction"), AnyCommand]
 public sealed partial class CompanyCommand : ToolshedCommand
 {
     [Dependency] private CompanyManager _company = default!;

--- a/Content.Server/_Mono/Company/CompanySystem.cs
+++ b/Content.Server/_Mono/Company/CompanySystem.cs
@@ -63,34 +63,20 @@ public sealed partial class CompanySystem : EntitySystem
             companyComp.CompanyName = job.AssignedCompany;
             assigned = companyComp.CompanyName != "None";
         }
+
         if (!assigned)
         {
-            // Only consider whitelist if the player has NO specific company preference
-            bool loginFound = false;
+            // Check for other companies if one wasn't assigned by the job
+            var allowedCompany = false;
 
-            // Only check logins if the player hasn't explicitly set a company preference
-            // or if their preference is "None"
-            if (string.IsNullOrEmpty(profileCompany))
+            // Check if the company isn't disabled and if they are whitelisted or the company has no whitelist
+            if (_prototypeManager.TryIndex<CompanyPrototype>(companyId, out var company) && !companyProto.Disabled && _companyManager.IsAllowed(c))
+                allowedCompany = true;
+
+            // If player is not allowed, set to none
+            if (!allowedCompany)
             {
-                foreach (var companyProto in _prototypeManager.EnumeratePrototypes<CompanyPrototype>())
-                {
-                    if (_manager.IsAllowed(args.Player, companyProto))
-                    {
-                        companyComp.CompanyName = companyProto.ID;
-                        loginFound = true;
-                        break;
-                    }
-                }
-            }
-
-            // If no login was found or login check was skipped due to player preference, use the player's preference
-            if (!loginFound)
-            {
-                // Use "None" as fallback for empty company
-                if (string.IsNullOrEmpty(profileCompany))
-                    profileCompany = "None";
-
-                // Restore the player's original company preference
+                profileCompany = "None";
                 companyComp.CompanyName = profileCompany;
             }
         }

--- a/Content.Server/_Mono/Company/CompanySystem.cs
+++ b/Content.Server/_Mono/Company/CompanySystem.cs
@@ -64,21 +64,11 @@ public sealed partial class CompanySystem : EntitySystem
             assigned = companyComp.CompanyName != "None";
         }
 
-        if (!assigned)
+        if (!assigned && _prototypeManager.TryIndex<CompanyPrototype>(profileCompany, out var companyPrototype))
         {
-            // Check for other companies if one wasn't assigned by the job
-            var allowedCompany = false;
-
-            // Check if the company isn't disabled and if they are whitelisted or the company has no whitelist
-            if (!_prototypeManager.TryIndex<CompanyPrototype>(profileCompany, out var companyPrototype))
-                return;
-
             // Check if the company isn't disabled and if the player is whitelisted OR the company has no whitelist
-            if (!companyPrototype.Disabled && _companyManager.IsAllowed(args.Player, companyPrototype))
-                allowedCompany = true;
-
-            // If player is not allowed, set to none
-            if (!allowedCompany)
+            // If it's not allowed, set the company to 'None'
+            if (companyPrototype.Disabled || !_manager.IsAllowed(args.Player, companyPrototype);)
             {
                 profileCompany = "None";
                 companyComp.CompanyName = profileCompany;

--- a/Content.Server/_Mono/Company/CompanySystem.cs
+++ b/Content.Server/_Mono/Company/CompanySystem.cs
@@ -69,10 +69,9 @@ public sealed partial class CompanySystem : EntitySystem
             // Check if the company isn't disabled and if the player is whitelisted OR the company has no whitelist
             // If it's not allowed, set the company to 'None'
             if (companyPrototype.Disabled || !_manager.IsAllowed(args.Player, companyPrototype))
-            {
                 profileCompany = "None";
-                companyComp.CompanyName = profileCompany;
-            }
+
+            companyComp.CompanyName = profileCompany;
         }
 
         // Ensure the component is networked to clients

--- a/Content.Server/_Mono/Company/CompanySystem.cs
+++ b/Content.Server/_Mono/Company/CompanySystem.cs
@@ -70,7 +70,11 @@ public sealed partial class CompanySystem : EntitySystem
             var allowedCompany = false;
 
             // Check if the company isn't disabled and if they are whitelisted or the company has no whitelist
-            if (_prototypeManager.TryIndex<CompanyPrototype>(companyId, out var company) && !companyProto.Disabled && _companyManager.IsAllowed(c))
+            if (!_prototypeManager.TryIndex<CompanyPrototype>(profileCompany, out var companyPrototype))
+                return;
+
+            // Check if the company isn't disabled and if the player is whitelisted OR the company has no whitelist
+            if (!companyPrototype.Disabled && _companyManager.IsAllowed(args.Player, companyPrototype))
                 allowedCompany = true;
 
             // If player is not allowed, set to none

--- a/Content.Server/_Mono/Company/CompanySystem.cs
+++ b/Content.Server/_Mono/Company/CompanySystem.cs
@@ -68,7 +68,7 @@ public sealed partial class CompanySystem : EntitySystem
         {
             // Check if the company isn't disabled and if the player is whitelisted OR the company has no whitelist
             // If it's not allowed, set the company to 'None'
-            if (companyPrototype.Disabled || !_manager.IsAllowed(args.Player, companyPrototype);)
+            if (companyPrototype.Disabled || !_manager.IsAllowed(args.Player, companyPrototype))
             {
                 profileCompany = "None";
                 companyComp.CompanyName = profileCompany;

--- a/Resources/Locale/en-US/_Mono/company/whitelist-commands.ftl
+++ b/Resources/Locale/en-US/_Mono/company/whitelist-commands.ftl
@@ -5,7 +5,7 @@ cmd-faction-player-not-found = Player {$player} not found.
 cmd-faction-hint-player = [player]
 cmd-faction-hint-company = [company]
 
-command-faction-company-addmember = Lets a player play a whitelisted company.
+command-faction-faction-addmember = Lets a player play a whitelisted company.
 cmd-company-memberadd-already-whitelisted = {$player} is already whitelisted to play as {$companyId} .({$companyName}).
 cmd-company-memberadd-added = Added {$player} to the {$companyId} ({$companyName}) whitelist.
 

--- a/Resources/Locale/en-US/_Mono/company/whitelist-commands.ftl
+++ b/Resources/Locale/en-US/_Mono/company/whitelist-commands.ftl
@@ -22,7 +22,7 @@ cmd-company-members-whitelisted-for = Company {$company} is whitelisted for:
 command-description-faction-setowner = Set owner status of a player in company. Note: Add member to company before this command!
 cmd-company-setowner-success = Successfully changed owner status of {$player} to {$status}
 
-command-description-company-removemember = Removes a player's ability to play a whitelisted company.
+command-description-faction-removemember = Removes a player's ability to play a whitelisted company.
 cmd-company-memberremove-removed = Removed {$player} from the whitelist for {$companyId} ({$companyName}).
 
 cmd-company-was-not-whitelisted = {$player} was not whitelisted to play as {$companyId} ({$companyName}).

--- a/Resources/Locale/en-US/_Mono/company/whitelist-commands.ftl
+++ b/Resources/Locale/en-US/_Mono/company/whitelist-commands.ftl
@@ -1,25 +1,25 @@
 cmd-company-not-enough-permissions = Insufficient permissions to use this command.
 
-cmd-company-company-does-not-exist = Company {$company} does not exist.
-cmd-company-player-not-found = Player {$player} not found.
-cmd-company-hint-player = [player]
-cmd-company-hint-company = [company]
+cmd-faction-company-does-not-exist = Company {$company} does not exist.
+cmd-faction-player-not-found = Player {$player} not found.
+cmd-faction-hint-player = [player]
+cmd-faction-hint-company = [company]
 
-command-description-company-addmember = Lets a player play a whitelisted company.
+command-faction-company-addmember = Lets a player play a whitelisted company.
 cmd-company-memberadd-already-whitelisted = {$player} is already whitelisted to play as {$companyId} .({$companyName}).
 cmd-company-memberadd-added = Added {$player} to the {$companyId} ({$companyName}) whitelist.
 
-command-description-company-playercompanies = Gets all the companies that a player has been whitelisted for.
+command-description-faction-playercompanies = Gets all the companies that a player has been whitelisted for.
 cmd-company-playercompanies-whitelisted-for = Player {$player} is whitelisted for:
 {$companies}
 
-command-description-company-members = Gets all the players that has been whitelisted for a company.
+command-description-faction-members = Gets all the players that has been whitelisted for a company.
 cmd-company-members-whitelisted-for = Company {$company} is whitelisted for:
     {$players}
     {$company} owners:
     {$owners}
 
-command-description-company-setowner = Set owner status of a player in company. Note: Add member to company before this command!
+command-description-faction-setowner = Set owner status of a player in company. Note: Add member to company before this command!
 cmd-company-setowner-success = Successfully changed owner status of {$player} to {$status}
 
 command-description-company-removemember = Removes a player's ability to play a whitelisted company.

--- a/Resources/Locale/en-US/_Mono/company/whitelist-commands.ftl
+++ b/Resources/Locale/en-US/_Mono/company/whitelist-commands.ftl
@@ -5,7 +5,7 @@ cmd-faction-player-not-found = Player {$player} not found.
 cmd-faction-hint-player = [player]
 cmd-faction-hint-company = [company]
 
-command-faction-company-addmember = Lets a player play a whitelisted company.
+command-description-faction-addmember = Lets a player play a whitelisted company.
 cmd-company-memberadd-already-whitelisted = {$player} is already whitelisted to play as {$companyId} .({$companyName}).
 cmd-company-memberadd-added = Added {$player} to the {$companyId} ({$companyName}) whitelist.
 

--- a/Resources/Locale/en-US/preferences/ui/humanoid-profile-editor.ftl
+++ b/Resources/Locale/en-US/preferences/ui/humanoid-profile-editor.ftl
@@ -62,7 +62,7 @@ humanoid-profile-editor-flavortext-tab = Description
 # Company
 humanoid-profile-editor-company-tab = Player Factions
 humanoid-profile-editor-company-label = Player Faction:
-humanoid-profile-editor-company-warning = Notice: These are player factions. Functionally, these player factions simply give you access to a ship IFF tag and a badge on your ID card. If none appear here, you are not in any player factions. All player factions are operated ICly, so if you wish to join one, get recruited in-game! Player factions do not get any benefits besides from the ship IFF tag, it is purely to denote that your character is apart of a guild.
+humanoid-profile-editor-company-warning = Notice: This tab is for selecting player-owned factions/guilds. Functionally, these player factions simply give you access to a ship IFF tag and a badge on your ID card. If none appear here, you are not in any player factions. All player factions are operated ICly, so if you wish to join one, get recruited in-game! Player factions do not get any benefits besides from the ship IFF tag, it is purely to denote that your character is apart of a guild.
 
 # Traits
 humanoid-profile-editor-traits-tab = Traits

--- a/Resources/Locale/en-US/preferences/ui/humanoid-profile-editor.ftl
+++ b/Resources/Locale/en-US/preferences/ui/humanoid-profile-editor.ftl
@@ -62,7 +62,7 @@ humanoid-profile-editor-flavortext-tab = Description
 # Company
 humanoid-profile-editor-company-tab = Player Factions
 humanoid-profile-editor-company-label = Player Faction:
-humanoid-profile-editor-company-warning = Notice: This tab is for selecting player-owned factions/guilds. Functionally, these player factions simply give you access to a ship IFF tag and a badge on your ID card. If none appear here, you are not in any player factions. All player factions are operated ICly, so if you wish to join one, get recruited in-game! Player factions do not get any benefits besides from the ship IFF tag, it is purely to denote that your character is apart of a guild.
+humanoid-profile-editor-company-warning = Notice: This tab is for selecting player-owned factions/guilds. If none appear here, you are not in any player factions. All player factions are operated ICly. If you wish to join one, get recruited in-game! Player factions do not get any benefits besides from the ship IFF tag, it is purely to denote that your character is apart of a guild.
 
 # Traits
 humanoid-profile-editor-traits-tab = Traits

--- a/Resources/Locale/en-US/preferences/ui/humanoid-profile-editor.ftl
+++ b/Resources/Locale/en-US/preferences/ui/humanoid-profile-editor.ftl
@@ -60,8 +60,9 @@ humanoid-profile-editor-markings-tab = Markings
 humanoid-profile-editor-flavortext-tab = Description
 
 # Company
-humanoid-profile-editor-company-tab = Minor Factions
-humanoid-profile-editor-company-label = Minor Faction:
+humanoid-profile-editor-company-tab = Player Factions
+humanoid-profile-editor-company-label = Player Faction:
+humanoid-profile-editor-company-warning = Notice: These are player factions. Functionally, these player factions simply give you access to a ship IFF tag and a badge on your ID card. If none appear here, you are not in any player factions. All player factions are operated ICly, so if you wish to join one, get recruited in-game! Player factions do not get any benefits besides from the ship IFF tag, it is purely to denote that your character is apart of a guild.
 
 # Traits
 humanoid-profile-editor-traits-tab = Traits


### PR DESCRIPTION
## About the PR
notice label to clear up confusion on why there's nothing here

<img width="734" height="488" alt="image" src="https://github.com/user-attachments/assets/03616dc8-9f3b-4202-a480-cd591b82a69d" />

Also fixed it not removing player factions you are not whitelisted for

Add added a server-side check for companies (The client was authoritive? What?)


**Changelog**
:cl:
- add: Added a notice label to the player factions tab in the character profile editor to clear up any confusion
- tweak: (ADMIN) Company toolshed command renamed to Faction toolshed commands
