### PR TITLE
Fixes Melee Self Executions

### DIFF
--- a/Content.Shared/Execution/SharedExecutionSystem.cs
+++ b/Content.Shared/Execution/SharedExecutionSystem.cs
@@ -98,6 +98,11 @@ public sealed partial class SharedExecutionSystem : EntitySystem
 
     public bool CanBeExecuted(EntityUid victim, EntityUid attacker)
     {
+        // Triad - No self-executions.
+        if (victim == attacker)
+            return false;
+        // End Triad
+
         // No point executing someone if they can't take damage
         if (!HasComp<DamageableComponent>(victim))
             return false;


### PR DESCRIPTION
## About the PR
This PR fixes melee self-executions. Previously, only gun self-executions were fixed

Check called early in the code because it's useless to check anything after. Lightest thing to test for as well

## Media
<img width="583" height="533" alt="image" src="https://github.com/user-attachments/assets/4e16412f-dc11-4b20-8648-586f63aa5ea3" />

<img width="766" height="545" alt="image" src="https://github.com/user-attachments/assets/fa508233-9c12-41d7-9e7c-f475d4861382" />

## Requirements
<!-- Confirm the following by placing an X in the brackets [X]: -->
- [X] I have read [Attributing Your Changes](https://github.com/Triad-Sector/Triad_Sector/wiki/Attributing-Your-Changes) and the documentation relevant to this PR.
- [X] I have added media to this PR or it does not require an ingame showcase.
- [X] I can confirm this PR contains either no AI-generated content, or AI-generated content that meets our guidelines.
<!-- You should understand that not following the above may get your PR closed at maintainer’s discretion -->
<!-- When using AI, make sure you are already proficient in creating whatever content you are attempting to generate and that you already have experience contributing to SS14. This means using AI to enhance your preexisting workflow, not vibecoding. -->

## How to test
1. Spawn in a Urist
2. Handcuff it
3. Grab any knife. "combat knife" works fine.
4. Right click on the Urist. Execute is an option
5. Right-click yourself. Execute is not an option
6. Grab a gun and try. It will also not allow self-executions

Omit changelog if desired. Unnecessary as this should be assumed behavior
**Changelog**
:cl: Minerva
- fix: Melee self-executions are no longer possible.