### PR TITLE
Radiator Wall Conductance Follows Mass Flux Instead of Saturating

### DIFF
--- a/Content.IntegrationTests/Tests/_Triad/RadiatorTest.cs
+++ b/Content.IntegrationTests/Tests/_Triad/RadiatorTest.cs
@@ -202,6 +202,95 @@ public sealed class RadiatorTest
     }
 
     /// <summary>
+    /// The mass-flux law: two rigs at the same pressure ratio, one ten times
+    /// denser, must NOT hand the same joules to the body. Under the old clamp
+    /// both saturated at flowFactor 1 and transferred identically; now the
+    /// dense loop moves ten times the moles per pass and its wall conductance
+    /// follows, up to the cap. This is what makes loop pressure a decision.
+    /// </summary>
+    [Test]
+    public async Task DenserLoopTransfersMoreHeatThroughTheWall()
+    {
+        await using var pair = await PoolManager.GetServerClient();
+        var server = pair.Server;
+        var entMan = server.EntMan;
+        var atmosSystem = entMan.System<AtmosphereSystem>();
+
+        var testMapThin = await pair.CreateTestMap();
+        var testMapDense = await pair.CreateTestMap();
+        var (radiatorThin, inletThin, outletThin) = await SpawnRadiator(pair, testMapThin);
+        var (radiatorDense, inletDense, outletDense) = await SpawnRadiator(pair, testMapDense);
+
+        const float dt = 0.1f;
+        await server.WaitPost(() =>
+        {
+            var compThin = entMan.GetComponent<HeatExchangerComponent>(radiatorThin);
+            var compDense = entMan.GetComponent<HeatExchangerComponent>(radiatorDense);
+
+            foreach (var comp in new[] { compThin, compDense })
+            {
+                // Body pinned as an infinite cold sink, no environment exchange,
+                // and a deliberately small wall conductance so the exchange
+                // stays in its linear regime (dE ≈ conductance × ΔT × dt) and
+                // the joules moved read the conductance directly instead of
+                // both rigs converging to the sink.
+                comp.alpha = 0f;
+                comp.K = 0f;
+                comp.BodyHeatCapacity = 1e9f;
+                comp.BodyTemperature = Atmospherics.T20C;
+                comp.PipeConductance = 100f;
+            }
+
+            // Same 100:1 pressure ratio, 10x the absolute pressure. The thin
+            // rig's pass lands at about RatedFlow (factor ~1); the dense rig's
+            // lands well past it and hits MaxFlowFactor.
+            inletThin.Air.AdjustMoles(Gas.Nitrogen, 20f);
+            outletThin.Air.AdjustMoles(Gas.Nitrogen, 0.2f);
+            inletDense.Air.AdjustMoles(Gas.Nitrogen, 200f);
+            outletDense.Air.AdjustMoles(Gas.Nitrogen, 2f);
+            foreach (var node in new[] { inletThin, outletThin, inletDense, outletDense })
+                node.Air.Temperature = 600f;
+        });
+
+        float heatThinBefore = 0f, heatDenseBefore = 0f;
+        await server.WaitPost(() =>
+        {
+            heatThinBefore = PipeHeatContent(atmosSystem, inletThin) + PipeHeatContent(atmosSystem, outletThin);
+            heatDenseBefore = PipeHeatContent(atmosSystem, inletDense) + PipeHeatContent(atmosSystem, outletDense);
+
+            // One hand-raised update each; gas moved between nets conserves
+            // heat content, so the drop is exactly what crossed into the body.
+            var ev = new AtmosDeviceUpdateEvent(dt, null, null);
+            entMan.EventBus.RaiseLocalEvent(radiatorThin, ref ev);
+            entMan.EventBus.RaiseLocalEvent(radiatorDense, ref ev);
+        });
+
+        await server.WaitAssertion(() =>
+        {
+            var compThin = entMan.GetComponent<HeatExchangerComponent>(radiatorThin);
+            var joulesThin = heatThinBefore - PipeHeatContent(atmosSystem, inletThin) - PipeHeatContent(atmosSystem, outletThin);
+            var joulesDense = heatDenseBefore - PipeHeatContent(atmosSystem, inletDense) - PipeHeatContent(atmosSystem, outletDense);
+
+            // Expected ratio is (floor + (1-floor) × cap) / (floor + (1-floor) × ~1)
+            // ≈ 2.8 at the defaults; assert the clamp-era answer (1.0) is gone
+            // by a wide margin, and that the cap actually bounds it.
+            var capRatio = (compThin.StaticConductanceFloor + (1f - compThin.StaticConductanceFloor) * compThin.MaxFlowFactor)
+                           / compThin.StaticConductanceFloor;
+            Assert.Multiple(() =>
+            {
+                Assert.That(joulesThin, Is.GreaterThan(0f), "Thin rig transferred nothing; the wall is dead.");
+                Assert.That(joulesDense, Is.GreaterThan(joulesThin * 2f),
+                    $"Mass-flux law not biting: dense loop moved {joulesDense:F0} J vs thin {joulesThin:F0} J. " +
+                    "Loop pressure is supposed to buy wall conductance.");
+                Assert.That(joulesDense, Is.LessThan(joulesThin * capRatio),
+                    $"Dense loop moved {joulesDense:F0} J vs thin {joulesThin:F0} J, past what MaxFlowFactor allows.");
+            });
+        });
+
+        await pair.CleanReturnAsync();
+    }
+
+    /// <summary>
     /// Overheat ceiling: a white-hot radiator takes structural damage while the
     /// cvar is on and none while it is off. Also proves the radiator's damage
     /// container actually accepts the Structural type.

