### PR TITLE
Fixes Plastitanium Wall Description

### DIFF
--- a/Resources/Prototypes/Entities/Structures/Walls/walls.yml
+++ b/Resources/Prototypes/Entities/Structures/Walls/walls.yml
@@ -346,6 +346,7 @@
   parent: [ WallPlastitaniumIndestructible, BaseWallTierThree ]
   id: WallPlastitanium
   name: plastitanium wall
+  description: Keeps the air in and space out. # Triad
   suffix: ""
   components:
   - type: Construction # Mono
@@ -360,6 +361,7 @@
   parent: [ WallPlastitaniumDiagonalIndestructible, BaseWallTierTwo ] # Mono
   id: WallPlastitaniumDiagonal
   name: plastitanium wall
+  description: Keeps the air in and space out. # Triad
   suffix: diagonal
   placement:
     mode: SnapgridCenter


### PR DESCRIPTION
## About the PR
Fixes the incorrect plastitanium wall descriptions from https://github.com/Triad-Sector/Triad_Sector/pull/591

## Media
<img width="580" height="484" alt="image" src="https://github.com/user-attachments/assets/8a2dbdc6-2e9b-4f6c-b631-d8614ebc72a1" />

## Requirements
<!-- Confirm the following by placing an X in the brackets [X]: -->
- [X] I have read [Attributing Your Changes](https://github.com/Triad-Sector/Triad_Sector/wiki/Attributing-Your-Changes) and the documentation relevant to this PR.
- [X] I have added media to this PR or it does not require an ingame showcase.
- [X] I can confirm this PR contains either no AI-generated content, or AI-generated content that meets our guidelines.
<!-- You should understand that not following the above may get your PR closed at maintainer’s discretion -->
<!-- When using AI, make sure you are already proficient in creating whatever content you are attempting to generate and that you already have experience contributing to SS14. This means using AI to enhance your preexisting workflow, not vibecoding. -->

## How to test
1. Spawn in regular plastitanium walls, diagonal walls, and windows
2. Examine them. The word "tough" does not appear

Changelog not required ~~and I think the players would make fun of me~~