### PR TITLE
Tweaks Generic Wall Descriptions

### DIFF
--- a/Resources/Prototypes/Entities/Structures/Doors/SecretDoor/secret_door.yml
+++ b/Resources/Prototypes/Entities/Structures/Doors/SecretDoor/secret_door.yml
@@ -4,7 +4,7 @@
   name: solid wall # No meta
   suffix: secret door
   abstract: true
-  description: Keeps the air in and the greytide out.
+  description: Keeps the air in and space out. # Triad
   components:
   - type: Sprite
     sprite: Structures/Doors/secret_door.rsi

--- a/Resources/Prototypes/Entities/Structures/Walls/walls.yml
+++ b/Resources/Prototypes/Entities/Structures/Walls/walls.yml
@@ -308,7 +308,6 @@
   parent: BaseWall
   id: WallPlastitaniumIndestructible
   name: plastitanium wall
-  description: Skub knows this wall is too hard to destroy. # Frontier
   suffix: indestructible
   components:
   - type: Tag
@@ -346,7 +345,6 @@
   parent: [ WallPlastitaniumIndestructible, BaseWallTierThree ]
   id: WallPlastitanium
   name: plastitanium wall
-  description: Keeps the air in and the chimera out. # Frontier: restore base value
   suffix: ""
   components:
   - type: Construction # Mono
@@ -361,7 +359,6 @@
   parent: [ WallPlastitaniumDiagonalIndestructible, BaseWallTierTwo ] # Mono
   id: WallPlastitaniumDiagonal
   name: plastitanium wall
-  description: Keeps the air in and the chimera out. #Mono
   suffix: diagonal
   placement:
     mode: SnapgridCenter
@@ -380,7 +377,6 @@
   id: WallPlastitaniumDiagonalIndestructible
   name: plastitanium wall
   suffix: diagonal, indestructible
-  description: Skub knows this wall is too hard to destroy. # Frontier
   placement:
     mode: SnapgridCenter
     snap:
@@ -624,7 +620,6 @@
   name: shuttle wall
   parent: BaseWallTierOne
   suffix: Diagonal
-  description: Keeps the air in and the greytide out.
   placement:
     mode: SnapgridCenter
     snap:
@@ -969,7 +964,7 @@
   parent: BaseWallTierOne
   id: WallWeb
   name: web wall
-  description: Keeps the spiders in and the chimera out.
+  description: Keeps the spiders in and the greytide out.
   components:
   - type: Clickable
   - type: MeleeSound

--- a/Resources/Prototypes/Entities/Structures/Walls/walls.yml
+++ b/Resources/Prototypes/Entities/Structures/Walls/walls.yml
@@ -308,6 +308,7 @@
   parent: BaseWall
   id: WallPlastitaniumIndestructible
   name: plastitanium wall
+  description: Far too tough to destroy. # Triad
   suffix: indestructible
   components:
   - type: Tag
@@ -376,6 +377,7 @@
 - type: entity
   id: WallPlastitaniumDiagonalIndestructible
   name: plastitanium wall
+  description: Far too tough to destroy. # Triad
   suffix: diagonal, indestructible
   placement:
     mode: SnapgridCenter

--- a/Resources/Prototypes/Entities/Structures/Walls/walls.yml
+++ b/Resources/Prototypes/Entities/Structures/Walls/walls.yml
@@ -3,7 +3,7 @@
   parent: BaseStructure
   id: BaseWall
   name: basewall
-  description: Keeps the air in and the greytide out.
+  description: Keeps the air in and space out. # Triad
   placement:
     mode: SnapgridCenter
     snap:
@@ -964,7 +964,7 @@
   parent: BaseWallTierOne
   id: WallWeb
   name: web wall
-  description: Keeps the spiders in and the greytide out.
+  description: Keeps the spiders in and space out. # Triad
   components:
   - type: Clickable
   - type: MeleeSound

--- a/Resources/Prototypes/Entities/Structures/Windows/plastitanium.yml
+++ b/Resources/Prototypes/Entities/Structures/Windows/plastitanium.yml
@@ -80,9 +80,7 @@
   name: plastitanium window
   parent: PlastitaniumWindowSquareBase
   suffix: indestructible
-  # Frontier: colored indestructible windows
-  description: Skub knows this window is too hard to destroy.
-  # End Frontier
+  description: Far too tough to destroy. # Triad
 
 - type: entity
   id: PlastitaniumWindow
