### PR TITLE
Fixed the Gas Processing Order in a Reactor.

### DIFF
--- a/Content.Server/_FarHorizons/Power/Generation/FissionGenerator/ReactorPartSystem.cs
+++ b/Content.Server/_FarHorizons/Power/Generation/FissionGenerator/ReactorPartSystem.cs
@@ -344,8 +344,8 @@ public sealed partial class ReactorPartSystem : SharedReactorPartSystem
 
         var neutronCount = 1;
         var gas = reactorPart.AirContents;
-
-        if (gas.GetMoles(Gas.CarbonDioxide) > 1) //process co2 before the moderator gasses, so it can actually, y'know. Reduce the neutron levels.
+        //Triad: Reordered: process co2 before the moderator gasses, so it can actually, y'know. Reduce the neutron levels.
+        if (gas.GetMoles(Gas.CarbonDioxide) > 1)
         {
             var reactMolPerLiter = 0.4;
             var reactMol = reactMolPerLiter * gas.Volume;
@@ -357,7 +357,7 @@ public sealed partial class ReactorPartSystem : SharedReactorPartSystem
             neutronCount -= Math.Min(co2ReactCount, neutronCount);
         }
 
-        if (gas.GetMoles(Gas.Tritium) > 1) //Process trit before plasma, since plasma makes it
+        if (gas.GetMoles(Gas.Tritium) > 1) //Process trit before plasma, since plasma... produces trit.
         {
             var reactMolPerLiter = 0.5;
             var reactMol = reactMolPerLiter * gas.Volume;
@@ -392,7 +392,7 @@ public sealed partial class ReactorPartSystem : SharedReactorPartSystem
             }
         }
 
-        if (gas.GetMoles(Gas.Plasma) > 1) //process plasma last
+        if (gas.GetMoles(Gas.Plasma) > 1) //process plasma last, so it doesn't eat up neutrons before co2, and doesn't have its tritium get eated.
         {
             var reactMolPerLiter = 0.25;
             var reactMol = reactMolPerLiter * gas.Volume;
@@ -404,7 +404,7 @@ public sealed partial class ReactorPartSystem : SharedReactorPartSystem
             gas.AdjustMoles(Gas.Tritium, plasmaReactCount * 2);
             neutronCount += plasmaReactCount;
         }
-
+        //End Triad
 
         return neutronCount;
     }

--- a/Content.Server/_FarHorizons/Power/Generation/FissionGenerator/ReactorPartSystem.cs
+++ b/Content.Server/_FarHorizons/Power/Generation/FissionGenerator/ReactorPartSystem.cs
@@ -148,7 +148,7 @@ public sealed partial class ReactorPartSystem : SharedReactorPartSystem
             reactorPart.MeltHealth -= _random.Next(10, 50 + 1);
         if (reactorPart.MeltHealth <= 0)
             Melt(reactorPart, reactorEnt, reactorSystem);
-        
+
         return;
 
         // I would really like for these to be defined by the MaterialPrototype, like GasReactionPrototype, but it caused the client and server to fight when I tried
@@ -172,7 +172,7 @@ public sealed partial class ReactorPartSystem : SharedReactorPartSystem
                 return;
 
             var molesPerUnit = 100f; // Arbitrary value for how much gaseous plasma is in each unit of active plasma
-            
+
             var payload = new GasMixture();
             payload.SetMoles(Gas.Plasma, (float)Math.Min(part.Properties.ActivePlasma * molesPerUnit, Math.Log(((part.Temperature - temperatureThreshold) / 100) + 1)));
             payload.Temperature = part.Temperature;
@@ -182,7 +182,7 @@ public sealed partial class ReactorPartSystem : SharedReactorPartSystem
             _atmosphereSystem.Merge(reactor.AirContents, payload);
         }
     }
-    
+
     /// <summary>
     /// Melts the related ReactorPart.
     /// </summary>
@@ -270,7 +270,7 @@ public sealed partial class ReactorPartSystem : SharedReactorPartSystem
             }
             reactorPart.Properties.NeutronRadioactivity -= ReactionReactant * SpontaneousReactionConsumptionMultiplier;
             reactorPart.Properties.Radioactivity += ReactionProduct * SpontaneousReactionConsumptionMultiplier;
