### PR TITLE
Fix/Rpd Placement Parity

### DIFF
--- a/Content.Client/RCD/RCDConstructionGhostSystem.cs
+++ b/Content.Client/RCD/RCDConstructionGhostSystem.cs
@@ -151,6 +151,11 @@ public sealed partial class RCDConstructionGhostSystem : EntitySystem
             _lastHeldRcd = heldEntity;
             _useMirrorPrototype = rcd.UseMirrorPrototype;
             _lastSentLayer = null; // Triad: force a fresh layer send for the newly held tool.
+            // Triad: seed the direction cache from the tool's networked state, not from whatever the previous tool
+            // (or a construction-menu ghost) left in the placement manager. ConstructionDirection is per-tool and
+            // defaults South, so without this a freshly held tool spawned South-facing while the ghost showed the
+            // old direction until the operator rotated once.
+            _placementDirection = rcd.ConstructionDirection;
         }
         // End Triad
 

--- a/Content.IntegrationTests/Tests/RPD/RPDPlacementRulesTest.cs
+++ b/Content.IntegrationTests/Tests/RPD/RPDPlacementRulesTest.cs
@@ -1,0 +1,305 @@
+#nullable enable
+using System.Collections.Generic;
+using System.Linq;
+using System.Numerics;
+using Content.Shared.Atmos;
+using Content.Shared.Atmos.Components;
+using Content.Shared.Construction.Conditions;
+using Content.Shared.Construction.Prototypes;
+using Content.Shared.Coordinates;
+using Content.Shared.Physics;
+using Content.Shared.RCD;
+using Content.Shared.RCD.Components;
+using Content.Shared.RCD.Systems;
+using Content.Shared.RPD;
+using Content.Shared.RPD.Components;
+using Content.Shared.RPD.Systems;
+using Content.Shared.Tag;
+using Content.Shared.Wall;
+using Robust.Shared.GameObjects;
+using Robust.Shared.Map;
+using Robust.Shared.Map.Components;
+using Robust.Shared.Maths;
+using Robust.Shared.Prototypes;
+
+namespace Content.IntegrationTests.Tests.RPD;
+
+/// <summary>
+/// Holds the RPD to the hand-placement contract. Each test is named for the rule it enforces; the rules live on the
+/// wiki page "Pipe Placement Rules" (P1-P17) and the gaps they closed on "RPD Placement Parity Design".
+/// </summary>
+[TestFixture]
+public sealed class RPDPlacementRulesTest
+{
+    private const string RpdProto = "RPD";
+
+    private static IEnumerable<RCDPrototype> RpdRecipes(IPrototypeManager protoMan, IComponentFactory factory)
+    {
+        var rpd = protoMan.Index<EntityPrototype>(RpdProto);
+        Assert.That(rpd.TryComp<RCDComponent>(out var rcd, factory), Is.True, "RPD prototype has no RCD component");
+        foreach (var id in rcd!.AvailablePrototypes)
+            yield return protoMan.Index(id);
+    }
+
+    private static readonly ProtoId<RCDPrototype> StraightRecipe = "PipeStraight";
+
+
+    /// <summary>
+    /// P9 and P10: the construction menu is the canon. Every RPD recipe names its hand twin in constructionRecipe
+    /// and the twin resolves, so RCDSystem can hold the placement to the twin's conditions and canBuildInImpassable.
+    /// A recipe with no twin fails rather than being skipped: without one there is nothing to hold parity against.
+    /// </summary>
+    [Test]
+    public async Task P9_P10_EveryRecipeNamesItsHandTwin()
+    {
+        await using var pair = await PoolManager.GetServerClient();
+        var server = pair.Server;
+        var protoMan = server.ResolveDependency<IPrototypeManager>();
+        var factory = server.ResolveDependency<IComponentFactory>();
+
+        await server.WaitAssertion(() =>
+        {
+            Assert.Multiple(() =>
+            {
+                foreach (var recipe in RpdRecipes(protoMan, factory))
+                {
+                    if (recipe.Mode != RcdMode.ConstructObject)
+                        continue;
+
+                    Assert.That(recipe.ConstructionRecipe, Is.Not.Null, $"{recipe.ID}: no constructionRecipe, nothing to hold parity against");
+                    if (recipe.ConstructionRecipe is not { } twinId)
+                        continue;
+
+                    Assert.That(protoMan.HasIndex(twinId), Is.True, $"{recipe.ID}: constructionRecipe {twinId} does not exist");
+                    Assert.That(recipe.CollisionMask, Is.EqualTo(CollisionGroup.None),
+                        $"{recipe.ID}: the wall rule comes from the twin's canBuildInImpassable, not a hand-written collisionMask");
+                }
+            });
+        });
+
+        await pair.CleanReturnAsync();
+    }
+
+    /// <summary>
+    /// P10: the manifold is Unstackable-tagged (the wrench refuses to stack it) but its menu recipe carries no
+    /// NoUnstackableInTile, and the menu is the canon, so the RPD places a manifold on a tile that holds a vent.
+    /// </summary>
+    [Test]
+    public async Task P10_ManifoldStacksLikeTheMenu()
+    {
+        await using var pair = await PoolManager.GetServerClient();
+        var server = pair.Server;
+        var entMan = server.ResolveDependency<IEntityManager>();
+        var mapSys = entMan.System<SharedMapSystem>();
+        var rcd = entMan.System<RCDSystem>();
+
+        await server.WaitAssertion(() =>
+        {
+            mapSys.CreateMap(out var mapId);
+            var grid = mapSys.CreateGridEntity(mapId);
+            mapSys.SetTile(grid, new Vector2i(0, 0), new Tile(1));
+            var user = entMan.SpawnEntity(null, grid.Owner.ToCoordinates(0, 0));
+
+            // An East-facing Secondary vent: the manifold spans all three layers North-South, so no pipe-node overlap.
+            var vent = entMan.SpawnAttachedTo("GasVentPumpAlt1", grid.Owner.ToCoordinates(0, 0), rotation: Direction.East.ToAngle());
+            Assert.That(entMan.GetComponent<TransformComponent>(vent).Anchored, Is.True, "fixture vent must anchor");
+
+            var rpdTool = entMan.SpawnEntity(RpdProto, grid.Owner.ToCoordinates(0, 0));
+            var rcdComp = entMan.GetComponent<RCDComponent>(rpdTool);
+            Assert.That(rcd.TryGetMapGridData(grid.Owner.ToCoordinates(0, 0), user, out var data), Is.True);
+
+            SelectRecipe(entMan, rpdTool, "ManifoldGas");
+            Assert.That(rcd.IsConstructionLocationValid(rpdTool, rcdComp, data!.Value, user, popMsgs: false),
+                Is.True, "the menu allows a manifold beside a vent, so the RPD must too");
+        });
+
+        await pair.CleanReturnAsync();
+    }
+
+    /// <summary>
+    /// P10: the RPD refuses a second Unstackable device on a tile even when their pipe nodes do not overlap. The
+    /// pump faces East so its Longitudinal-rotated nodes miss the vent's South port; only the tag check can say no.
+    /// </summary>
+    [Test]
+    public async Task P10_RejectsSecondUnstackableOnTile()
+    {
+        await using var pair = await PoolManager.GetServerClient();
+        var server = pair.Server;
+        var entMan = server.ResolveDependency<IEntityManager>();
+        var mapSys = entMan.System<SharedMapSystem>();
+        var rcd = entMan.System<RCDSystem>();
+
+        await server.WaitAssertion(() =>
+        {
+            mapSys.CreateMap(out var mapId);
+            var grid = mapSys.CreateGridEntity(mapId);
+            mapSys.SetTile(grid, new Vector2i(0, 0), new Tile(1));
+            var user = entMan.SpawnEntity(null, grid.Owner.ToCoordinates(0, 0));
+
+            // A South-facing Secondary vent occupies the tile.
+            var vent = entMan.SpawnEntity("GasVentPumpAlt1", grid.Owner.ToCoordinates(0, 0));
+            Assert.That(entMan.GetComponent<TransformComponent>(vent).Anchored, Is.True, "fixture vent must anchor");
+
+            var rpdTool = entMan.SpawnEntity(RpdProto, grid.Owner.ToCoordinates(0, 0));
+            var rcdComp = entMan.GetComponent<RCDComponent>(rpdTool);
+            Assert.That(rcd.TryGetMapGridData(grid.Owner.ToCoordinates(0, 0), user, out var data), Is.True);
+
+            // Select the pressure pump recipe and face it East (Primary layer): no shared direction, different layer.
+            SelectRecipe(entMan, rpdTool, "PressurePump");
+
+            Assert.That(rcd.IsConstructionLocationValid(rpdTool, rcdComp, data!.Value, user, popMsgs: false, tilePlacementDirection: Direction.East),
+                Is.False, "a pump must not stack on a vent even with no pipe-node overlap");
+
+            // Control: the same pump on an empty neighbouring tile is fine.
+            mapSys.SetTile(grid, new Vector2i(1, 0), new Tile(1));
+            Assert.That(rcd.TryGetMapGridData(grid.Owner.ToCoordinates(1, 0), user, out var freeData), Is.True);
+            Assert.That(rcd.IsConstructionLocationValid(rpdTool, rcdComp, freeData!.Value, user, popMsgs: false, tilePlacementDirection: Direction.East),
+                Is.True, "control: the pump must be placeable on a free tile");
+        });
+
+        await pair.CleanReturnAsync();
+    }
+
+    /// <summary>
+    /// P11: the layer that ships is the one captured at commit, not the tool's live cursor layer.
+    /// </summary>
+    [Test]
+    public async Task P11_CommittedLayerSurvivesCursorMove()
+    {
+        await using var pair = await PoolManager.GetServerClient();
+        var server = pair.Server;
+        var entMan = server.ResolveDependency<IEntityManager>();
+        var mapSys = entMan.System<SharedMapSystem>();
+        var protoMan = server.ResolveDependency<IPrototypeManager>();
+        var rpd = entMan.System<RPDSystem>();
+
+        await server.WaitAssertion(() =>
+        {
+            mapSys.CreateMap(out var mapId);
+            var grid = mapSys.CreateGridEntity(mapId);
+            mapSys.SetTile(grid, new Vector2i(0, 0), new Tile(1));
+            var rpdTool = entMan.SpawnEntity(RpdProto, grid.Owner.ToCoordinates(0, 0));
+            var rpdComp = entMan.GetComponent<RPDComponent>(rpdTool);
+            var recipe = protoMan.Index(StraightRecipe);
+
+            // Commit at Secondary.
+            rpd.SetLayer((rpdTool, rpdComp), AtmosPipeLayer.Secondary);
+            var commit = new RCDPlacementCommitEvent();
+            entMan.EventBus.RaiseLocalEvent(rpdTool, ref commit);
+            Assert.That(commit.Layer, Is.EqualTo(AtmosPipeLayer.Secondary));
+
+            // Cursor moves to Tertiary before the do-after completes.
+            rpd.SetLayer((rpdTool, rpdComp), AtmosPipeLayer.Tertiary);
+
+            // The spawn resolves against the committed layer.
+            var spawn = new RCDObjectSpawnAttemptEvent(recipe, recipe.Prototype, commit.Layer);
+            entMan.EventBus.RaiseLocalEvent(rpdTool, ref spawn);
+            Assert.That(spawn.SpawnProto, Is.EqualTo("GasPipeStraightAlt1"), "spawn must use the layer captured at commit");
+        });
+
+        await pair.CleanReturnAsync();
+    }
+
+    /// <summary>
+    /// P6: the RPD's layer pick is the hand placement mode's math. Deadzone is Primary; outside it NE/E is Secondary
+    /// and SW/W is Tertiary, on a screen-relative axis.
+    /// </summary>
+    [Test]
+    public void P6_LayerMathMatchesHandPlacement()
+    {
+        Assert.Multiple(() =>
+        {
+            // Inside the 0.25 tile deadzone, any direction.
+            Assert.That(RPDLayerMath.PickLayer(new Vector2(0.2f, 0f), Angle.Zero, Angle.Zero), Is.EqualTo(AtmosPipeLayer.Primary));
+            Assert.That(RPDLayerMath.PickLayer(new Vector2(-0.1f, -0.2f), Angle.Zero, Angle.Zero), Is.EqualTo(AtmosPipeLayer.Primary));
+
+            // Outside it, unrotated: East and North of centre are Secondary, West and South are Tertiary.
+            Assert.That(RPDLayerMath.PickLayer(new Vector2(0.4f, 0f), Angle.Zero, Angle.Zero), Is.EqualTo(AtmosPipeLayer.Secondary));
+            Assert.That(RPDLayerMath.PickLayer(new Vector2(0f, 0.4f), Angle.Zero, Angle.Zero), Is.EqualTo(AtmosPipeLayer.Secondary));
+            Assert.That(RPDLayerMath.PickLayer(new Vector2(-0.4f, 0f), Angle.Zero, Angle.Zero), Is.EqualTo(AtmosPipeLayer.Tertiary));
+            Assert.That(RPDLayerMath.PickLayer(new Vector2(0f, -0.4f), Angle.Zero, Angle.Zero), Is.EqualTo(AtmosPipeLayer.Tertiary));
+
+            // A half-turn of the eye flips the axis: what was Secondary reads Tertiary.
+            Assert.That(RPDLayerMath.PickLayer(new Vector2(0.4f, 0f), Angle.FromDegrees(180), Angle.Zero), Is.EqualTo(AtmosPipeLayer.Tertiary));
+            // Grid rotation is added the same way as eye rotation.
+            Assert.That(RPDLayerMath.PickLayer(new Vector2(0.4f, 0f), Angle.Zero, Angle.FromDegrees(180)), Is.EqualTo(AtmosPipeLayer.Tertiary));
+        });
+    }
+
+    /// <summary>
+    /// P4: an empty (space) tile cannot be anchored to, and the RPD refuses before spawning rather than dropping a
+    /// loose pipe the way the hand path does.
+    /// </summary>
+    [Test]
+    public async Task P4_RefusesEmptyTile()
+    {
+        await using var pair = await PoolManager.GetServerClient();
+        var server = pair.Server;
+        var entMan = server.ResolveDependency<IEntityManager>();
+        var mapSys = entMan.System<SharedMapSystem>();
+        var rcd = entMan.System<RCDSystem>();
+
+        await server.WaitAssertion(() =>
+        {
+            mapSys.CreateMap(out var mapId);
+            var grid = mapSys.CreateGridEntity(mapId);
+            mapSys.SetTile(grid, new Vector2i(0, 0), new Tile(1));
+            var user = entMan.SpawnEntity(null, grid.Owner.ToCoordinates(0, 0));
+            var rpdTool = entMan.SpawnEntity(RpdProto, grid.Owner.ToCoordinates(0, 0));
+            var rcdComp = entMan.GetComponent<RCDComponent>(rpdTool);
+
+            // (1, 0) is part of the grid's chunk but holds no tile.
+            Assert.That(rcd.TryGetMapGridData(grid.Owner.ToCoordinates(1, 0), user, out var data), Is.True);
+            Assert.That(data!.Value.Tile.Tile.IsEmpty, Is.True, "fixture: the target tile must be empty");
+            Assert.That(rcd.IsConstructionLocationValid(rpdTool, rcdComp, data.Value, user, popMsgs: false), Is.False,
+                "RPD must refuse an empty tile");
+        });
+
+        await pair.CleanReturnAsync();
+    }
+
+    /// <summary>
+    /// P16: a wall-mount on the RPD is held to the menu's WallmountCondition through its twin, so every recipe whose
+    /// entity carries WallMount must name a twin that declares that condition.
+    /// </summary>
+    [Test]
+    public async Task P16_WallMountTwinsCarryWallmountCondition()
+    {
+        await using var pair = await PoolManager.GetServerClient();
+        var server = pair.Server;
+        var protoMan = server.ResolveDependency<IPrototypeManager>();
+        var factory = server.ResolveDependency<IComponentFactory>();
+
+        await server.WaitAssertion(() =>
+        {
+            Assert.Multiple(() =>
+            {
+                foreach (var recipe in RpdRecipes(protoMan, factory))
+                {
+                    if (recipe.Mode != RcdMode.ConstructObject || recipe.Prototype == null)
+                        continue;
+
+                    var proto = protoMan.Index<EntityPrototype>(recipe.Prototype);
+                    if (!proto.TryComp<WallMountComponent>(out _, factory))
+                        continue;
+
+                    Assert.That(recipe.ConstructionRecipe.HasValue && protoMan.TryIndex(recipe.ConstructionRecipe.Value, out var twin)
+                                && twin.Conditions.Any(c => c is WallmountCondition), Is.True,
+                        $"{recipe.ID} spawns a wall-mount ({recipe.Prototype}) and its twin must declare WallmountCondition");
+                }
+            });
+        });
+
+        await pair.CleanReturnAsync();
+    }
+
+    /// <summary>
+    /// RCDComponent is Access-restricted to RCDSystem/RPDSystem, so drive the selection through the BUI message the
+    /// client would send.
+    /// </summary>
+    private static void SelectRecipe(IEntityManager entMan, EntityUid tool, string recipeId)
+    {
+        entMan.EventBus.RaiseLocalEvent(tool, new RCDSystemMessage(recipeId));
+        Assert.That(entMan.GetComponent<RCDComponent>(tool).ProtoId.Id, Is.EqualTo(recipeId), "recipe selection did not take");
+    }
+}

