### PR TITLE
Fixes the Ship Gun Linking Exploit

### DIFF
--- a/Content.Server/_Mono/FireControl/FireControlSystem.cs
+++ b/Content.Server/_Mono/FireControl/FireControlSystem.cs
@@ -5,6 +5,7 @@ using Content.Server.Weapons.Ranged.Systems;
 using Content.Shared._Mono.FireControl;
 using Content.Shared.Power;
 using Content.Shared.Weapons.Ranged.Components;
+using Content.Shared.Weapons.Ranged.Events;
 using Robust.Shared.Map;
 using Robust.Shared.Physics;
 using Robust.Shared.Physics.Systems;
@@ -51,6 +52,7 @@ public sealed partial class FireControlSystem : EntitySystem
         SubscribeLocalEvent<FireControllableComponent, PowerChangedEvent>(OnControllablePowerChanged);
         SubscribeLocalEvent<FireControllableComponent, ComponentShutdown>(OnControllableShutdown);
         SubscribeLocalEvent<FireControllableComponent, EntParentChangedMessage>(OnControllableParentChanged);
+        SubscribeLocalEvent<FireControllableComponent, ShotAttemptedEvent>(OnShotAttempted); // Triad
 
         // Subscribe to grid split events to ensure we update when grids change
         SubscribeLocalEvent<GridSplitEvent>(OnGridSplit);
@@ -94,6 +96,14 @@ public sealed partial class FireControlSystem : EntitySystem
             )
         );
     }
+
+    // Triad - Prevent firing guns unless controlled.
+    private void OnShotAttempted(EntityUid uid, FireControllableComponent component, ref ShotAttemptedEvent args)
+    {
+        if (component.ControllingServer == null)
+            args.Cancel();
+    }
+    // End Triad
 
     private void OnControllablePowerChanged(EntityUid uid, FireControllableComponent component, PowerChangedEvent args)
     {

--- a/Content.Server/_Mono/FireControl/FireControlSystem.cs
+++ b/Content.Server/_Mono/FireControl/FireControlSystem.cs
@@ -5,7 +5,7 @@ using Content.Server.Weapons.Ranged.Systems;
 using Content.Shared._Mono.FireControl;
 using Content.Shared.Power;
 using Content.Shared.Weapons.Ranged.Components;
-using Content.Shared.Weapons.Ranged.Events;
+using Content.Shared.Weapons.Ranged.Events; // Triad
 using Robust.Shared.Map;
 using Robust.Shared.Physics;
 using Robust.Shared.Physics.Systems;
@@ -52,7 +52,6 @@ public sealed partial class FireControlSystem : EntitySystem
         SubscribeLocalEvent<FireControllableComponent, PowerChangedEvent>(OnControllablePowerChanged);
         SubscribeLocalEvent<FireControllableComponent, ComponentShutdown>(OnControllableShutdown);
         SubscribeLocalEvent<FireControllableComponent, EntParentChangedMessage>(OnControllableParentChanged);
-        SubscribeLocalEvent<FireControllableComponent, ShotAttemptedEvent>(OnShotAttempted); // Triad
 
         // Subscribe to grid split events to ensure we update when grids change
         SubscribeLocalEvent<GridSplitEvent>(OnGridSplit);
@@ -98,6 +97,7 @@ public sealed partial class FireControlSystem : EntitySystem
     }
 
     // Triad - Prevent firing guns unless controlled.
+    [SubscribeLocalEvent]
     private void OnShotAttempted(EntityUid uid, FireControllableComponent component, ref ShotAttemptedEvent args)
     {
         if (component.ControllingServer == null)


### PR DESCRIPTION
## About the PR
This PR fixes ship guns firing when they aren't linked to a gunnery control server. This helps prevent people sidestepping ship gun balance

If a ship gun has the `FireControllable` component, it will cancel all `ShotAttempted` events if not linked to a server. Gunnery servers prevent more guns being linked than they can handle

## Why / Balance
Unintended behavior. Exploit

## Media
I can't really demonstrate something that's on screen for a second. Have this

<img width="619" height="709" alt="image" src="https://github.com/user-attachments/assets/ffecd8d8-ee43-4cac-bb6d-5340c1a3d113" />

## Requirements
<!-- Confirm the following by placing an X in the brackets [X]: -->
- [X] I have read [Attributing Your Changes](https://github.com/Triad-Sector/Triad_Sector/wiki/Attributing-Your-Changes) and the documentation relevant to this PR.
- [X] I have added media to this PR or it does not require an ingame showcase.
- [X] I can confirm this PR contains either no AI-generated content, or AI-generated content that meets our guidelines.
<!-- You should understand that not following the above may get your PR closed at maintainer’s discretion -->
<!-- When using AI, make sure you are already proficient in creating whatever content you are attempting to generate and that you already have experience contributing to SS14. This means using AI to enhance your preexisting workflow, not vibecoding. -->

## How to test
1. Link a bunch of ship guns to a signal button (or any link sink)
3. Fire via GCS and link. Works fine
4. Delete the gunnery server. Try firing by any means again. It won't work
5. Fire a regular handheld gun to ensure I didn't somehow break something there. It fires

**Changelog**
:cl: Minerva
- fix: Ship guns no longer bypass gunnery restrictions when firing via signals. If you have signal-linked guns, they will not fire unless connected to a gunnery server. You can check if your gun is connected by using a gunnery console.