@@ -182,9 +180,7 @@
   name: plastitanium window
   parent: PlastitaniumWindowDiagonalBase
   suffix: diagonal, indestructible
-  # Frontier: colored indestructible windows
-  description: Skub knows this window is too hard to destroy.
-  # End Frontier
+  description: Far too tough to destroy. # Triad
 
 - type: entity
   id: PlastitaniumWindowDiagonal

--- a/Resources/Prototypes/Recipes/Construction/structures.yml
+++ b/Resources/Prototypes/Recipes/Construction/structures.yml
@@ -59,7 +59,7 @@
   startNode: start
   targetNode: wall
   category: construction-category-structures
-  description: Keeps the air in and the greytide out.
+  description: Keeps the air in and space out. # Triad
   icon:
     sprite: _NF/Structures/Walls/solid.rsi # Frontier
     state: full
@@ -77,7 +77,7 @@
   startNode: start
   targetNode: reinforcedWall
   category: construction-category-structures
-  description: Keeps the air in and the greytide out.
+  description: Keeps the air in and space out. # Triad
   icon:
     sprite: _NF/Structures/Walls/solid.rsi # Frontier
     state: rgeneric
@@ -95,7 +95,7 @@
   startNode: start
   targetNode: clockworkWall
   category: construction-category-structures
-  description: Keeps the air in and the greytide out.
+  description: Keeps the air in and space out. # Triad
   icon:
     sprite: Structures/Walls/clock.rsi
     state: full
@@ -113,7 +113,7 @@
   startNode: start
   targetNode: woodWall
   category: construction-category-structures
-  description: Keeps the air in and the greytide out.
+  description: Keeps the air in and space out. # Triad
   icon:
     sprite: Structures/Walls/wood.rsi
     state: full
@@ -131,7 +131,7 @@
   startNode: start
   targetNode: uraniumWall
   category: construction-category-structures
-  description: Keeps the air in and the greytide out.
+  description: Keeps the air in and space out. # Triad
   icon:
     sprite: Structures/Walls/uranium.rsi
     state: full
@@ -149,7 +149,7 @@
   startNode: start
   targetNode: silverWall
   category: construction-category-structures
-  description: Keeps the air in and the greytide out.
+  description: Keeps the air in and space out. # Triad
   icon:
     sprite: Structures/Walls/silver.rsi
     state: full
@@ -167,7 +167,7 @@
   startNode: start
   targetNode: plasticWall
   category: construction-category-structures
-  description: Keeps the air in and the greytide out.
+  description: Keeps the air in and space out. # Triad
   icon:
     sprite: Structures/Walls/plastic.rsi
     state: full
@@ -185,7 +185,7 @@
   startNode: start
   targetNode: plasmaWall
   category: construction-category-structures
-  description: Keeps the air in and the greytide out.
+  description: Keeps the air in and space out. # Triad
   icon:
     sprite: Structures/Walls/plasma.rsi
     state: full
@@ -203,7 +203,7 @@
   startNode: start
   targetNode: goldWall
   category: construction-category-structures
-  description: Keeps the air in and the greytide out.
+  description: Keeps the air in and space out. # Triad
   icon:
     sprite: Structures/Walls/gold.rsi
     state: full
@@ -221,7 +221,7 @@
   startNode: start
   targetNode: shuttleWall
   category: construction-category-structures
-  description: Keeps the air in and the greytide out.
+  description: Keeps the air in and space out. # Triad
   icon:
     sprite: Structures/Walls/shuttle.rsi
     state: full
@@ -239,7 +239,7 @@
   startNode: start
   targetNode: shuttleInteriorWall
   category: construction-category-structures
-  description: Keeps the air in and the greytide out.
+  description: Keeps the air in and space out. # Triad
   icon:
     sprite: Structures/Walls/shuttleinterior.rsi
     state: full
@@ -257,7 +257,7 @@
   startNode: start
   targetNode: diagonalshuttleWall
   category: construction-category-structures
-  description: Keeps the air in and the greytide out.
+  description: Keeps the air in and space out. # Triad
   icon:
     sprite: Structures/Walls/shuttle_diagonal.rsi
     state: state0
@@ -275,7 +275,7 @@
   startNode: start
   targetNode: bananiumWall
   category: construction-category-structures
-  description: Keeps the air in and the greytide out.
+  description: Keeps the air in and space out. # Triad
   icon:
     sprite: Structures/Walls/clown.rsi
     state: full

