### PR TITLE
Removed Grenade Chain Reactions

### DIFF
--- a/Resources/Prototypes/Entities/Objects/Weapons/Bombs/plastic.yml
+++ b/Resources/Prototypes/Entities/Objects/Weapons/Bombs/plastic.yml
@@ -16,17 +16,18 @@
     blacklist: # can't stick it to other items
       components:
       - Item
-  - type: Damageable
-    damageContainer: Inorganic
-  - type: Destructible
-    thresholds:
-    - trigger:
-        !type:DamageTrigger
-        damage: 50
-      behaviors:
-      - !type:DoActsBehavior
-        acts: ["Destruction"]
-      - !type:ExplodeBehavior
+  # Triad - Begin (Remove Sympathetic Detonation)
+  #- type: Damageable
+  #  damageContainer: Inorganic
+  #- type: Destructible
+  #  thresholds:
+  #  - trigger:
+  #      !type:DamageTrigger
+  #      damage: 50
+  #    behaviors:
+  #    - !type:DoActsBehavior
+  #      acts: ["Destruction"]
+  #    - !type:ExplodeBehavior
   - type: StickyVisualizer
   - type: Appearance
   - type: GenericVisualizer

--- a/Resources/Prototypes/Entities/Objects/Weapons/Throwable/grenades.yml
+++ b/Resources/Prototypes/Entities/Objects/Weapons/Throwable/grenades.yml
@@ -23,15 +23,17 @@
       - Timer
   - type: Damageable
     damageContainer: Inorganic
-  - type: Destructible
-    thresholds:
-    - trigger:
-        !type:DamageTrigger
-        damage: 10
-      behaviors:
-      - !type:TriggerBehavior
-      - !type:DoActsBehavior
-        acts: ["Destruction"]
+  # Triad - Begin (Remove Sympathetic Detonation)
+  #- type: Destructible
+  #  thresholds:
+  #  - trigger:
+  #      !type:DamageTrigger
+  #      damage: 10
+  #    behaviors:
+  #    - !type:TriggerBehavior
+  #    - !type:DoActsBehavior
+  #      acts: ["Destruction"]
+  # Triad - End
   - type: Appearance
   - type: AnimationPlayer
   - type: GenericVisualizer
@@ -126,20 +128,22 @@
     sprite: Objects/Weapons/Grenades/syndgrenade.rsi
   - type: ExplosionResistance
     damageCoefficient: 0.1
-  - type: Destructible
-    thresholds:
-    - trigger:
-        !type:DamageTrigger
-        damage: 10
-      behaviors:
-      - !type:TimerStartBehavior
-    - trigger:
-        !type:DamageTrigger
-        damage: 45
-      behaviors:
-      - !type:TriggerBehavior
-      - !type:DoActsBehavior
-        acts: ["Destruction"]
+  # Triad - Begin (Remove Sympathetic Detonation)
+  #- type: Destructible
+  #  thresholds:
+  #  - trigger:
+  #      !type:DamageTrigger
+  #      damage: 10
+  #    behaviors:
+  #    - !type:TimerStartBehavior
+  #  - trigger:
+  #      !type:DamageTrigger
+  #      damage: 45
+  #    behaviors:
+  #    - !type:TriggerBehavior
+  #    - !type:DoActsBehavior
+  #      acts: ["Destruction"]
+  # Triad - End
   - type: OnUseTimerTrigger
     delay: 5
   - type: ExplodeOnTrigger
@@ -334,15 +338,17 @@
     node: emptyCase
   - type: Damageable
     damageContainer: Inorganic
-  - type: Destructible
-    thresholds:
-    - trigger:
-        !type:DamageTrigger
-        damage: 50
-      behaviors:
-      - !type:TriggerBehavior
-      - !type:DoActsBehavior
-        acts: [ "Destruction" ]
+  # Triad - Begin (Remove Sympathetic Detonation)
+  #- type: Destructible
+  #  thresholds:
+  #  - trigger:
+  #      !type:DamageTrigger
+  #      damage: 50
+  #    behaviors:
+  #    - !type:TriggerBehavior
+  #    - !type:DoActsBehavior
+  #      acts: [ "Destruction" ]
+  # Triad - End
   - type: Appearance
   - type: GenericVisualizer
     visuals:

--- a/Resources/Prototypes/Entities/Objects/Weapons/Throwable/grenades.yml
+++ b/Resources/Prototypes/Entities/Objects/Weapons/Throwable/grenades.yml
@@ -1,6 +1,6 @@
 - type: entity
   abstract: true
-  parent: [BaseItem, RecyclableItemSteelSmall] # Frontier: added RecyclableItemSteelSmall
+  parent: [BaseItem, RecyclableItemSteelSmall, BaseSafeGrenade] # Frontier: added RecyclableItemSteelSmall, Triad: Added BaseSafeGrenade to avoid chain reaction.
   id: GrenadeBase
   components:
   - type: WeaponCaseInsertable # Frontier