-            reactorPart.Temperature += 20f * SpontaneousHeatingFactor; 
+            reactorPart.Temperature += 20f * SpontaneousHeatingFactor;
         }
         if (Prob(reactorPart.Properties.Radioactivity * ReactionRate * reactorPart.NeutronCrossSection))
         {
@@ -345,20 +345,7 @@ public sealed partial class ReactorPartSystem : SharedReactorPartSystem
         var neutronCount = 1;
         var gas = reactorPart.AirContents;
 
-        if (gas.GetMoles(Gas.Plasma) > 1)
-        {
-            var reactMolPerLiter = 0.25;
-            var reactMol = reactMolPerLiter * gas.Volume;
-
-            var plasma = gas.GetMoles(Gas.Plasma);
-            var plasmaReactCount = (int)Math.Round((plasma - (plasma % reactMol)) / reactMol) + (Prob(plasma - (plasma % reactMol)) ? 1 : 0);
-            plasmaReactCount = _random.Next(0, plasmaReactCount + 1);
-            gas.AdjustMoles(Gas.Plasma, plasmaReactCount * -0.5f);
-            gas.AdjustMoles(Gas.Tritium, plasmaReactCount * 2);
-            neutronCount += plasmaReactCount;
-        }
-
-        if (gas.GetMoles(Gas.CarbonDioxide) > 1)
+        if (gas.GetMoles(Gas.CarbonDioxide) > 1) //process co2 before the moderator gasses, so it can actually, y'know. Reduce the neutron levels.
         {
             var reactMolPerLiter = 0.4;
             var reactMol = reactMolPerLiter * gas.Volume;
@@ -370,7 +357,7 @@ public sealed partial class ReactorPartSystem : SharedReactorPartSystem
             neutronCount -= Math.Min(co2ReactCount, neutronCount);
         }
 
-        if (gas.GetMoles(Gas.Tritium) > 1)
+        if (gas.GetMoles(Gas.Tritium) > 1) //Process trit before plasma, since plasma makes it
         {
             var reactMolPerLiter = 0.5;
             var reactMol = reactMolPerLiter * gas.Volume;
@@ -404,6 +391,20 @@ public sealed partial class ReactorPartSystem : SharedReactorPartSystem
                 }
             }
         }
+
+        if (gas.GetMoles(Gas.Plasma) > 1) //process plasma last
+        {
+            var reactMolPerLiter = 0.25;
+            var reactMol = reactMolPerLiter * gas.Volume;
+
+            var plasma = gas.GetMoles(Gas.Plasma);
+            var plasmaReactCount = (int)Math.Round((plasma - (plasma % reactMol)) / reactMol) + (Prob(plasma - (plasma % reactMol)) ? 1 : 0);
+            plasmaReactCount = _random.Next(0, plasmaReactCount + 1);
+            gas.AdjustMoles(Gas.Plasma, plasmaReactCount * -0.5f);
+            gas.AdjustMoles(Gas.Tritium, plasmaReactCount * 2);
+            neutronCount += plasmaReactCount;
+        }
+
 
         return neutronCount;
     }


### PR DESCRIPTION
## About the PR
<!-- What did you change? -->
Fixed plasma reaction in a nuclear reactor being processed before tritium, resulting in no tritium/weird interactions. Also fixed co2 processing neutrons after plasma (but not tritium!).
<!-- If this is a code change, summarize at high level how your new code works. This makes it easier to review. -->

All I did was re-order the if statements from:
plasma -> co2 -> trit

To:

co2 -> trit -> plasma

## Why / Balance
<!-- Discuss how this would affect game balance or explain why it was changed. Link any relevant discussions or issues. -->
Plasma was producing trit but having it be consumed in the same tick, while deleting the trit products, when ran through. Bugged! this fixes that, and makes co2 Actually Work when mixed in with plasma, which it previously didn't! Effectively meant that co2 added to a mix of plasma would do nothing until it made up the vast majority of the ratio, it now does Something.
## Media
<!-- Attach media if the PR makes ingame changes (clothing, items, features, etc). 
Small fixes/refactors are exempt. Media may be used in progress reports with credit. -->
<img width="2048" height="1332" alt="Screenshot 2026-09-10 at 9 02 59 PM" src="https://github.com/user-attachments/assets/3e411edd-b516-447b-8185-240b2e22ee13" />
yay!!

## Requirements
<!-- Confirm the following by placing an X in the brackets [X]: -->
- [X] I have read [Attributing Your Changes](https://github.com/Triad-Sector/Triad_Sector/wiki/Attributing-Your-Changes) and the documentation relevant to this PR.
- [X] I have added media to this PR or it does not require an ingame showcase.
- [X] I can confirm this PR contains either no AI-generated content, or AI-generated content that meets our guidelines.
<!-- You should understand that not following the above may get your PR closed at maintainer’s discretion -->
<!-- When using AI, make sure you are already proficient in creating whatever content you are attempting to generate and that you already have experience contributing to SS14. This means using AI to enhance your preexisting workflow, not vibecoding. -->

## How to test
<!-- Describe the way it can be tested -->

## Breaking changes
<!-- List any breaking changes, including namespaces, public class/method/field changes, prototype renames; and provide instructions for fixing them. -->

**Changelog**
<!-- Add a Changelog entry to make players aware of new features or changes that could affect gameplay.
Make sure to read the guidelines and take this Changelog template out of the comment block in order for it to show up.
Changelog must have a :cl: symbol, so the bot recognizes the changes and adds them to the game's changelog.
Remove this symbol for non-player facing PRs.-->
:cl:
- fix: Co2 now absorbs neutron in a reactor before plasma.
- fix: Plasma in a reactor's gas loop will now actually form tritium in the outlet line, instead of sacrificing it to the god of floating point errors.