### PR TITLE
Adds Leather Satchels to Contractor Loadout

### DIFF
--- a/Resources/Prototypes/_NF/Loadouts/contractor_loadout_groups.yml
+++ b/Resources/Prototypes/_NF/Loadouts/contractor_loadout_groups.yml
@@ -241,6 +241,7 @@
   - ContractorClothingBackpackDuffel
   - ContractorClothingBackpackSatchel
   - ContractorClothingBackpackMessenger
+  - ClothingBackpackSatchelLeather # Triad
   - ContractorClothingBackpackCaptain
   - ContractorClothingBackpackDuffelCaptain
   - ContractorClothingBackpackSatchelCaptain


### PR DESCRIPTION
## About the PR
This PR adds leather satchels to the Contractor backpack loadout

## Why / Balance
They're already available free in the ClothesMate (right next to regular satchels, backpacks, and duffel bags), plus this fills the niche of a fancy, non-gaudy satchel that might fit better with a character than anything else

## Media
<img width="189" height="204" alt="image" src="https://github.com/user-attachments/assets/8e99cea9-d523-4264-ac2c-0ccd948256dd" />

<img width="931" height="417" alt="image" src="https://github.com/user-attachments/assets/e2e4b0fa-1ac0-4af5-84a9-215872050873" />


## Requirements
<!-- Confirm the following by placing an X in the brackets [X]: -->
- [X] I have read the guidelines and documentation relevant to this PR.
- [X] I have added media to this PR or it does not require an ingame showcase.
- [X] I can confirm this PR contains either no AI-generated content, or AI-generated content that meets our guidelines.
<!-- You should understand that not following the above may get your PR closed at maintainer’s discretion -->
<!-- When using AI, make sure you are already proficient in creating whatever content you are attempting to generate and that you already have experience contributing to SS14. This means using AI to enhance your preexisting workflow, not vibecoding. -->

## How to test
1. Open a job loadout. There's probably a leather satchel under there

**Changelog**
:cl: Minerva
- tweak: Leather satchels have been added to the general backpack loadout.