@@ -23,17 +23,15 @@
       - Timer
   - type: Damageable
     damageContainer: Inorganic
-  # Triad - Begin (Remove Sympathetic Detonation)
-  #- type: Destructible
-  #  thresholds:
-  #  - trigger:
-  #      !type:DamageTrigger
-  #      damage: 10
-  #    behaviors:
-  #    - !type:TriggerBehavior
-  #    - !type:DoActsBehavior
-  #      acts: ["Destruction"]
-  # Triad - End
+  - type: Destructible
+    thresholds:
+    - trigger:
+        !type:DamageTrigger
+        damage: 10
+      behaviors:
+      - !type:TriggerBehavior
+      - !type:DoActsBehavior
+        acts: ["Destruction"]
   - type: Appearance
   - type: AnimationPlayer
   - type: GenericVisualizer
@@ -128,22 +126,20 @@
     sprite: Objects/Weapons/Grenades/syndgrenade.rsi
   - type: ExplosionResistance
     damageCoefficient: 0.1
-  # Triad - Begin (Remove Sympathetic Detonation)
-  #- type: Destructible
-  #  thresholds:
-  #  - trigger:
-  #      !type:DamageTrigger
-  #      damage: 10
-  #    behaviors:
-  #    - !type:TimerStartBehavior
-  #  - trigger:
-  #      !type:DamageTrigger
-  #      damage: 45
-  #    behaviors:
-  #    - !type:TriggerBehavior
-  #    - !type:DoActsBehavior
-  #      acts: ["Destruction"]
-  # Triad - End
+  - type: Destructible
+    thresholds:
+    - trigger:
+        !type:DamageTrigger
+        damage: 10
+      behaviors:
+      - !type:TimerStartBehavior
+    - trigger:
+        !type:DamageTrigger
+        damage: 45
+      behaviors:
+      - !type:TriggerBehavior
+      - !type:DoActsBehavior
+        acts: ["Destruction"]
   - type: OnUseTimerTrigger
     delay: 5
   - type: ExplodeOnTrigger

--- a/Resources/Prototypes/Entities/Objects/Weapons/Throwable/grenades.yml
+++ b/Resources/Prototypes/Entities/Objects/Weapons/Throwable/grenades.yml
@@ -334,17 +334,15 @@
     node: emptyCase
   - type: Damageable
     damageContainer: Inorganic
-  # Triad - Begin (Remove Sympathetic Detonation)
-  #- type: Destructible
-  #  thresholds:
-  #  - trigger:
-  #      !type:DamageTrigger
-  #      damage: 50
-  #    behaviors:
-  #    - !type:TriggerBehavior
-  #    - !type:DoActsBehavior
-  #      acts: [ "Destruction" ]
-  # Triad - End
+  - type: Destructible
+    thresholds:
+    - trigger:
+        !type:DamageTrigger
+        damage: 50
+      behaviors:
+      - !type:TriggerBehavior
+      - !type:DoActsBehavior
+        acts: [ "Destruction" ]
   - type: Appearance
   - type: GenericVisualizer
     visuals:

--- a/Resources/Prototypes/Entities/Objects/Weapons/Throwable/grenades.yml
+++ b/Resources/Prototypes/Entities/Objects/Weapons/Throwable/grenades.yml
@@ -365,7 +365,7 @@
 - type: entity
   name: EMP grenade
   description: A grenade designed to wreak havoc on electronic systems.
-  parent: [GrenadeBase, BaseUnsafeGrenade] # Triad: Added BaseUnsafeGrenade to allow chain reactions.
+  parent: [BaseUnsafeGrenade, GrenadeBase] # Triad: Added BaseUnsafeGrenade to allow chain reactions.
   id: EmpGrenade
   components:
   - type: Sprite
@@ -411,7 +411,7 @@
       path: /Audio/Effects/hallelujah.ogg
 
 - type: entity
-  parent: [GrenadeBase, BaseUnsafeGrenade] # Triad: Added BaseUnsafeGrenade to allow chain reactions.
+  parent: [BaseUnsafeGrenade, GrenadeBase] # Triad: Added BaseUnsafeGrenade to allow chain reactions.
   id: SmokeGrenade
   name: smoke grenade
   description: A tactical grenade that releases a large, long-lasting cloud of smoke when used.
@@ -481,7 +481,7 @@
         Quantity: 50
 
 - type: entity
