### PR TITLE
Fixes Inconsistent Jamjar Glasses Price

### DIFF
--- a/Resources/Prototypes/_NF/Loadouts/Jobs/Contractor/eyes.yml
+++ b/Resources/Prototypes/_NF/Loadouts/Jobs/Contractor/eyes.yml
@@ -29,7 +29,7 @@
   effects:
   - !type:GroupLoadoutEffect
     proto: ContractorT1
-  price: 500
+  #price: 500 # Triad removal
   equipment:
     eyes: ClothingEyesGlassesJamjar
 


### PR DESCRIPTION
## About the PR
This PR fixes the inconsistent 500 credits price on the jamjar glasses

## Why / Balance
Everything else is free

I commented the line out instead of setting the price to zero because already it's the default value. No point changing something to what it's currently set to

## Media
<img width="549" height="611" alt="image" src="https://github.com/user-attachments/assets/600b2b6c-59f0-4587-a875-5221dc6855a6" />

## Requirements
<!-- Confirm the following by placing an X in the brackets [X]: -->
- [X] I have read [Attributing Your Changes](https://github.com/Triad-Sector/Triad_Sector/wiki/Attributing-Your-Changes) and the documentation relevant to this PR.
- [X] I have added media to this PR or it does not require an ingame showcase.
- [X] I can confirm this PR contains either no AI-generated content, or AI-generated content that meets our guidelines.
<!-- You should understand that not following the above may get your PR closed at maintainer’s discretion -->
<!-- When using AI, make sure you are already proficient in creating whatever content you are attempting to generate and that you already have experience contributing to SS14. This means using AI to enhance your preexisting workflow, not vibecoding. -->

## How to test
1. Loadout

Not worth documenting. Expected behavior
