### PR TITLE
Adds the Bureaucracy Loadout to All Jobs

### DIFF
--- a/Resources/Prototypes/_NF/Loadouts/role_loadouts.yml
+++ b/Resources/Prototypes/_NF/Loadouts/role_loadouts.yml
@@ -156,6 +156,7 @@
   - ContractorUtility # Mono
   - ContractorFun
   - ContractorTrinkets
+  - ContractorBureaucracy # Triad
   - NFSpeciesSpecific
   - ContractorFirearm # Mono
   - ContractorMag # Mono

--- a/Resources/Prototypes/_Triad/Loadouts/role_loadouts.yml
+++ b/Resources/Prototypes/_Triad/Loadouts/role_loadouts.yml
@@ -66,6 +66,7 @@
   - ContractorBoxSurvival
   - ContractorWallet
   - ContractorTrinkets
+  - ContractorBureaucracy
   - NFSpeciesSpecific
 
 # These are admin only roles, but they need a rudimentary loadout so that they do not spawn naked if the jobs are spawned by admins

--- a/Resources/Prototypes/_Triad/Loadouts/role_loadouts_tdf.yml
+++ b/Resources/Prototypes/_Triad/Loadouts/role_loadouts_tdf.yml
@@ -19,6 +19,7 @@
   - ContractorEncryptionKey
   - ContractorFun
   - ContractorTrinkets
+  - ContractorBureaucracy
   - NfsdSpeciesSpecific
   - TdfFirearm
   - TdfMag
@@ -47,6 +48,7 @@
   - ContractorEncryptionKey
   - ContractorFun
   - ContractorTrinkets
+  - ContractorBureaucracy
   - NfsdSpeciesSpecific
   - TdfFirearm
   - TdfMag
@@ -75,6 +77,7 @@
   - ContractorEncryptionKey
   - ContractorFun
   - ContractorTrinkets
+  - ContractorBureaucracy
   - NfsdSpeciesSpecific
   - TdfFirearm
   - TdfMag
@@ -103,6 +106,7 @@
   - ContractorEncryptionKey
   - ContractorFun
   - SeniorOfficerTrinkets
+  - ContractorBureaucracy
   - NfsdSpeciesSpecific
   - TdfFirearm
   - TdfMag
@@ -131,6 +135,7 @@
   - ContractorEncryptionKey
   - ContractorFun
   - SeniorOfficerTrinkets
+  - ContractorBureaucracy
   - NfsdSpeciesSpecific
   - TdfFirearm
   - TdfMag
@@ -159,6 +164,7 @@
   - ContractorFun
   - ContractorEncryptionKey
   - SeniorOfficerTrinkets
+  - ContractorBureaucracy
   - NfsdSpeciesSpecific
   - TdfChiefEnforcerFirearm
   - TdfChiefEnforcerMag


### PR DESCRIPTION
## About the PR
This PR adds the Bureaucracy loadout to all jobs, including TDF roles, Sector Technician, and Janitor

## Why / Balance
Every other job has this and it feels like an oversight

## Media
<img width="281" height="270" alt="image" src="https://github.com/user-attachments/assets/fb6a0cd4-19cf-4d30-ab87-e7626878ecd8" />

<img width="972" height="694" alt="image" src="https://github.com/user-attachments/assets/241ffbf3-e45c-4f5c-8e1e-5580ac06c831" />

## Requirements
<!-- Confirm the following by placing an X in the brackets [X]: -->
- [X] I have read the guidelines and documentation relevant to this PR.
- [X] I have added media to this PR or it does not require an ingame showcase.
- [X] I can confirm this PR contains either no AI-generated content, or AI-generated content that meets our guidelines.
<!-- You should understand that not following the above may get your PR closed at maintainer’s discretion -->
<!-- When using AI, make sure you are already proficient in creating whatever content you are attempting to generate and that you already have experience contributing to SS14. This means using AI to enhance your preexisting workflow, not vibecoding. -->

## How to test
1. Look at every jobs loadout. Bureaucracy is in there

**Changelog**
:cl: Minerva
- tweak: Every job now has the Bureaucracy loadout, including TDF roles.