--- a/Content.Server/RPD/RPDConflictSystem.cs
+++ b/Content.Server/RPD/RPDConflictSystem.cs
@@ -13,7 +13,8 @@ namespace Content.Server.RPD;
 /// <summary>
 /// Server-side RPD half: answers <see cref="RCDConstructionAttemptEvent"/> with the layer-aware pipe overlap rule
 /// (<see cref="PipeRestrictOverlapSystem.WouldPlacementOverlap"/>), so a same-(direction, layer) placement is
-/// rejected before spawn. Server-side because the overlap query reads server pipe-node data.
+/// rejected before spawn. Server-side because the overlap query reads server pipe-node data. The layer comes from
+/// the event (captured at commit), not from <c>RPDComponent.CurrentLayer</c>.
 /// </summary>
 public sealed partial class RPDConflictSystem : EntitySystem
 {
@@ -37,12 +38,13 @@ public sealed partial class RPDConflictSystem : EntitySystem
             || !baseProto.TryComp<AtmosPipeLayersComponent>(out var pipeLayers, EntityManager.ComponentFactory))
             return;
 
-        // Resolve the layer-specific prototype (base proto IS the Primary variant).
+        // Resolve the layer-specific prototype (base proto IS the Primary variant). args.Layer is the layer captured
+        // at the commit click, so every re-validation during the do-after judges the same placement the click did.
         var proto = args.Recipe.Prototype!;
