### PR TITLE
Big Hammers Now Send People Flying

### DIFF
--- a/Resources/Prototypes/Entities/Objects/Weapons/Melee/hammers.yml
+++ b/Resources/Prototypes/Entities/Objects/Weapons/Melee/hammers.yml
@@ -12,6 +12,9 @@
       types:
         Blunt: 15 #Triad 20 < 10, low damage cause it would be too heavy to swing
         Structural: 40 #Triad 40 < 10
+  - type: MeleeThrowOnHit # Triad
+    speed: 30
+    distance: 50
   - type: SpeedModifiedOnWield # Mono
     walkModifier: 0.9
     sprintModifier: 0.7

--- a/Resources/Prototypes/Nyanotrasen/Entities/Objects/Weapons/Melee/breaching_hammer.yml
+++ b/Resources/Prototypes/Nyanotrasen/Entities/Objects/Weapons/Melee/breaching_hammer.yml
@@ -29,6 +29,9 @@
       types:
         Blunt: 50
         Structural: 250 # takes about 1 minute to breach a plastitanium wall
+  - type: MeleeThrowOnHit # Triad
+    speed: 30
+    distance: 50
   - type: Tool
     qualities:
       - Prying

--- a/Resources/Prototypes/_Mono/Entities/Objects/Weapons/Melee/shockmaul.yml
+++ b/Resources/Prototypes/_Mono/Entities/Objects/Weapons/Melee/shockmaul.yml
@@ -25,6 +25,9 @@
         Blunt: 50
         Shock: 10
         Structural: 250 
+  - type: MeleeThrowOnHit # Triad
+    speed: 30
+    distance: 50
   - type: Defibrillator # "OH NO...*I* SAY WHEN I SAY WE'RE DONE"
     zapHeal:
        types:


### PR DESCRIPTION
## About the PR
<!-- What did you change? -->
<!-- If this is a code change, summarize at high level how your new code works. This makes it easier to review. -->
Simple YML addition to make the Tintreach, Breaching Hammer and Sledgehammer throw their targets back on hit.

## Why / Balance
<!-- Discuss how this would affect game balance or explain why it was changed. Link any relevant discussions or issues. -->
The big, beefy Hammers underperform badly when compared to other melee options.
They are bigger, are twohanded (no shields), have the same/worse DPS at a slower swingspeed, dont have any reflect chance etc...
A simple buff to its damages would be boring, so i thought the addition of the MeleeThrowOnHit component would make the weapon feel a lot better to use and open up interesting usecases. (it is technically a nerf? since you will need to close the distance again for a follow up hit unless you position with the knockback in mind)
its also very funny to send people flying

## Media
<!-- Attach media if the PR makes ingame changes (clothing, items, features, etc). 
Small fixes/refactors are exempt. Media may be used in SS14 progress reports with credit. -->
https://github.com/user-attachments/assets/7c2a5dee-2e25-44bb-8590-96879b8075fe



## Requirements
<!-- Confirm the following by placing an X in the brackets [X]: -->
- [X] I have read the guidelines and documentation relevant to this PR.
- [X] I have added media to this PR or it does not require an ingame showcase.
- [X] I can confirm this PR contains either no AI-generated content, or AI-generated content that meets our guidelines.
<!-- You should understand that not following the above may get your PR closed at maintainer’s discretion -->
<!-- When using AI, make sure you are already proficient in creating whatever content you are attempting to generate and that you already have experience contributing to SS14. This means using AI to enhance your preexisting workflow, not vibecoding. -->

## How to test
<!-- Describe the way it can be tested -->
Spawn either a Tintreach, the Breaching Hammer or a Sledgehammer
Spawn in an Avali (for no particular reason)
Hit them with the hammer

## Breaking changes
<!-- List any breaking changes, including namespaces, public class/method/field changes, prototype renames; and provide instructions for fixing them. -->

**Changelog**
:cl:
- tweak: The Tintreach, the Breaching Hammer and the Sledgehammer now send people flying when you hit them
