### PR TITLE
Makes ELINT Greebles Less Demanding About Placement

### DIFF
--- a/Resources/Prototypes/_Triad/Recipes/Construction/greebles.yml
+++ b/Resources/Prototypes/_Triad/Recipes/Construction/greebles.yml
@@ -44,10 +44,7 @@
     state: elint1
   objectType: Structure
   placementMode: SnapgridCenter
-  canBuildInImpassable: false
-  conditions:
-  - !type:TileNotBlocked
-    failIfSpace: false
+  canBuildInImpassable: true
   ghostOffset: 0,1
 
 - type: construction


### PR DESCRIPTION
## About the PR
This PR makes ELINT greebles have the same placement stuff as antennas, meaning they can be built anywhere an antenna can

## Why / Balance
I don't really know why I originally made it this way and it's silly. Why can't ELINTs be built on walls?

## Media
<img width="345" height="574" alt="image" src="https://github.com/user-attachments/assets/9463138f-9c4d-4044-9887-8436fedf0338" />

## Requirements
<!-- Confirm the following by placing an X in the brackets [X]: -->
- [X] I have read the guidelines and documentation relevant to this PR.
- [X] I have added media to this PR or it does not require an ingame showcase.
- [X] I can confirm this PR contains either no AI-generated content, or AI-generated content that meets our guidelines.
<!-- You should understand that not following the above may get your PR closed at maintainer’s discretion -->
<!-- When using AI, make sure you are already proficient in creating whatever content you are attempting to generate and that you already have experience contributing to SS14. This means using AI to enhance your preexisting workflow, not vibecoding. -->

## How to test
1. Build an ELINT and the antennas on a wall. They all place the same
2. Do the same, but on lattice. Still all places

**Changelog**
:cl: Minerva
- tweak: Decorative ELINT greebles can now be built everywhere an antenna can be built. Including on walls.