### PR TITLE
Reorders the Triad Military Backpacks in Loadout

### DIFF
--- a/Resources/Prototypes/_NF/Loadouts/contractor_loadout_groups.yml
+++ b/Resources/Prototypes/_NF/Loadouts/contractor_loadout_groups.yml
@@ -232,11 +232,6 @@
   - ContractorClothingModsuitCaptainPowerCell
   - ContractorClothingModsuitEngineerPowerCell
   ## Mono end
-  # Triad start
-  - ClothingBackpackMilitary
-  - ClothingBackpackSatchelMilitary
-  - ClothingBackpackDuffelMilitary
-  # Triad end
   - ContractorClothingBackpack
   - ContractorClothingBackpackDuffel
   - ContractorClothingBackpackSatchel
@@ -300,6 +295,11 @@
   - ContractorClothingBackpackDrakeIndustries
   - ContractorClothingBackpackDuffelDrakeIndustries
   - ContractorClothingBackpackSatchelDrakeIndustries
+  # Triad start
+  - ClothingBackpackMilitary
+  - ClothingBackpackSatchelMilitary
+  - ClothingBackpackDuffelMilitary
+  # Triad end
   - ContractorClothingBackpackClown
   - ContractorClothingBackpackDuffelClown
   - ContractorClothingBackpackSatchelClown

--- a/Resources/Prototypes/_NF/Loadouts/contractor_loadout_groups.yml
+++ b/Resources/Prototypes/_NF/Loadouts/contractor_loadout_groups.yml
@@ -297,8 +297,8 @@
   - ContractorClothingBackpackSatchelDrakeIndustries
   # Triad start
   - ClothingBackpackMilitary
-  - ClothingBackpackSatchelMilitary
   - ClothingBackpackDuffelMilitary
+  - ClothingBackpackSatchelMilitary
   # Triad end
   - ContractorClothingBackpackClown
   - ContractorClothingBackpackDuffelClown


### PR DESCRIPTION
## About the PR
Reorders the Triad militarized backpacks away from the top of the loadout—around the Drake Industries ones

Also moves the duffel above the satchel for consistency

## Why / Balance
Why do these come before the normal, default backpacks? MODsuits get a pass because they have other functionality

## Media
Screenshot outdated as of commit 2. Functionally the exact same
<img width="780" height="587" alt="image" src="https://github.com/user-attachments/assets/db386c35-b862-4fb7-882b-92b51a458f7b" />
<img width="789" height="625" alt="image" src="https://github.com/user-attachments/assets/5997c0e2-25c4-4a79-9455-78ac020c1d36" />

## Requirements
<!-- Confirm the following by placing an X in the brackets [X]: -->
- [X] I have read [Attributing Your Changes](https://github.com/Triad-Sector/Triad_Sector/wiki/Attributing-Your-Changes) and the documentation relevant to this PR.
- [X] I have added media to this PR or it does not require an ingame showcase.
- [X] I can confirm this PR contains either no AI-generated content, or AI-generated content that meets our guidelines.
<!-- You should understand that not following the above may get your PR closed at maintainer’s discretion -->
<!-- When using AI, make sure you are already proficient in creating whatever content you are attempting to generate and that you already have experience contributing to SS14. This means using AI to enhance your preexisting workflow, not vibecoding. -->

## How to test
1. Open loadout
2. The militarized backpacks are now lower

This is on the border of "so insignificant I shouldn't CL it". Better make a changelog than have people think it was removed, I suppose

**Changelog**
:cl: Minerva
- tweak: The militarized backpacks are now lower in the loadout list.