--- a/Resources/Prototypes/_Mono/Entities/Structures/walls.yml
+++ b/Resources/Prototypes/_Mono/Entities/Structures/walls.yml
@@ -5,7 +5,7 @@
   parent: BaseWall
   id: BaseWallTierOne
   name: default wall
-  description: Keeps the air in and the chimera out.
+  description: Keeps the air in and space out. # Triad
   placement:
     mode: SnapgridCenter
     snap:
@@ -55,7 +55,7 @@
   parent: BaseWall
   id: BaseWallTierTwo
   name: reinforced wall
-  description: Keeps the air in and the chimera out.
+  description: Keeps the air in and space out. # Triad
   placement:
     mode: SnapgridCenter
     snap:
@@ -105,7 +105,7 @@
   parent: BaseWall
   id: BaseWallTierThree
   name: super reinforced wall
-  description: Keeps the air in and the chimera out.
+  description: Keeps the air in and space out. # Triad
   placement:
     mode: SnapgridCenter
     snap:
@@ -155,7 +155,7 @@
   parent: BaseWall
   id: BaseWallTierFour
   name: super ultra giga reinforced wall
-  description: Keeps the air in and the chimera out.
+  description: Keeps the air in and space out. # Triad
   placement:
     mode: SnapgridCenter
     snap:
@@ -205,7 +205,7 @@
   parent: BaseWall
   id: BaseWallOutpost
   name: super ultra giga mega deluxe reinforced wall
-  description: Keeps the air in and the chimera out.
+  description: Keeps the air in and space out. # Triad
   suffix: OUTPOST ONLY
   placement:
     mode: SnapgridCenter

--- a/Resources/Prototypes/_Mono/Recipes/Construction/structures.yml
+++ b/Resources/Prototypes/_Mono/Recipes/Construction/structures.yml
@@ -5,7 +5,7 @@
   startNode: start
   targetNode: wallSolidDiagonal
   category: construction-category-structures
-  description: Keeps the air in and the greytide out.
+  description: Keeps the air in and space out. # Triad
   icon:
     sprite: /Textures/Structures/Walls/solid_diagonal.rsi
     state: state0
@@ -23,7 +23,7 @@
   startNode: start
   targetNode: wallReinforcedDiagonal
   category: construction-category-structures
-  description: Keeps the air in and the greytide out.
+  description: Keeps the air in and space out. # Triad
   icon:
     sprite: /Textures/Structures/Walls/reinforced_diagonal.rsi
     state: state0
@@ -41,7 +41,7 @@
   startNode: start
   targetNode: wallPlastitaniumDiagonal
   category: construction-category-structures
-  description: Keeps the air in and the greytide out.
+  description: Keeps the air in and space out. # Triad
   icon:
     sprite: /Textures/Structures/Walls/plastitanium_diagonal.rsi
     state: state0
@@ -59,7 +59,7 @@
   startNode: start
   targetNode: plastitaniumWall
   category: construction-category-structures
-  description: Keeps the air in and the greytide out.
+  description: Keeps the air in and space out. # Triad
   icon:
     sprite: /Textures/Structures/Walls/plastitanium.rsi
     state: full


### PR DESCRIPTION
## About the PR
This PR does the following:
- Reverts all non-upstream changes to generic wall descriptions... hopefully with minimum side-effects. This include NF's indestructible wall descriptions because they mentioned "Skub". I think they're a different color anyway so it should be fine
- Changes all generic wall descriptions to not mention greytide *or* chimera. Instead, it just says it keeps space out

Removed lines should be consistent with upstream `walls.yml`

Note: PR description finished in a hurry

## Why / Balance
Greytide is a bit LRP to have in a description you can only avoid by being in deep space. Chimera are also not a very prevalent threat

## Media
Text changes

## Requirements
<!-- Confirm the following by placing an X in the brackets [X]: -->
- [X] I have read [Attributing Your Changes](https://github.com/Triad-Sector/Triad_Sector/wiki/Attributing-Your-Changes) and the documentation relevant to this PR.
- [X] I have added media to this PR or it does not require an ingame showcase.
- [X] I can confirm this PR contains either no AI-generated content, or AI-generated content that meets our guidelines.
<!-- You should understand that not following the above may get your PR closed at maintainer’s discretion -->
<!-- When using AI, make sure you are already proficient in creating whatever content you are attempting to generate and that you already have experience contributing to SS14. This means using AI to enhance your preexisting workflow, not vibecoding. -->

## How to test
1. Search "wall" in the spawn menu. Hover over the walls to see the names

Not player-facing enough to need a changelog
