### PR TITLE
Adds a Name to Distinguish the Buildable Sinks From Eachother

### DIFF
--- a/Resources/Prototypes/_Triad/Recipes/Construction/furniture.yml
+++ b/Resources/Prototypes/_Triad/Recipes/Construction/furniture.yml
@@ -104,7 +104,7 @@
 
 - type: construction
   id: SinkStemless
-  name: sink
+  name: wall sink
   description: The faucets have been tightened to the maximum possible torque but are still known to drip.
   graph: sinkstemlesswater
   startNode: start


### PR DESCRIPTION
## About the PR
Renames the stemless (the sink that looks wall-mounted as opposed to floor-mounted) sink recipe to "wall sink" instead of just "sink" (the same as the other one)

## Why / Balance
Two visually identical sinks in the crafting menu. Upon closer examination, one was slightly different. I should not have to use close examination on a small preview of a sprite to tell it is actually different instead of a bug

## Media
<img width="438" height="470" alt="image" src="https://github.com/user-attachments/assets/7859866c-ab0e-4b50-b9b0-167376e1011d" />

## Requirements
<!-- Confirm the following by placing an X in the brackets [X]: -->
- [X] I have read [Attributing Your Changes](https://github.com/Triad-Sector/Triad_Sector/wiki/Attributing-Your-Changes) and the documentation relevant to this PR.
- [X] I have added media to this PR or it does not require an ingame showcase.
- [X] I can confirm this PR contains either no AI-generated content, or AI-generated content that meets our guidelines.
<!-- You should understand that not following the above may get your PR closed at maintainer’s discretion -->
<!-- When using AI, make sure you are already proficient in creating whatever content you are attempting to generate and that you already have experience contributing to SS14. This means using AI to enhance your preexisting workflow, not vibecoding. -->

## How to test
1. Open the build menu
2. Search sink
3. All sinks are labelled

Changelog is unnecessary. Expected behavior