-  parent: [SmokeGrenade, BaseSafeGrenade] # Triad: Added BaseSafeGrenade to avoid chain reaction, nobody likes their metal foam entombing them.
+  parent: [BaseSafeGrenade, SmokeGrenade] # Triad: Added BaseSafeGrenade to avoid chain reaction, nobody likes their metal foam entombing them.
   id: MetalFoamGrenade
   name: metal foam grenade
   description: An emergency tool used for patching up holes. Almost as good as real walls.

--- a/Resources/Prototypes/Entities/Objects/Weapons/Throwable/grenades.yml
+++ b/Resources/Prototypes/Entities/Objects/Weapons/Throwable/grenades.yml
@@ -365,7 +365,7 @@
 - type: entity
   name: EMP grenade
   description: A grenade designed to wreak havoc on electronic systems.
-  parent: GrenadeBase
+  parent: [GrenadeBase, BaseUnsafeGrenade] # Triad: Added BaseUnsafeGrenade to allow chain reactions.
   id: EmpGrenade
   components:
   - type: Sprite
@@ -411,7 +411,7 @@
       path: /Audio/Effects/hallelujah.ogg
 
 - type: entity
-  parent: GrenadeBase
+  parent: [GrenadeBase, BaseUnsafeGrenade] # Triad: Added BaseUnsafeGrenade to allow chain reactions.
   id: SmokeGrenade
   name: smoke grenade
   description: A tactical grenade that releases a large, long-lasting cloud of smoke when used.
@@ -481,7 +481,7 @@
         Quantity: 50
 
 - type: entity
-  parent: SmokeGrenade
+  parent: [SmokeGrenade, BaseSafeGrenade] # Triad: Added BaseSafeGrenade to avoid chain reaction, nobody likes their metal foam entombing them.
   id: MetalFoamGrenade
   name: metal foam grenade
   description: An emergency tool used for patching up holes. Almost as good as real walls.

--- a/Resources/Prototypes/Entities/Objects/Weapons/Throwable/projectile_grenades.yml
+++ b/Resources/Prototypes/Entities/Objects/Weapons/Throwable/projectile_grenades.yml
@@ -1,6 +1,6 @@
 ﻿- type: entity
   abstract: true
-  parent: BaseItem
+  parent: [BaseItem, BaseSafeGrenade] # Triad: Added BaseSafeGrenade to avoid chain reaction.
   id: ProjectileGrenadeBase
   components:
   - type: Appearance
@@ -11,15 +11,13 @@
   - type: Damageable
     damageContainer: Inorganic
   - type: DeleteOnTrigger
-  # Triad - Begin (Remove Sympathetic Detonation)
-  #- type: Destructible
-  #  thresholds:
-  #  - trigger:
-  #      !type:DamageTrigger
-  #      damage: 10
-  #    behaviors:
-  #    - !type:TriggerBehavior
-  # Triad - End
+  - type: Destructible
+    thresholds:
+    - trigger:
+        !type:DamageTrigger
+        damage: 10
+      behaviors:
+      - !type:TriggerBehavior
   - type: ContainerContainer
     containers:
       cluster-payload: !type:Container

--- a/Resources/Prototypes/Entities/Objects/Weapons/Throwable/projectile_grenades.yml
+++ b/Resources/Prototypes/Entities/Objects/Weapons/Throwable/projectile_grenades.yml
@@ -11,13 +11,15 @@
   - type: Damageable
     damageContainer: Inorganic
   - type: DeleteOnTrigger
-  - type: Destructible
-    thresholds:
-    - trigger:
-        !type:DamageTrigger
-        damage: 10
-      behaviors:
-      - !type:TriggerBehavior
+  # Triad - Begin (Remove Sympathetic Detonation)
+  #- type: Destructible
+  #  thresholds:
+  #  - trigger:
+  #      !type:DamageTrigger
+  #      damage: 10
+  #    behaviors:
+  #    - !type:TriggerBehavior
+  # Triad - End
   - type: ContainerContainer
     containers:
       cluster-payload: !type:Container

--- a/Resources/Prototypes/Entities/Objects/Weapons/Throwable/scattering_grenades.yml
+++ b/Resources/Prototypes/Entities/Objects/Weapons/Throwable/scattering_grenades.yml
@@ -8,15 +8,17 @@
   - type: ContainerContainer
     containers:
       cluster-payload: !type:Container
-  - type: Damageable
-    damageContainer: Inorganic
-  - type: Destructible
-    thresholds:
-    - trigger:
-        !type:DamageTrigger
-        damage: 10
-      behaviors:
-      - !type:TriggerBehavior
+  # Triad - Begin (Remove Sympathetic Detonation)
+  #- type: Damageable
+  #  damageContainer: Inorganic
+  #- type: Destructible
+  #  thresholds:
+  #  - trigger:
+  #      !type:DamageTrigger
+  #      damage: 10
+  #    behaviors:
+  #    - !type:TriggerBehavior
+  # Triad - End
   - type: ScatteringGrenade
 
 - type: entity