--- a/Content.Server/Atmos/Components/HeatExchangerComponent.cs
+++ b/Content.Server/Atmos/Components/HeatExchangerComponent.cs
@@ -59,8 +59,10 @@ public sealed partial class HeatExchangerComponent : Component
 
     /// <summary>
     /// Triad: gas-to-body conductance at rated flow (J/K/sec). Forced
-    /// convection: actual conductance scales between
-    /// <see cref="StaticConductanceFloor"/> and 1x with flow through the device.
+    /// convection: actual conductance scales from
+    /// <see cref="StaticConductanceFloor"/> at zero flow, through 1x at
+    /// <see cref="RatedFlow"/>, up to <see cref="MaxFlowFactor"/> as a
+    /// mass-flux power law (<see cref="FlowExponent"/>).
     /// </summary>
     [ViewVariables(VVAccess.ReadWrite)]
     [DataField("pipeConductance")]
@@ -76,12 +78,33 @@ public sealed partial class HeatExchangerComponent : Component
     public float StaticConductanceFloor = 0.1f;
 
     /// <summary>
-    /// Triad: flow (mol/sec) at which gas-to-body conductance reaches full
-    /// strength.
+    /// Triad: flow (mol/sec) at which gas-to-body conductance equals
+    /// <see cref="PipeConductance"/>. Flow is moles moved through the device
+    /// per second, so at a given pump setting a high-pressure loop rates
+    /// higher than a thin one: absolute pressure enters here.
     /// </summary>
     [ViewVariables(VVAccess.ReadWrite)]
     [DataField("ratedFlow")]
-    public float RatedFlow = 10f;
+    public float RatedFlow = 100f;
+
+    /// <summary>
+    /// Triad: exponent of the mass-flux law. Real gas-side film coefficients
+    /// go as mass flux^0.8 in turbulent flow (Dittus-Boelter), so doubling
+    /// the flow buys ~1.74x conductance, not 2x.
+    /// </summary>
+    [ViewVariables(VVAccess.ReadWrite)]
+    [DataField("flowExponent")]
+    public float FlowExponent = 0.8f;
+
+    /// <summary>
+    /// Triad: cap on the flow multiplier applied to
+    /// <see cref="PipeConductance"/>, so a pressure pump at its ceiling
+    /// cannot scale the wall conductance without bound. 3x is reached at
+    /// roughly four times <see cref="RatedFlow"/>.
+    /// </summary>
+    [ViewVariables(VVAccess.ReadWrite)]
+    [DataField("maxFlowFactor")]
+    public float MaxFlowFactor = 3f;
 
     /// <summary>
     /// Triad: cap on the environment-density multiplier applied to the