-        if (_pipeLayers.TryGetAlternativePrototype(pipeLayers, ent.Comp.CurrentLayer, out var alt))
+        if (_pipeLayers.TryGetAlternativePrototype(pipeLayers, args.Layer, out var alt))
             proto = alt.Id;
 
-        if (_overlap.WouldPlacementOverlap((args.MapGridData.GridUid, args.MapGridData.Component), args.MapGridData.Position, proto, args.Direction.ToAngle(), ent.Comp.CurrentLayer))
+        if (_overlap.WouldPlacementOverlap((args.MapGridData.GridUid, args.MapGridData.Component), args.MapGridData.Position, proto, args.Direction.ToAngle(), args.Layer))
         {
             if (args.ShowPopups)
                 _popup.PopupEntity(Loc.GetString("rcd-component-cannot-build-on-occupied-tile-message"), ent, args.User);

--- a/Content.Shared/RCD/RCDEvents.cs
+++ b/Content.Shared/RCD/RCDEvents.cs
@@ -1,3 +1,4 @@
+using Content.Shared.Atmos.Components; // Triad
 using Content.Shared.RCD.Systems;
 using Robust.Shared.Prototypes;
 using Robust.Shared.Serialization;
@@ -95,12 +96,36 @@ public struct RCDDeconstructAttemptEvent
 public struct RCDObjectSpawnAttemptEvent
 {
     public readonly RCDPrototype Recipe;
+    /// <summary>
+    /// The pipe layer captured when the operator committed the placement (see <see cref="RCDPlacementCommitEvent"/>),
+    /// carried through the do-after so cursor movement after the click cannot change where the pipe lands.
+    /// </summary>
+    public readonly AtmosPipeLayer Layer;
     public string? SpawnProto;
 
-    public RCDObjectSpawnAttemptEvent(RCDPrototype recipe, string? spawnProto)
+    public RCDObjectSpawnAttemptEvent(RCDPrototype recipe, string? spawnProto, AtmosPipeLayer layer)
     {
         Recipe = recipe;
         SpawnProto = spawnProto;
+        Layer = layer;
+    }
+}
+
+/// <summary>
+/// Raised on the tool at the start of a placement click, before validation, so a sibling system can stamp the
+/// per-placement state RCD does not own onto the do-after. The RPD sets <c>Layer</c> from its cursor-aimed layer;
+/// plain RCD has no handler and the default (Primary) is inert for non-layered recipes. Everything downstream
+/// (<see cref="RCDConstructionAttemptEvent"/>, <see cref="RCDObjectSpawnAttemptEvent"/>) reads this captured value,
+/// never the tool's live state.
+/// </summary>
+[ByRefEvent]
+public struct RCDPlacementCommitEvent
+{
+    public AtmosPipeLayer Layer;
+
+    public RCDPlacementCommitEvent()
+    {
+        Layer = AtmosPipeLayer.Primary;
     }
 }
 
@@ -153,15 +178,20 @@ public struct RCDConstructionAttemptEvent
     public readonly MapGridData MapGridData;
     public readonly RCDPrototype Recipe;
     public readonly Direction Direction;
+    /// <summary>
+    /// The pipe layer this placement was committed on (see <see cref="RCDPlacementCommitEvent"/>).
+    /// </summary>
+    public readonly AtmosPipeLayer Layer;
     public readonly EntityUid User;
     public readonly bool ShowPopups;
     public bool Cancelled;
 
-    public RCDConstructionAttemptEvent(MapGridData mapGridData, RCDPrototype recipe, Direction direction, EntityUid user, bool showPopups)
+    public RCDConstructionAttemptEvent(MapGridData mapGridData, RCDPrototype recipe, Direction direction, AtmosPipeLayer layer, EntityUid user, bool showPopups)
     {
         MapGridData = mapGridData;
         Recipe = recipe;
         Direction = direction;
+        Layer = layer;
         User = user;
         ShowPopups = showPopups;
         Cancelled = false;

--- a/Content.Shared/RCD/RCDPrototype.cs
+++ b/Content.Shared/RCD/RCDPrototype.cs
@@ -1,3 +1,4 @@
+using Content.Shared.Construction.Prototypes; // Triad
 using Content.Shared.Physics;
 using Robust.Shared.Maths;
 using Robust.Shared.Physics.Collision.Shapes;
@@ -75,6 +76,15 @@ public sealed partial class RCDPrototype : IPrototype
     /// </summary>
     [DataField, ViewVariables(VVAccess.ReadOnly)]
     public bool NoLayers { get; private set; }
+
+    /// <summary>
+    /// The construction-menu recipe this RCD recipe is a shortcut for. When set, placement is held to that recipe's
+    /// own rules: its <c>conditions</c> run against the target tile, and <c>canBuildInImpassable: false</c> adds the
+    /// <c>Impassable</c> collision mask. The construction menu is the canon for what may be placed where; this field
+    /// keeps the RCD from drifting from it.
+    /// </summary>
+    [DataField, ViewVariables(VVAccess.ReadOnly)]
+    public ProtoId<ConstructionPrototype>? ConstructionRecipe { get; private set; }
     // End Triad
 
     /// <summary>

--- a/Content.Shared/RCD/Systems/RCDSystem.cs
+++ b/Content.Shared/RCD/Systems/RCDSystem.cs
@@ -4,6 +4,7 @@ using Content.Shared.Atmos.Components; // Triad
 using Content.Shared.Charges.Components;
 using Content.Shared.Charges.Systems;
 using Content.Shared.Construction;
+using Content.Shared.Construction.Prototypes; // Triad
 using Content.Shared.Database;
 using Content.Shared.DoAfter;
 using Content.Shared.Examine;
@@ -202,8 +203,15 @@ public partial class RCDSystem : EntitySystem
         }
         // End Triad
 
+        // Triad: capture per-placement state a sibling system owns (the RPD's cursor-aimed pipe layer) once, here,
+        // and carry it through the do-after. Reading it live at completion let cursor movement after the click move
+        // the pipe onto another layer.
+        var commit = new RCDPlacementCommitEvent();
+        RaiseLocalEvent(uid, ref commit);
+        // End Triad
+
         if (!IsRCDOperationStillValid(uid, component, mapGridData.Value, target, args.User,
-                tilePlacementDirection: component.ConstructionDirection))
+                tilePlacementDirection: component.ConstructionDirection, layer: commit.Layer))
             return;
 
         if (!_net.IsServer)
