### PR TITLE
Besieger Adjustment

### DIFF
--- a/Resources/Prototypes/_Triad/Entities/Clothing/OuterClothing/Modsuits/modsuits.yml
+++ b/Resources/Prototypes/_Triad/Entities/Clothing/OuterClothing/Modsuits/modsuits.yml
@@ -45,8 +45,8 @@
   - type: Sprite
     sprite: _Triad/Clothing/OuterClothing/Modsuits/HZDBesieger.rsi
   - type: ClothingSpeedModifier
-    walkModifier: 0.83
-    sprintModifier: 0.83
+    walkModifier: 0.84
+    sprintModifier: 0.84
   - type: ExplosionResistance
     damageCoefficient: 0.2
   - type: StaminaDamageResistance
@@ -54,11 +54,11 @@
   - type: Armor
     modifiers:
       coefficients:
-        Blunt: 0.55
+        Blunt: 0.45
         Slash: 0.55
-        Piercing: 0.55
+        Piercing: 0.45
         Heat: 0.35
         Caustic: 0.6
         Radiation: 0.35
   - type: FireProtection
-    reduction: 0.65
+    reduction: 0.35

--- a/Resources/Prototypes/_Triad/Recipes/Lathes/clothing_modsuit.yml
+++ b/Resources/Prototypes/_Triad/Recipes/Lathes/clothing_modsuit.yml
@@ -8,7 +8,7 @@
     Steel: 3000
     Plastic: 4000
     Plasteel: 3000
-    Plastitanium: 4500
+    Plastitanium: 2500
     Durathread: 5000
     Silver: 1000
     Gold: 1000


### PR DESCRIPTION
## About the PR
<!-- What did you change? -->
<!-- If this is a code change, summarize at high level how your new code works. This makes it easier to review. -->
Buffed specific stats of the HZD Cuirass, (1% less movement penalty, 10% more pierce and blunt resist, fire protection upped to 65%), Stripped 20 plastitanium from the recipe, leaving it at 25 plastitanium (plus other mats) to print
## Why / Balance
<!-- Discuss how this would affect game balance or explain why it was changed. Link any relevant discussions or issues. -->
Evidentally the crowd thought the Besieger was too expensive for what it was, this should hopefully fix that.
## Media
<!-- Attach media if the PR makes ingame changes (clothing, items, features, etc). 
Small fixes/refactors are exempt. Media may be used in SS14 progress reports with credit. -->
No.
## Requirements
<!-- Confirm the following by placing an X in the brackets [X]: -->
- [x] I have read the guidelines and documentation relevant to this PR.
- [x] I have added media to this PR or it does not require an ingame showcase.
- [x] I can confirm this PR contains either no AI-generated content, or AI-generated content that meets our guidelines.
<!-- You should understand that not following the above may get your PR closed at maintainer’s discretion -->
<!-- When using AI, make sure you are already proficient in creating whatever content you are attempting to generate and that you already have experience contributing to SS14. This means using AI to enhance your preexisting workflow, not vibecoding. -->

## How to test
<!-- Describe the way it can be tested -->
Spawn in besieger, verify stat changes!
## Breaking changes
<!-- List any breaking changes, including namespaces, public class/method/field changes, prototype renames; and provide instructions for fixing them. -->

**Changelog**
<!-- Add a Changelog entry to make players aware of new features or changes that could affect gameplay.
Make sure to read the guidelines and take this Changelog template out of the comment block in order for it to show up.
Changelog must have a :cl: symbol, so the bot recognizes the changes and adds them to the game's changelog.
Remove this symbol for non-player facing PRs.-->
:cl:
- tweak: Buffed multiple components of the besieger, including speed, blunt, pierce, and fire resistances, and lowered the plastitanium cost down to 25