--- a/Resources/Prototypes/Entities/Objects/Weapons/Throwable/scattering_grenades.yml
+++ b/Resources/Prototypes/Entities/Objects/Weapons/Throwable/scattering_grenades.yml
@@ -1,24 +1,22 @@
 ﻿# ScatteringGrenade is intended for grenades that spawn entities, especially those with timers
 - type: entity
   abstract: true
-  parent: BaseItem
+  parent: [BaseItem, BaseSafeGrenade] # Triad: Added BaseSafeGrenade to avoid chain reaction.
   id: ScatteringGrenadeBase
   components:
   - type: Appearance
   - type: ContainerContainer
     containers:
       cluster-payload: !type:Container
-  # Triad - Begin (Remove Sympathetic Detonation)
-  #- type: Damageable
-  #  damageContainer: Inorganic
-  #- type: Destructible
-  #  thresholds:
-  #  - trigger:
-  #      !type:DamageTrigger
-  #      damage: 10
-  #    behaviors:
-  #    - !type:TriggerBehavior
-  # Triad - End
+  - type: Damageable
+    damageContainer: Inorganic
+  - type: Destructible
+    thresholds:
+    - trigger:
+        !type:DamageTrigger
+        damage: 10
+      behaviors:
+      - !type:TriggerBehavior
   - type: ScatteringGrenade
 
 - type: entity

--- a/Resources/Prototypes/_Triad/Entities/Objects/Weapons/Throwable/grenades.yml
+++ b/Resources/Prototypes/_Triad/Entities/Objects/Weapons/Throwable/grenades.yml
@@ -4,3 +4,10 @@
   components:
   - type: ExplosionResistance
     damageCoefficient: 0
+
+# Parent this to clear the explosion resistance, making them able to chain react.
+- type: entity
+  id: BaseUnsafeGrenade
+  components:
+  - type: ExplosionResistance
+    damageCoefficient: 1

--- a/Resources/Prototypes/_Triad/Entities/Objects/Weapons/Throwable/grenades.yml
+++ b/Resources/Prototypes/_Triad/Entities/Objects/Weapons/Throwable/grenades.yml
@@ -1,0 +1,6 @@
+# Parent this to make a grenade explosion proof, preventing accidental detonations.
+- type: entity
+  id: BaseSafeGrenade
+  components:
+  - type: ExplosionResistance
+    damageCoefficient: 0


### PR DESCRIPTION
## About the PR
<!-- What did you change? -->
<!-- If this is a code change, summarize at high level how your new code works. This makes it easier to review. -->
As requested by Ricky. Grenades can no longer be damaged by explosions, so they shouldn't detonate in your bag before you tell them to. You can still place them on the ground and beat the shit out of them to cause instant detonation.
EMP and smoke grenades still chain react.

## Why / Balance
<!-- Discuss how this would affect game balance or explain why it was changed. Link any relevant discussions or issues. -->
Hand grenades are sort of underpowered, and nobody likes being instant killed with no counterplay except to not use grenades.

## Media
<!-- Attach media if the PR makes ingame changes (clothing, items, features, etc). 
Small fixes/refactors are exempt. Media may be used in progress reports with credit. -->
https://github.com/user-attachments/assets/f920a9f1-bba8-4bd7-94cc-f1385b1bd851

## Requirements
<!-- Confirm the following by placing an X in the brackets [X]: -->
- [x] I have read [Attributing Your Changes](https://github.com/Triad-Sector/Triad_Sector/wiki/Attributing-Your-Changes) and the documentation relevant to this PR.
- [x] I have added media to this PR or it does not require an ingame showcase.
- [x] I can confirm this PR contains either no AI-generated content, or AI-generated content that meets our guidelines.
<!-- You should understand that not following the above may get your PR closed at maintainer’s discretion -->
<!-- When using AI, make sure you are already proficient in creating whatever content you are attempting to generate and that you already have experience contributing to SS14. This means using AI to enhance your preexisting workflow, not vibecoding. -->

## How to test
<!-- Describe the way it can be tested -->
Beat every grenade with a e-sword, marvel at their resilience.

## Breaking changes
<!-- List any breaking changes, including namespaces, public class/method/field changes, prototype renames; and provide instructions for fixing them. -->

**Changelog**
<!-- Add a Changelog entry to make players aware of new features or changes that could affect gameplay.
Make sure to read the guidelines and take this Changelog template out of the comment block in order for it to show up.
Changelog must have a :cl: symbol, so the bot recognizes the changes and adds them to the game's changelog.
Remove this symbol for non-player facing PRs.-->
:cl:Nox38
- remove: A new motion by Triad Command requires safety fuses on hand grenades, preventing chain reactions. Fragile canister gas grenades and EMP grenades can still chain react.