@@ -277,7 +285,8 @@ public partial class RCDSystem : EntitySystem
             component.ConstructionDirection,
             component.ProtoId,
             cost,
-            EntityManager.GetNetEntity(effect));
+            EntityManager.GetNetEntity(effect),
+            commit.Layer); // Triad
 
         var doAfterArgs = new DoAfterArgs(EntityManager, user, delay*component.DelayMultiplier, ev, uid, target: target, used: uid) // Mono - add delay multiplier.
         {
@@ -322,7 +331,7 @@ public partial class RCDSystem : EntitySystem
         var mapGridData = new MapGridData(gridUid, mapGrid, location, tile, position);
 
         if (!IsRCDOperationStillValid(uid, component, mapGridData, args.Event.Target, args.Event.User,
-                tilePlacementDirection: args.Event.Direction))
+                tilePlacementDirection: args.Event.Direction, layer: args.Event.Layer)) // Triad: captured layer
             args.Cancel();
     }
 
@@ -348,11 +357,11 @@ public partial class RCDSystem : EntitySystem
 
         // Ensure the RCD operation is still valid
         if (!IsRCDOperationStillValid(uid, component, mapGridData, args.Target, args.User,
-                tilePlacementDirection: args.Direction))
+                tilePlacementDirection: args.Direction, layer: args.Layer)) // Triad: captured layer
             return;
 
         // Finalize the operation