--- a/Content.Server/Atmos/EntitySystems/HeatExchangerSystem.cs
+++ b/Content.Server/Atmos/EntitySystems/HeatExchangerSystem.cs
@@ -190,11 +190,19 @@ public sealed partial class HeatExchangerSystem : EntitySystem
             }
         }
 
-        // Triad: forced vs natural convection. Conductance scales from the
-        // static floor up to full strength with flow through the device.
-        var flowFactor = comp.RatedFlow > 0f
-            ? Math.Clamp(MathF.Abs(n) / (comp.RatedFlow * dt), 0f, 1f)
-            : 1f;
+        // Triad: forced vs natural convection as a mass-flux law. The gas-side
+        // film coefficient of a real exchanger goes as (mass flux)^0.8, so the
+        // conductance multiplier is (moles per second / RatedFlow)^FlowExponent,
+        // capped at MaxFlowFactor, rather than a clamp that saturated at ~1 kPa
+        // of ΔP. Absolute pressure enters through the moles: at the same pump
+        // setting a high-pressure loop moves more gas per pass, and that buys
+        // it more wall conductance. Zero flow still lands on the static floor.
+        var flowFactor = 1f;
+        if (comp.RatedFlow > 0f && dt > 0f)
+        {
+            var rate = MathF.Abs(n) / dt;
+            flowFactor = MathF.Min(MathF.Pow(rate / comp.RatedFlow, comp.FlowExponent), comp.MaxFlowFactor);
+        }
         var pipeConductance = comp.PipeConductance *
             (comp.StaticConductanceFloor + (1f - comp.StaticConductanceFloor) * flowFactor);
 

--- a/Resources/ServerInfo/Guidebook/Engineering/Radiators.xml
+++ b/Resources/ServerInfo/Guidebook/Engineering/Radiators.xml
@@ -25,6 +25,6 @@
 
   Gas will flow naturally through the radiator via differences in pressure, but you can use a gas pump to increase the flow rate.
 
-  Increasing the flow rate of gas through the radiator will increase the rate of heat exchange.
+  Increasing the flow rate of gas through the radiator will increase the rate of heat exchange. Flow is measured in gas moved, not pump setting: a loop running at high pressure pushes more gas through each pass, so it exchanges heat faster than a thin loop on the same pump. The gain tapers off, and a loop with no flow at all still exchanges a little.
 
   </Document>


### PR DESCRIPTION
## About the PR
The radiator's gas-to-body conductance now follows a mass-flux law instead of a clamp: it scales with moles per second through the device as (flow / 100 mol/s)^0.8, capped at 3x, with the same 10% static floor at zero flow. Two new `HeatExchanger` datafields carry the exponent and the cap. Code and guidebook only, no prototype changes.

## Why / Balance
The old flow factor saturated at 10 mol/s, so every pumped loop got the same wall conductance however it was built; the new law lets a dense, fast loop buy more, the way a real exchanger does. In practice this is a fidelity change rather than a balance one: gas already leaves a run of radiators at fin temperature under either law, so loop temperatures barely move and nothing gets nerfed. The new datafields are the knobs for later tuning if the wall is ever made to matter.

## Media
N/A, server-side physics change.

## Requirements
- [x] I have read the guidelines and documentation relevant to this PR.
- [ ] I have added media to this PR or it does not require an ingame showcase.
- [x] I can confirm this PR contains either no AI-generated content, or AI-generated content that meets our guidelines.

## How to test
Run a hot pumped loop through a radiator chain and confirm it behaves as before; then compare a short run at low and high loop pressure on the same pump setting, where the dense loop should exchange slightly faster. `RadiatorTest` (7, including the new `DenserLoopTransfersMoreHeatThroughTheWall`) and both `PrototypeSaveTest` classes pass locally under the CI build flags.

## Breaking changes
None. Two new `HeatExchanger` datafields (`flowExponent`, `maxFlowFactor`) and `ratedFlow`'s default moves from 10 to 100 mol/s; no prototype in tree declares `ratedFlow`, so nothing pins the old value.

**Changelog**
:cl:
- tweak: Radiator heat exchange now scales with how much gas actually flows through the device instead of saturating at a trickle. Pumped loops behave as before.
