### PR TITLE
Swaps the Pilots Default Jumpsuit for the Military Variant

### DIFF
--- a/Resources/Prototypes/_NF/Loadouts/pilot_loadout_groups.yml
+++ b/Resources/Prototypes/_NF/Loadouts/pilot_loadout_groups.yml
@@ -10,7 +10,7 @@
   subgroups:
   - ContractorJumpsuit
   fallbacks:
-  #- PilotClothingUniformJumpsuitPilot # Triad removal - The military variant looks better.
+  #- PilotClothingUniformJumpsuitPilot # Triad removal - The military variant is higher quality.
   - PilotClothingUniformJumpsuitMilitaryPilot # Triad
   - ContractorClothingUniformJumpskirtColorGrey # Sorry harpies, no pilot skirt for you.
 

--- a/Resources/Prototypes/_NF/Loadouts/pilot_loadout_groups.yml
+++ b/Resources/Prototypes/_NF/Loadouts/pilot_loadout_groups.yml
@@ -10,7 +10,8 @@
   subgroups:
   - ContractorJumpsuit
   fallbacks:
-  - PilotClothingUniformJumpsuitPilot
+  #- PilotClothingUniformJumpsuitPilot # Triad removal - The military variant looks better.
+  - PilotClothingUniformJumpsuitMilitaryPilot # Triad
   - ContractorClothingUniformJumpskirtColorGrey # Sorry harpies, no pilot skirt for you.
 
 - type: loadoutGroup


### PR DESCRIPTION
## About the PR
This PR swaps the fallback jumpsuit for Pilot to the military variant

## Why / Balance
The military variant is just a higher-quality sprite and fits the other default clothings for Pilot better. This is a somewhat experimental PR as I don't really care that much, but it *is* something I always swap because that jumpsuit does not look good to me

<img width="1025" height="544" alt="image" src="https://github.com/user-attachments/assets/8ad13921-3537-4c36-b221-ef6c37f9b037" />

## Media
<!-- Attach media if the PR makes ingame changes (clothing, items, features, etc). 
Small fixes/refactors are exempt. Media may be used in SS14 progress reports with credit. -->

## Requirements
<!-- Confirm the following by placing an X in the brackets [X]: -->
- [X] I have read the guidelines and documentation relevant to this PR.
- [X] I have added media to this PR or it does not require an ingame showcase.
- [X] I can confirm this PR contains either no AI-generated content, or AI-generated content that meets our guidelines.
<!-- You should understand that not following the above may get your PR closed at maintainer’s discretion -->
<!-- When using AI, make sure you are already proficient in creating whatever content you are attempting to generate and that you already have experience contributing to SS14. This means using AI to enhance your preexisting workflow, not vibecoding. -->

## How to test
1. Look at an existing character if you have one. The Pilot jumpsuit is the same
2. Make a new character. The default Pilot jumpsuit will be the military variant. Change it, save, and reopen. It stays the same

**Changelog**
:cl: Minerva
- tweak: The default Pilot jumpsuit has been swapped to the darker military variant. If you haven't explicitly set a jumpsuit on existing characters, it will be changed to the military variant. If you wish to continue using the lighter-colored jumpsuit, just switch back to it in loadout.