-        FinalizeRCDOperation(uid, component, mapGridData, args.Direction, args.Target, args.User);
+        FinalizeRCDOperation(uid, component, mapGridData, args.Direction, args.Target, args.User, args.Layer); // Triad: captured layer
 
         // Play audio and consume charges
         _audio.PlayPredicted(component.SuccessSound, uid, args.User);
@@ -384,7 +393,7 @@ public partial class RCDSystem : EntitySystem
     #region Entity construction/deconstruction rule checks
 
     public bool IsRCDOperationStillValid(EntityUid uid, RCDComponent component, MapGridData mapGridData, EntityUid? target, EntityUid user, bool popMsgs = true,
-        Direction? tilePlacementDirection = null)
+        Direction? tilePlacementDirection = null, AtmosPipeLayer layer = AtmosPipeLayer.Primary) // Triad: layer
     {
         var prototype = _protoManager.Index(component.ProtoId);
         var tileDir = tilePlacementDirection ?? component.ConstructionDirection;
@@ -421,7 +430,7 @@ public partial class RCDSystem : EntitySystem
         switch (prototype.Mode)
         {
             case RcdMode.ConstructTile: return IsConstructionLocationValid(uid, component, mapGridData, user, popMsgs, tileDir);
-            case RcdMode.ConstructObject: return IsConstructionLocationValid(uid, component, mapGridData, user, popMsgs);
+            case RcdMode.ConstructObject: return IsConstructionLocationValid(uid, component, mapGridData, user, popMsgs, layer: layer); // Triad: layer
             case RcdMode.Deconstruct: return IsDeconstructionStillValid(uid, component, mapGridData, target, user, popMsgs);
         }
 
@@ -429,7 +438,7 @@ public partial class RCDSystem : EntitySystem
     }
 
     public bool IsConstructionLocationValid(EntityUid uid, RCDComponent component, MapGridData mapGridData, EntityUid user, bool popMsgs = true,
-        Direction? tilePlacementDirection = null)
+        Direction? tilePlacementDirection = null, AtmosPipeLayer layer = AtmosPipeLayer.Primary) // Triad: layer
     {
         var prototype = _protoManager.Index(component.ProtoId);
 
@@ -505,6 +514,19 @@ public partial class RCDSystem : EntitySystem
             && prototype.Prototype != null
             && _protoManager.TryIndex<EntityPrototype>(prototype.Prototype, out var baseProto)
             && baseProto.TryComp<AtmosPipeLayersComponent>(out _, EntityManager.ComponentFactory);
+
+        // Triad: the construction menu is the canon for what may be placed where. A recipe that names its hand twin
+        // inherits the twin's wall rule here (canBuildInImpassable: false means the Impassable mask) and runs the
+        // twin's conditions below (NoUnstackableInTile, WallmountCondition, ...), so the RCD cannot drift from the
+        // menu. Nothing in the mask loop sees stacked atmos devices on its own: their fixtures carry no collision
+        // layer, and the identity guard is bypassed for layer-capable recipes.
+        ConstructionPrototype? twin = null;
+        if (prototype.ConstructionRecipe is { } twinId && !_protoManager.TryIndex(twinId, out twin))
+            Log.Error($"RCD recipe {prototype.ID} names construction recipe {twinId}, which does not exist.");
+
+        var collisionMask = prototype.CollisionMask;
+        if (twin is { CanBuildInImpassable: false })
+            collisionMask |= CollisionGroup.Impassable;
         // End Triad
 
         foreach (var ent in _intersectingEntities)
@@ -541,12 +563,12 @@ public partial class RCDSystem : EntitySystem
                 return false;
             }
 
-            if (prototype.CollisionMask != CollisionGroup.None && TryComp<FixturesComponent>(ent, out var fixtures))
+            if (collisionMask != CollisionGroup.None && TryComp<FixturesComponent>(ent, out var fixtures)) // Triad: twin-derived mask
             {
                 foreach (var fixture in fixtures.Fixtures.Values)
                 {
                     // Continue if no collision is possible
-                    if (!fixture.Hard || fixture.CollisionLayer <= 0 || (fixture.CollisionLayer & (int)prototype.CollisionMask) == 0)
+                    if (!fixture.Hard || fixture.CollisionLayer <= 0 || (fixture.CollisionLayer & (int)collisionMask) == 0) // Triad: twin-derived mask
                         continue;
 
                     // Continue if our custom collision bounds are not intersected
@@ -563,9 +585,25 @@ public partial class RCDSystem : EntitySystem
             }
         }
 
+        // Triad: the hand twin's own placement conditions, evaluated exactly as the construction menu evaluates them.
+        if (twin != null)
+        {
+            var dir = tilePlacementDirection ?? component.ConstructionDirection;
+            foreach (var condition in twin.Conditions)
+            {
+                if (condition.Condition(user, mapGridData.Location, dir))
+                    continue;
+
+                if (popMsgs && condition.GenerateGuideEntry()?.Localization is { } message)
+                    _popup.PopupClient(Loc.GetString(message), uid, user);
+
+                return false;
+            }
+        }
+
         // Triad: let a sibling system (RPD) apply layer-aware conflict rules RCD does not own. Plain RCD has no
         // handler, so this is a no-op for non-RPD tools.
-        var constructAttempt = new RCDConstructionAttemptEvent(mapGridData, prototype, tilePlacementDirection ?? component.ConstructionDirection, user, popMsgs);
+        var constructAttempt = new RCDConstructionAttemptEvent(mapGridData, prototype, tilePlacementDirection ?? component.ConstructionDirection, layer, user, popMsgs);
         RaiseLocalEvent(uid, ref constructAttempt);
         if (constructAttempt.Cancelled)
             return false;
@@ -640,7 +678,7 @@ public partial class RCDSystem : EntitySystem
 
     #region Entity construction/deconstruction
 
-    private void FinalizeRCDOperation(EntityUid uid, RCDComponent component, MapGridData mapGridData, Direction direction, EntityUid? target, EntityUid user)
+    private void FinalizeRCDOperation(EntityUid uid, RCDComponent component, MapGridData mapGridData, Direction direction, EntityUid? target, EntityUid user, AtmosPipeLayer layer) // Triad: layer
     {
         if (!_net.IsServer)
             return;
@@ -671,7 +709,7 @@ public partial class RCDSystem : EntitySystem
                     ? mirror.Id
                     : prototype.Prototype;
 
-                var spawnAttempt = new RCDObjectSpawnAttemptEvent(prototype, spawnProto);
+                var spawnAttempt = new RCDObjectSpawnAttemptEvent(prototype, spawnProto, layer);
                 RaiseLocalEvent(uid, ref spawnAttempt);
                 spawnProto = spawnAttempt.SpawnProto;
 
@@ -846,6 +884,10 @@ public sealed partial class RCDDoAfterEvent : DoAfterEvent
     [DataField("fx")]
     public NetEntity? Effect { get; private set; } = null;
 
+    // Triad: the pipe layer the placement was committed on, captured at the click like Location and Direction.
+    [DataField]
+    public AtmosPipeLayer Layer { get; private set; } = AtmosPipeLayer.Primary;
+
     private RCDDoAfterEvent() { }
 
     public RCDDoAfterEvent(
@@ -854,7 +896,8 @@ public sealed partial class RCDDoAfterEvent : DoAfterEvent
         Direction direction,
         ProtoId<RCDPrototype> startingProtoId,
         int cost,
-        NetEntity? effect = null)
+        NetEntity? effect = null,
+        AtmosPipeLayer layer = AtmosPipeLayer.Primary) // Triad
     {
         Location = location;
         TargetGridId = targetGridId;
@@ -862,6 +905,7 @@ public sealed partial class RCDDoAfterEvent : DoAfterEvent
         StartingProtoId = startingProtoId;
         Cost = cost;
         Effect = effect;
+        Layer = layer; // Triad
     }
 
     public override DoAfterEvent Clone() => this;

--- a/Content.Shared/RPD/Components/RPDComponent.cs
+++ b/Content.Shared/RPD/Components/RPDComponent.cs
@@ -23,9 +23,9 @@ public sealed partial class RPDComponent : Component
     public string PipeColor { get; set; } = RPDPalette.DefaultKey;
 
     /// <summary>
-    /// Pipe layer chosen at the last <see cref="Robust.Shared.GameObjects.AfterInteractEvent"/>. Per-entity so
-    /// concurrent users with their own RPDs don't trample each other's selection between click and do-after
-    /// completion. Server-only state.
+    /// The operator's cursor-aimed pipe layer, streamed by the client on change. Read at the commit click (stamped
+    /// onto the do-after via <c>RCDPlacementCommitEvent</c>) and for deconstruct targeting; a placement in flight
+    /// never reads it again, so moving the cursor during the do-after cannot move the pipe. Server-only state.
     /// </summary>
     [ViewVariables(VVAccess.ReadOnly)]
     public AtmosPipeLayer CurrentLayer { get; set; } = AtmosPipeLayer.Primary;

--- a/Content.Shared/RPD/Systems/RPDSystem.cs
+++ b/Content.Shared/RPD/Systems/RPDSystem.cs
@@ -32,6 +32,7 @@ public sealed partial class RPDSystem : EntitySystem
         base.Initialize();
 
         SubscribeLocalEvent<RPDComponent, RCDDeconstructAttemptEvent>(OnDeconstructAttempt);
+        SubscribeLocalEvent<RPDComponent, RCDPlacementCommitEvent>(OnPlacementCommit);
         SubscribeLocalEvent<RPDComponent, RCDObjectSpawnAttemptEvent>(OnObjectSpawnAttempt);
         SubscribeLocalEvent<RPDComponent, RCDDeconstructTargetResolveEvent>(OnDeconstructTargetResolve);
         SubscribeLocalEvent<RPDComponent, RPDColorChangeMessage>(OnColorChange);
@@ -69,8 +70,19 @@ public sealed partial class RPDSystem : EntitySystem
     }
 
     /// <summary>
+    /// Stamps the cursor-aimed layer onto the placement at the commit click. From here on the RCD pipeline carries
+    /// it in the do-after; <see cref="RPDComponent.CurrentLayer"/> keeps streaming for the next click and for
+    /// deconstruct targeting, but this placement no longer reads it.
+    /// </summary>
+    private void OnPlacementCommit(Entity<RPDComponent> ent, ref RCDPlacementCommitEvent args)
+    {
+        args.Layer = ent.Comp.CurrentLayer;
+    }
+
+    /// <summary>
     /// Rewrites the spawn prototype to the AtmosPipeLayer alternative when the recipe is layer-capable and the
-    /// target entity defines pipe-layer variants. Falls through to the original prototype otherwise.
+    /// target entity defines pipe-layer variants. Falls through to the original prototype otherwise. Reads the
+    /// layer captured at commit (<see cref="RCDObjectSpawnAttemptEvent.Layer"/>), never the live cursor state.
     /// </summary>
     private void OnObjectSpawnAttempt(Entity<RPDComponent> ent, ref RCDObjectSpawnAttemptEvent args)
     {
@@ -83,7 +95,7 @@ public sealed partial class RPDSystem : EntitySystem
         if (!entityProto.TryComp<AtmosPipeLayersComponent>(out var atmosPipeLayers, EntityManager.ComponentFactory))
             return;
 
-        if (_pipeLayers.TryGetAlternativePrototype(atmosPipeLayers, ent.Comp.CurrentLayer, out var layerProto))
+        if (_pipeLayers.TryGetAlternativePrototype(atmosPipeLayers, args.Layer, out var layerProto))
             args.SpawnProto = layerProto.Id;
     }
 

--- a/Resources/Prototypes/_Triad/RPD/rpd.yml
+++ b/Resources/Prototypes/_Triad/RPD/rpd.yml
@@ -5,6 +5,10 @@
 # Fractional cost (cost: 0.5) was rounded to 1 because RCDPrototype.Cost is int upstream; RPD maxCharges
 # was halved to 45 to preserve effective build count (90 pipe segments per charge after halving).
 # HeatPump and GasTemperatureGate omitted because their prototypes aren't in this fork yet.
+#
+# The construction menu is the canon for placement rules. Every recipe names its hand twin in constructionRecipe and
+# RCDSystem holds the placement to that twin's conditions and canBuildInImpassable (which is why no recipe here
+# carries a collisionMask). If the menu lets you place it, the RPD lets you place it; nothing more, nothing less.
 
 - type: rcd
   id: PipeFourway
@@ -14,6 +18,7 @@
     state: pipeFourway
   mode: ConstructObject
   prototype: GasPipeFourway
+  constructionRecipe: GasPipeFourway
   cost: 1
   delay: 0
   rotation: User
@@ -27,6 +32,7 @@
     state: pipeStraight
   mode: ConstructObject
   prototype: GasPipeStraight
+  constructionRecipe: GasPipeStraight
   cost: 1
   delay: 0
   rotation: User
@@ -40,6 +46,7 @@
     state: pipeBend
   mode: ConstructObject
   prototype: GasPipeBend
+  constructionRecipe: GasPipeBend
   cost: 1
   delay: 0
   rotation: User
@@ -53,9 +60,9 @@
     state: pipeTJunction
   mode: ConstructObject
   prototype: GasPipeTJunction
+  constructionRecipe: GasPipeTJunction
   cost: 1
   delay: 0
-  collisionMask: Impassable
   rotation: User
   fx: EffectRCDConstruct0
 
@@ -67,9 +74,9 @@
     state: pipeHalf
   mode: ConstructObject
   prototype: GasPipeHalf
+  constructionRecipe: GasPipeHalf
   cost: 1
   delay: 0
-  collisionMask: Impassable
   rotation: User
   fx: EffectRCDConstruct0
 
@@ -82,9 +89,9 @@
     state: pipeManifold
   mode: ConstructObject
   prototype: GasPipeManifold
+  constructionRecipe: GasPipeManifold
   cost: 1
   delay: 0
-  collisionMask: Impassable
   rotation: User
   fx: EffectRCDConstruct0
   noLayers: true
@@ -97,9 +104,9 @@
     state: pumpPressure
   mode: ConstructObject
   prototype: GasPressurePump
+  constructionRecipe: GasPressurePump
   cost: 1
   delay: 0
-  collisionMask: Impassable
   rotation: User
   fx: EffectRCDConstruct0
 
@@ -111,9 +118,9 @@
     state: pumpVolume
   mode: ConstructObject
   prototype: GasVolumePump
+  constructionRecipe: GasVolumePump
   cost: 1
   delay: 0
-  collisionMask: Impassable
   rotation: User
   fx: EffectRCDConstruct0
 
@@ -125,9 +132,9 @@
     state: pumpManualValve
   mode: ConstructObject
   prototype: GasValve
+  constructionRecipe: GasValve
   cost: 1
   delay: 0
-  collisionMask: Impassable
   rotation: User
   fx: EffectRCDConstruct0
 
@@ -139,9 +146,9 @@
     state: pumpSignalValve
   mode: ConstructObject
   prototype: SignalControlledValve
+  constructionRecipe: SignalControlledValve
   cost: 1
   delay: 0
-  collisionMask: Impassable
   rotation: User
   fx: EffectRCDConstruct0
 
@@ -153,9 +160,9 @@
     state: "off"
   mode: ConstructObject
   prototype: PressureControlledValve
+  constructionRecipe: PressureControlledValve
   cost: 1
   delay: 0
-  collisionMask: Impassable
   rotation: User
   fx: EffectRCDConstruct0
 
@@ -167,9 +174,9 @@
     state: pumpPressureRegulator
   mode: ConstructObject
   prototype: GasPressureRegulator
+  constructionRecipe: GasPressureRegulator
   cost: 1
   delay: 0
-  collisionMask: Impassable
   rotation: User
   fx: EffectRCDConstruct0
 
@@ -181,9 +188,9 @@
     state: injector
   mode: ConstructObject
   prototype: GasOutletInjector
+  constructionRecipe: GasOutletInjector
   cost: 1
   delay: 0
-  collisionMask: Impassable
   rotation: User
   fx: EffectRCDConstruct0
 
@@ -195,9 +202,9 @@
     state: scrub_off
   mode: ConstructObject
   prototype: GasVentScrubber
+  constructionRecipe: GasVentScrubber
   cost: 1
   delay: 0
-  collisionMask: Impassable
   rotation: User
   fx: EffectRCDConstruct0
 
@@ -209,9 +216,9 @@
     state: vent_off
   mode: ConstructObject
   prototype: GasVentPump
+  constructionRecipe: GasVentPump
   cost: 1
   delay: 0
-  collisionMask: Impassable
   rotation: User
   fx: EffectRCDConstruct0
 
@@ -223,9 +230,9 @@
     state: vent_off
   mode: ConstructObject
   prototype: GasDualPortVentPump
+  constructionRecipe: GasDualPortVentPump
   cost: 1
   delay: 0
-  collisionMask: Impassable
   rotation: User
   fx: EffectRCDConstruct0
 
@@ -237,9 +244,9 @@
     state: vent_passive
   mode: ConstructObject
   prototype: GasPassiveVent
+  constructionRecipe: GasPassiveVent
   cost: 1
   delay: 0
-  collisionMask: Impassable
   rotation: User
   fx: EffectRCDConstruct0
 
@@ -251,9 +258,9 @@
     state: heStraight
   mode: ConstructObject
   prototype: HeatExchanger
+  constructionRecipe: HeatExchanger
   cost: 1
   delay: 0
-  collisionMask: Impassable
   rotation: User
   fx: EffectRCDConstruct0
   # Radiators are numberOfPipeLayers: 1 by design (they exchange with the environment, not a layer),
@@ -268,9 +275,9 @@
     state: heBend
   mode: ConstructObject
   prototype: HeatExchangerBend
+  constructionRecipe: HeatExchangerBend
   cost: 1
   delay: 0
-  collisionMask: Impassable
   rotation: User
   fx: EffectRCDConstruct0
   noLayers: true # single-layer by design, same as Radiator above
@@ -283,10 +290,10 @@
     state: gasMixer
   mode: ConstructObject
   prototype: GasMixer
+  constructionRecipe: GasMixer
   mirrorPrototype: GasMixerFlipped
   cost: 1
   delay: 0
-  collisionMask: Impassable
   rotation: User
   fx: EffectRCDConstruct0
 
@@ -298,10 +305,10 @@
     state: gasFilterF
   mode: ConstructObject
   prototype: GasFilter
+  constructionRecipe: GasFilter
   mirrorPrototype: GasFilterFlipped
   cost: 1
   delay: 0
-  collisionMask: Impassable
   rotation: User
   fx: EffectRCDConstruct0
 
@@ -313,9 +320,9 @@
     state: gasCanisterPort
   mode: ConstructObject
   prototype: GasPort
+  constructionRecipe: GasPort
   cost: 1
   delay: 0
-  collisionMask: Impassable
   rotation: User
   fx: EffectRCDConstruct0
 
@@ -327,6 +334,7 @@
     state: alarm0
   mode: ConstructObject
   prototype: AirAlarm
+  constructionRecipe: AirAlarmFixture
   cost: 2
   delay: 1
   rotation: User
@@ -341,9 +349,9 @@
     state: gsensor1
   mode: ConstructObject
   prototype: AirSensor
+  constructionRecipe: AirSensor
   cost: 1
   delay: 0
-  collisionMask: Impassable
   rotation: User
   fx: EffectRCDConstruct0
   noLayers: true
@@ -356,8 +364,8 @@
     state: base
   mode: ConstructObject
   prototype: GasPipeSensor
+  constructionRecipe: GasPipeSensor
   cost: 1
   delay: 0
-  collisionMask: Impassable
   rotation: User
   fx: EffectRCDConstruct0


### PR DESCRIPTION
## About the PR
Holds RPD placement to the construction menu's rules. Every `rcd` recipe now names its menu twin (`constructionRecipe`) and `RCDSystem` runs that recipe's own conditions and wall rule, so if the menu lets you place it the RPD lets you place it, and nothing more. Also fixes two client/commit bugs: a freshly held RPD spawned South-facing until you rotated once, and the pipe layer was read live at spawn instead of at the click.

## Why / Balance
The RPD could stack a pump on a vent, put an air alarm in open floor facing any way, and refused T-junctions, half pipes and manifolds under walls that the menu allows. With the twin mechanism the RPD can't drift from the menu again; the four menu recipes upstream forgot `NoUnstackableInTile` on (dual-port vent, both radiators, manifold) stack by RPD too, and a fix on the menu side fixes both paths.

The rule set the tests are named for is on the wiki: Pipe Placement Rules, and the design page RPD Placement Parity Design.

## Media
No visual changes.

## Requirements
- [x] I have read the guidelines and documentation relevant to this PR.
- [ ] I have added media to this PR or it does not require an ingame showcase.
- [x] I can confirm this PR contains either no AI-generated content, or AI-generated content that meets our guidelines.

## How to test
- Open the crafting menu, place a ghost, rotate it, then swap to a fresh RPD and place a pipe without pressing R: it faces the way the ghost shows.
- Select Alarm, click, and drag the cursor across the tile during the one-second delay: the alarm lands where you clicked. It refuses open floor and takes a wall behind you.
- Place a vent, then try a pump on the same tile facing another way: refused. A manifold on that tile: allowed (same as the menu).
- T-junction, half pipe and manifold go under a wall.
- `dotnet test Content.IntegrationTests --filter FullyQualifiedName~Tests.RPD` (17 tests).

## Breaking changes
`RCDConstructionAttemptEvent` and `RCDObjectSpawnAttemptEvent` (Triad events) gained a `Layer` constructor parameter. `RCDPrototype.CollisionMask` still works for plain RCD recipes; RPD recipes derive it from the twin instead.

:cl:
- fix: The RPD now follows the same placement rules as the construction menu: no more stacking devices on one tile, air alarms need a wall, and T-junctions, half pipes and manifolds fit under walls.
- fix: A freshly picked-up RPD places pipes facing the way its ghost shows.
- fix: Moving the cursor during an RPD placement no longer changes which layer the pipe lands on.
